### PR TITLE
case insensitive option added to fuzzy_retrieval

### DIFF
--- a/news/case_insensitive_fuzzy.rst
+++ b/news/case_insensitive_fuzzy.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* option for fuzzy_retrieval to be case insensitive
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/regolith/builders/preslistbuilder.py
+++ b/regolith/builders/preslistbuilder.py
@@ -117,7 +117,8 @@ class PresListBuilder(LatexBuilderBase):
                         pauthors = [pauthors]
                     authors = [
                         fuzzy_retrieval(
-                            self.gtx["people"], ["aka", "name", "_id"], author
+                            self.gtx["people"], ["aka", "name", "_id"], author,
+                            case_sensitive=False
                         )
                         for author in pauthors
                     ]
@@ -145,11 +146,13 @@ class PresListBuilder(LatexBuilderBase):
                     pres["authors"] = [
                         author
                         if fuzzy_retrieval(
-                            self.gtx["people"], ["aka", "name", "_id"], author
+                            self.gtx["people"], ["aka", "name", "_id"], author,
+                            case_sensitive=False
                         )
                         is None
                         else fuzzy_retrieval(
-                            self.gtx["people"], ["aka", "name", "_id"], author
+                            self.gtx["people"], ["aka", "name", "_id"], author,
+                            case_sensitive=False
                         )["name"]
                         for author in pauthors
                     ]
@@ -171,7 +174,7 @@ class PresListBuilder(LatexBuilderBase):
                             pres["institution"] = fuzzy_retrieval(
                                 self.gtx["institutions"],
                                 ["aka", "name", "_id"],
-                                pres["institution"],
+                                pres["institution"], case_sensitive=False
                             )
                         except:
                             exit(

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -354,7 +354,7 @@ def document_by_value(documents, address, value):
             return g_doc
 
 
-def fuzzy_retrieval(documents, sources, value):
+def fuzzy_retrieval(documents, sources, value, case_sensitive = True):
     """Retrieve a document from the documents where value is compared against
     multiple potential sources
 
@@ -366,6 +366,8 @@ def fuzzy_retrieval(documents, sources, value):
         The potential data sources
     value:
         The value to compare against to find the document of interest
+    case_sensitive: Bool
+        When true will match case (Default = True)
 
     Returns
     -------
@@ -374,9 +376,9 @@ def fuzzy_retrieval(documents, sources, value):
 
     Examples
     --------
-    >>> fuzzy_retrieval(people, ['aka', 'name'], 'pi_name')
+    >>> fuzzy_retrieval(people, ['aka', 'name'], 'pi_name', case_sensitive = False)
 
-    This would get the person entry for where either the alias or the name was
+    This would get the person entry for which either the alias or the name was
     ``pi_name``.
 
     """
@@ -397,5 +399,11 @@ def fuzzy_retrieval(documents, sources, value):
                 returns.append(ret)
             else:
                 returns.extend(ret)
-        if value in frozenset(returns):
-            return doc
+        if not case_sensitive:
+            returns = [ret.lower() for ret in returns if isinstance(ret,str)]
+            if isinstance(value, str):
+                if value.lower() in frozenset(returns):
+                    return doc
+        else:
+            if value in frozenset(returns):
+                return doc

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,5 +20,14 @@ def test_fuzzy_retrieval():
         "name": "Anthony Scopatz",
     }
     assert (
-        fuzzy_retrieval([person], ["aka", "name", "_id"], "scopatz") == person
+            fuzzy_retrieval([person], ["aka", "name", "_id"],
+                            "scopatz") == person
+    )
+    assert (
+            fuzzy_retrieval([person], ["aka", "name", "_id"],
+                            "scopatz, a") is None
+    )
+    assert (
+            fuzzy_retrieval([person], ["aka", "name", "_id"], "scopatz, a",
+                            case_sensitive=False) == person
     )


### PR DESCRIPTION
I wanted to try an option where we don't have to worry about capitalization in ``fuzzy_retrieval()``.  This will make it easier building aka lists, but could lead to more false-positives in the retrieval.  Anyway, I added it as an option with current behavior (case sensitive) as default so it should be safe.   I also mistakenly committed changes to ``preslistbuilder`` which are not strictly part of this PR, but....
@scopatz @CJ-Wright I think this is ready for review