### PR TITLE
post-doc ad builder

### DIFF
--- a/news/postdocadbuilder.rst
+++ b/news/postdocadbuilder.rst
@@ -1,0 +1,12 @@
+**Added:**
+ - builder for post-doc ad
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/regolith/builder.py
+++ b/regolith/builder.py
@@ -2,6 +2,7 @@
 
 from regolith.builders.cvbuilder import CVBuilder
 from regolith.builders.htmlbuilder import HtmlBuilder
+from regolith.builders.postdocadbuilder import PostdocadBuilder
 from regolith.builders.preslistbuilder import PresListBuilder
 from regolith.builders.publistbuilder import PubListBuilder
 from regolith.builders.gradebuilder import GradeReportBuilder
@@ -19,6 +20,7 @@ BUILDERS = {
     "grades": GradeReportBuilder,
     "resume": ResumeBuilder,
     "current-pending": CPBuilder,
+    "postdocad": PostdocadBuilder,
     "preslist": PresListBuilder,
     "reimb": ReimbursementBuilder,
     "figure": FigureBuilder,

--- a/regolith/builders/postdocadbuilder.py
+++ b/regolith/builders/postdocadbuilder.py
@@ -1,0 +1,60 @@
+"""Builder for Current and Pending Reports."""
+import datetime
+import time
+
+from regolith.builders.basebuilder import LatexBuilderBase
+from regolith.dates import month_to_int
+from regolith.fsclient import _id_key
+from regolith.sorters import position_key
+from regolith.tools import (
+    all_docs_from_collection,
+    filter_grants,
+    fuzzy_retrieval,
+)
+
+
+class PostdocadBuilder(LatexBuilderBase):
+    """Build current and pending report from database entries"""
+
+    btype = "postdocads"
+
+    def construct_global_ctx(self):
+        """Constructs the global context"""
+        super().construct_global_ctx()
+        gtx = self.gtx
+        rc = self.rc
+        gtx["postdocads"] = sorted(
+            all_docs_from_collection(rc.client, "postdocads"), key=_id_key
+        )
+        gtx["all_docs_from_collection"] = all_docs_from_collection
+        gtx["float"] = float
+        gtx["str"] = str
+        gtx["zip"] = zip
+
+    def latex(self):
+        """Render latex template"""
+        for ads in self.gtx["postdocads"]:
+            goals = ads['projectGoals']
+            positionOn = ads['positionOn']
+            projectTasks = ads['projectTasks']
+            requiredExperience = ads['requiredExperience']
+            additionalDesiredExperience = ads['additionalDesiredExperience']
+            startDate = ads['startDate']
+            thirdYear = ads['thirdyear']
+            k = ads['_id']
+            applicationDeadline = ads['applicationDeadline']
+            outname = "{}".format(k)
+            self.render(
+                "postdocad.tex",
+                outname+".tex",
+                projectGoals=goals,
+                positionOn=positionOn,
+                projectTasks=projectTasks,
+                requiredExperience=requiredExperience,
+                additionalDesiredExperience=additionalDesiredExperience,
+                startDate=startDate,
+                thirdYear=thirdYear,
+                k=k,
+                applicationDeadline=applicationDeadline
+            )
+            self.pdf("test")

--- a/regolith/templates/postdocad.tex
+++ b/regolith/templates/postdocad.tex
@@ -1,0 +1,41 @@
+\documentclass{letter}
+\usepackage{times}
+
+\begin{document}
+\begin{center}
+ {\bf
+  Post-Doctoral Fellowship Opportunity
+ }
+\end{center}
+\vskip 0.5 in 
+
+The Billinge group is seeking to fill a post-doctoral research position on {{positionOn}}.
+The goals of the project are {{projectGoals}}.
+The project will involve {{projectTasks}}.
+
+we seek candidates who are recent Ph.D. graduates in materials science, chemistry, physics, earth science, data science, computer science or a related field. {{requiredExperience}} Knowledge of x-ray, neutron or electron diffraction/scattering,
+synchrotron radiation experiments, data analysis, data science, software development in
+general and python programming in particular, are desirable but not required. In addition, experience in {{additionalDesiredExperience}} is valuable.  An ability to work well in a team environment is required. 
+
+We encourage applications from candidates with diverse backgrounds, experiences, and identities.
+
+\noindent{\bf Appointment and Funding}
+
+We are seeking a post-doc to start on or around {{ startDate }}.  The position is initially for one year with funding available for a second year if all parties wish to continue with the activity.  {{thirdYear}}
+
+\noindent{\bf Application Process}
+
+To apply, please submit the following materials to sb2896@columbia.edu with [{{latex_safe(k)}} post-doc] followed by your name in the subject line.  Candidates are encouraged to apply as early as possible and preferably before {{ applicationDeadline }}.
+
+Please submit as attachments to the email:
+\begin{itemize}
+\item A cover letter that explains your motivation for applying to this program
+\item A curriculum vitae (including a list of publications)
+\item PDF copies of the three publications that you are most proud of that describe work that was led and predominantly carried out by you.  
+\item {[optional]} links to any open-source software projects that you have contributed to significantly, and a description of your contributions.
+\item A brief research statement that summarizes current research interests, past accomplishments,and future research goals. 
+\item Three letters of reference submitted directly by the recommenders to sb2896@columbia.edu, preferrably with the subject line [your name, recommendation]
+\end{itemize}
+
+You will be contacted with an acknowledgement of receipt, and then contacted again if you are shortlisted for an interview.  Please send a followup email if you do not receive an acknowledgement within 2 days of sending the application.
+\end{document}


### PR DESCRIPTION
Hi @scopatz @CJ-Wright 
I don't want this pulled in because it is rather specific to MY needs, but I am making a PR to initiate some discussion about this issue....

I want to build builders with templates that are specific to my needs.  Perhaps others could adapt them for themselves, or not, I don't really care.  What I think this calls for is something like a local template database for these things, and perhaps local builders, I am not sure.

For now I just put this into a branch so I can build it locally, but to avoid it getting too complicated for me with hundreds of bespoke branches for this and that builder, I wonder if we could discuss what would be a good way to handle this more generally.

Not sure if I am being clear but....let me know your thoughts.