### PR TITLE
FIX: removing duplicate street in institutions schema

### DIFF
--- a/regolith/schemas.py
+++ b/regolith/schemas.py
@@ -1289,11 +1289,6 @@ SCHEMAS = {
             "required": False,
             "type": "string",
         },
-        "street": {
-            "description": "the street address of the institution",
-            "required": False,
-            "type": "string",
-        },
         "zip": {
             "description": "the zip or postal code of the institution",
             "required": False,


### PR DESCRIPTION
@scopatz @CJ-Wright this is a very small one.  I noticed street was defined twice in the institutions schema.