### PR TITLE
Use recursively merging to update the default schemas according to user schemas

### DIFF
--- a/news/schemas.rst
+++ b/news/schemas.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:**
+ - User supplied schemas now handles new keys in regolith validate.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -11,6 +11,7 @@ from regolith import commands
 from regolith import storage
 from regolith.builder import BUILDERS
 from regolith.schemas import SCHEMAS
+from regolith.tools import merge_nested_dicts
 
 DISCONNECTED_COMMANDS = {
     "rc": lambda rc: print(rc._pformat()),
@@ -255,20 +256,6 @@ def create_parser():
         help="If provided only validate that collection",
     )
     return p
-
-
-def merge_nested_dicts(dict0: dict, dict1: dict):
-    """Merge dict1 into dict0 recursively."""
-    for key in dict1.keys():  # iterate keys in dict1
-        if (key in dict0) and isinstance(dict0[key], dict) and isinstance(dict1[key], dict):
-            # if the key is also in dict0 and both values are dictionary,
-            # recursively merge the sub-dictionary
-            merge_nested_dicts(dict0[key], dict1[key])
-        else:
-            # if the key is not in dict0 or either of the values is not dictionary,
-            # use value in dict1 to update the dict0
-            dict0[key] = dict1[key]
-    return
 
 
 def main(args=None):

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -269,7 +269,6 @@ def main(args=None):
     rc._update(ns.__dict__)
     if "schemas" in rc._dict:
         user_schema = copy.deepcopy(rc.schemas)
-        print(user_schema)
         default_schema = copy.deepcopy(SCHEMAS)
         rc.schemas = update_schemas(default_schema, user_schema)
     else:

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import copy
 import os
-import collections
 from argparse import ArgumentParser, RawTextHelpFormatter
 
 from regolith.commands import INGEST_COLL_LU

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import copy
 import os
+import collections
 from argparse import ArgumentParser, RawTextHelpFormatter
 
 from regolith.commands import INGEST_COLL_LU
@@ -268,10 +269,8 @@ def main(args=None):
     rc._update(ns.__dict__)
     if "schemas" in rc._dict:
         user_schema = copy.deepcopy(rc.schemas)
-        rc.schemas = copy.deepcopy(SCHEMAS)
-        for k in user_schema:
-            for k2, v in user_schema[k].items():
-                rc.schemas[k][k2].update(v)
+        default_schema = copy.deepcopy(SCHEMAS)
+        rc.schemas = dict(collections.ChainMap(user_schema, default_schema))
     else:
         rc.schemas = SCHEMAS
     if ns.cmd in NEED_RC:

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -258,6 +258,20 @@ def create_parser():
     return p
 
 
+def merge_nested_dicts(dict0: dict, dict1: dict):
+    """Merge dict1 into dict0 recursively."""
+    for key in dict1.keys():  # iterate keys in dict1
+        if (key in dict0) and isinstance(dict0[key], dict) and isinstance(dict1[key], dict):
+            # if the key is also in dict0 and both values are dictionary,
+            # recursively merge the sub-dictionary
+            merge_nested_dicts(dict0[key], dict1[key])
+        else:
+            # if the key is not in dict0 or either of the values is not dictionary,
+            # use value in dict1 to update the dict0
+            dict0[key] = dict1[key]
+    return
+
+
 def main(args=None):
     rc = DEFAULT_RC
     parser = create_parser()
@@ -269,8 +283,8 @@ def main(args=None):
     rc._update(ns.__dict__)
     if "schemas" in rc._dict:
         user_schema = copy.deepcopy(rc.schemas)
-        default_schema = copy.deepcopy(SCHEMAS)
-        rc.schemas = dict(collections.ChainMap(user_schema, default_schema))
+        rc.schemas = copy.deepcopy(SCHEMAS)
+        merge_nested_dicts(rc.schemas, user_schema)  # merge user schemas into the default schemas
     else:
         rc.schemas = SCHEMAS
     if ns.cmd in NEED_RC:

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -11,7 +11,7 @@ from regolith import commands
 from regolith import storage
 from regolith.builder import BUILDERS
 from regolith.schemas import SCHEMAS
