### PR TITLE
get databases to build when I don't have an rc.remote set

### DIFF
--- a/news/bug_handle_database_when_no_rc_remote.rst
+++ b/news/bug_handle_database_when_no_rc_remote.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:**
+ - removed remote.rc logic from database.xsh
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -187,6 +187,6 @@ def connect(rc, dbs=None):
     down"""
     client = open_dbs(rc, dbs=dbs)
     yield client
-    for db in  rc.databases:
+    for db in rc.databases:
         dump_database(db, client, rc)
     client.close()

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -187,6 +187,6 @@ def connect(rc, dbs=None):
     down"""
     client = open_dbs(rc, dbs=dbs)
     yield client
-    for db in rc.databases:
+    for db in  rc.databases:
         dump_database(db, client, rc)
     client.close()

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -33,8 +33,6 @@ def load_git_database(db, client, rc):
         with indir(dbdir):
             (![git pull upstream master]
              or ![git pull origin master]
-             # or ![git pull @(rc.remote) master]
-             # or ![git pull @(rc.remote) @(rc.branch)]
              or ![git pull])
     else:
         git clone @(db['url']) @(dbdir)

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -33,8 +33,8 @@ def load_git_database(db, client, rc):
         with indir(dbdir):
             (![git pull upstream master]
              or ![git pull origin master]
-             or ![git pull @(rc.remote) master]
-             or ![git pull @(rc.remote) @(rc.branch)]
+             # or ![git pull @(rc.remote) master]
+             # or ![git pull @(rc.remote) @(rc.branch)]
              or ![git pull])
     else:
         git clone @(db['url']) @(dbdir)


### PR DESCRIPTION
@scopatz This is a bug that came up only with ``regolith grade``, but I don't have any ``rc.remote`` attribute set and databases weren't loading (working fine for regolith build, validate, etc. for some reason).  A quick @CJ-Wright hack fix was to simply comment out these lines in the xonsh file.

A fix could be for me to set rc.remote somehow, but I feel that this may be a bug or undesirable behavior so putting in a PR to discuss and possibly fix it.