-from regolith.tools import merge_nested_dicts
+from regolith.tools import update_schemas
 
 DISCONNECTED_COMMANDS = {
     "rc": lambda rc: print(rc._pformat()),
@@ -269,8 +269,8 @@ def main(args=None):
     rc._update(ns.__dict__)
     if "schemas" in rc._dict:
         user_schema = copy.deepcopy(rc.schemas)
-        rc.schemas = copy.deepcopy(SCHEMAS)
-        merge_nested_dicts(rc.schemas, user_schema)  # merge user schemas into the default schemas
+        default_schema = copy.deepcopy(SCHEMAS)
+        rc.schemas = update_schemas(default_schema, user_schema)
     else:
         rc.schemas = SCHEMAS
     if ns.cmd in NEED_RC:

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -269,6 +269,7 @@ def main(args=None):
     rc._update(ns.__dict__)
     if "schemas" in rc._dict:
         user_schema = copy.deepcopy(rc.schemas)
+        print(user_schema)
         default_schema = copy.deepcopy(SCHEMAS)
         rc.schemas = update_schemas(default_schema, user_schema)
     else:

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -682,12 +682,11 @@ def update_schemas(default_schema, user_schema):
     -------
     updated_schema : dict
         A new schema as a result of updating the default schema according to the user_schema.
-
     """
     if not isinstance(default_schema, dict):
-        raise TypeError(f"The schema0 must be a dictionary. This is {type(default_schema)}")
+        raise TypeError(f"The default schema must be a dictionary. This is a {type(default_schema)}")
     elif not isinstance(user_schema, dict):
-        raise TypeError(f"The schema1 must be a dictionary. This is {type(user_schema)}")
+        raise TypeError(f"The user schema must be a dictionary. This is a {type(user_schema)}")
     else:
         pass
 

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -669,19 +669,20 @@ def dereference_institution(input_record, institutions):
 
 def update_schemas(default_schema, user_schema):
     """
-    Update schemas into schemas0 recursively and return the result.
+    Merging the user schema into the default schema recursively and return the merged schema. The default schema and
+    user schema will not be modified during the merging.
 
     Parameters
     ----------
     default_schema : dict
-        A schema to be updated according to schema1.
+        The default schema.
     user_schema : dict
-        A schema to update schema0.
+        The user defined schema.
 
     Returns
     -------
     updated_schema : dict
-        A new schema as a result of updating the default schema according to the user_schema.
+        The merged schema.
     """
     updated_schema = deepcopy(default_schema)
     for key in user_schema.keys():

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -665,3 +665,13 @@ def dereference_institution(input_record, institutions):
             input_record["department"] = fuzzy_retrieval(
                 [db_inst["departments"]], ["name", "aka"], input_record["department"]
             )
+
+
+def merge_nested_dicts(dict0, dict1):
+    """Merge the dict1 into dict0 recursively."""
+    for key in dict1.keys():
+        if (key in dict0) and isinstance(dict0[key], dict) and isinstance(dict1[key], dict):
+            merge_nested_dicts(dict0[key], dict1[key])
+        else:
+            dict0[key] = dict1[key]
+    return

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -683,13 +683,6 @@ def update_schemas(default_schema, user_schema):
     updated_schema : dict
         A new schema as a result of updating the default schema according to the user_schema.
     """
-    if not isinstance(default_schema, dict):
-        raise TypeError(f"The default schema must be a dictionary. This is a {type(default_schema)}")
-    elif not isinstance(user_schema, dict):
-        raise TypeError(f"The user schema must be a dictionary. This is a {type(user_schema)}")
-    else:
-        pass
-
     updated_schema = deepcopy(default_schema)
     for key in user_schema.keys():
         if (key in updated_schema) and isinstance(updated_schema[key], dict) and isinstance(user_schema[key], dict):

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -667,11 +667,35 @@ def dereference_institution(input_record, institutions):
             )
 
 
-def merge_nested_dicts(dict0, dict1):
-    """Merge the dict1 into dict0 recursively."""
-    for key in dict1.keys():
-        if (key in dict0) and isinstance(dict0[key], dict) and isinstance(dict1[key], dict):
-            merge_nested_dicts(dict0[key], dict1[key])
+def update_schemas(default_schema, user_schema):
+    """
+    Update schemas into schemas0 recursively and return the result.
+
+    Parameters
+    ----------
+    default_schema : dict
+        A schema to be updated according to schema1.
+    user_schema : dict
+        A schema to update schema0.
+
+    Returns
+    -------
+    updated_schema : dict
+        A new schema as a result of updating the default schema according to the user_schema.
+
+    """
+    if not isinstance(default_schema, dict):
+        raise TypeError(f"The schema0 must be a dictionary. This is {type(default_schema)}")
+    elif not isinstance(user_schema, dict):
+        raise TypeError(f"The schema1 must be a dictionary. This is {type(user_schema)}")
+    else:
+        pass
+
+    updated_schema = deepcopy(default_schema)
+    for key in user_schema.keys():
+        if (key in updated_schema) and isinstance(updated_schema[key], dict) and isinstance(user_schema[key], dict):
+            updated_schema[key] = update_schemas(updated_schema[key], user_schema[key])
         else:
-            dict0[key] = dict1[key]
-    return
+            updated_schema[key] = user_schema[key]
+
+    return updated_schema

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -345,9 +345,7 @@ EXPECTED_SCHEMA3 = {
 USER_SCHEMA4 = {
     "expenses": {
         "itemized_expenses": {
-            "type": "list",
             "schema": {
-                "type": "dict",
                 "schema": {
                     "prepaid_expense": {
                         "description": "Expense paid by the direct billing",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -316,7 +316,7 @@ USER_SCHEMA3 = {
                 "type": "dict",
                 "schema": {
                     "day": {
-                        "anyof_type": ["integer", "string"]
+                        "description": "The date on the receipt"
                     },
                 },
             },
@@ -332,9 +332,9 @@ EXPECTED_SCHEMA3 = {
                 "type": "dict",
                 "schema": {
                     "day": {
-                        "description": "Expense day",
+                        "description": "The date on the receipt",
                         "required": True,
-                        "anyof_type": ["integer", "string"]
+                        "type": "integer",
                     },
                 },
             },

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,7 +3,7 @@ import pytest
 from regolith.tools import (filter_publications, fuzzy_retrieval,
                             number_suffix, latex_safe, is_before,
                             is_since, is_between, has_started, has_finished,
-                            is_current)
+                            is_current, update_schemas)
 
 
 def test_author_publications():
@@ -187,3 +187,257 @@ def test_number_suffix(input, expected):
 def test_latex_safe(input, expected, kwargs):
     output = latex_safe(input, **kwargs)
     assert output == expected
+
+
+DEFAULT_SCHEMA = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "integer",
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA0 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "required": False,
+                    },
+                },
+            },
+        },
+    },
+}
+
+EXPECTED_SCHEMA0 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": False,
+                        "type": "integer",
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA1 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "type": "string",
+                    },
+                },
+            },
+        },
+    },
+}
+
+EXPECTED_SCHEMA1 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "string",
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA2 = {
+    "expenses": {
+        "begin_day": {
+            "description": "The first day of expense",
+            "required": True,
+            "type": "string",
+        }
+    },
+}
+
+EXPECTED_SCHEMA2 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "integer",
+                    },
+                },
+            },
+        },
+        "begin_day": {
+            "description": "The first day of expense",
+            "required": True,
+            "type": "string",
+        }
+    },
+}
+
+USER_SCHEMA3 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "anyof_type": ["integer", "string"]
+                    },
+                },
+            },
+        },
+    },
+}
+
+EXPECTED_SCHEMA3 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "anyof_type": ["integer", "string"]
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA4 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "prepaid_expense": {
+                        "description": "Expense paid by the direct billing",
+                        "required": True,
+                        "type": "float",
+                    },
+                },
+            },
+        },
+    },
+}
+
+EXPECTED_SCHEMA4 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "integer",
+                    },
+                    "prepaid_expense": {
+                        "description": "Expense paid by the direct billing",
+                        "required": True,
+                        "type": "float",
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA5 = {}
+
+EXPECTED_SCHEMA5 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "integer",
+                    },
+                },
+            },
+        },
+    },
+}
+
+USER_SCHEMA6 = {
+    "expenses": {}
+}
+
+EXPECTED_SCHEMA6 = {
+    "expenses": {
+        "itemized_expenses": {
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "day": {
+                        "description": "Expense day",
+                        "required": True,
+                        "type": "integer",
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "default_schema, user_schema, expected_schema",
+    [
+        (DEFAULT_SCHEMA, USER_SCHEMA0, EXPECTED_SCHEMA0),
+        (DEFAULT_SCHEMA, USER_SCHEMA1, EXPECTED_SCHEMA1),
+        (DEFAULT_SCHEMA, USER_SCHEMA2, EXPECTED_SCHEMA2),
+        (DEFAULT_SCHEMA, USER_SCHEMA3, EXPECTED_SCHEMA3),
+        (DEFAULT_SCHEMA, USER_SCHEMA4, EXPECTED_SCHEMA4),
+        (DEFAULT_SCHEMA, USER_SCHEMA5, EXPECTED_SCHEMA5),
+        (DEFAULT_SCHEMA, USER_SCHEMA6, EXPECTED_SCHEMA6),
+    ],
+)
+def test_update_schemas(default_schema, user_schema, expected_schema):
+    updated_schema = update_schemas(default_schema, user_schema)
+    assert updated_schema == expected_schema


### PR DESCRIPTION
I am Songsheng Tao in Billinge group. I would like to recommend that we use the recursively merging of two nested dictionary to update the schemas instead of iterating the first two levels of keys. It will provide the user the freedom to add their own yaml files to db and add their own properties for the entries in yaml files.