### PR TITLE
Local broker fix

### DIFF
--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -13,7 +13,10 @@ Loading the broker
 ******************
 
 To load the broker you need a ``regolithrc.json`` file.
-With that you can use either the class based or function interface
+With that you can use either the class based or function interface.
+Note: When utilizing the broker with the local FS, load_db must be
+run from the local directory. In this case, the argument can optionally
+be omitted (i.e. db = Broker.from_rc()).
 
 .. code-block:: python
 
@@ -25,7 +28,8 @@ With that you can use either the class based or function interface
 Inserting files into the store
 ******************************
 
-To insert documents into the broker you can use the ``add_file`` interface
+To insert documents into the broker you can use the ``add_file`` interface.
+Note: The files to be added must be present in the cwd
 
 .. code-block:: python
 
@@ -49,7 +53,8 @@ This will:
 Retrieving files from the store
 *******************************
 
-To retrive files from the store you can use the ``get_file`` interface
+To retrieve files from the store you can use the ``get_file`` interface.
+Importantly, this will only retrieve the path to the file.
 
 .. code-block:: python
 

--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -7,36 +7,42 @@ Storing files with the broker
 Sharing figures (and other files) among various group members can be
 difficult, as everyone has slightly different file systems.
 Regolith has a system to help with this by providing file storage which can
-be addressed to various documents in the database.
+be addressed to various documents in the database. In order to do so, the user
+must clone the regolith-storage github directory into their dbs folder, and run
+python in a terminal in that (regolith-storage) directory with their
+regolith_env conda environment activated.
 
 Loading the broker
 ******************
 
-To load the broker you need a ``regolithrc.json`` file.
-With that you can use either the class based or function interface.
-Note: When utilizing the broker with the local FS, load_db must be
-run from the local directory. In this case, the argument can optionally
-be omitted (i.e. db = Broker.from_rc()).
+To load the broker you need a ``regolithrc.json`` file. This file should
+be present in the regolith-storage directory that the user has cloned. The following
+block of code should be run in the user's python terminal, in the cloned storage
+directory, with the regolith_env conda environment activated. If you intend to
+add a file to the heap, do not put the file in the cloned directory before loading the
+database as follows.
 
 .. code-block:: python
 
-    from regolith.broker import load_db, Broker
-    db = load_db('/path/to/regolithrc.json')
-    # or
-    db = Broker.from_rc('/path/to/regolithrc.json')
+    from regolith.broker import Broker
+    db = Broker.from_rc()
 
 Inserting files into the store
 ******************************
 
 To insert documents into the broker you can use the ``add_file`` interface.
-Note: The files to be added must be present in the cwd
+Due to the fact that the metadata is utilizing a local url and filesystem client,
+the user must add, commit, push to origin and PR the effected local databases after
+the addition of the file edits their metadata. See below for an example of how to
+both create and store a file in the regro document of the projects collection.
+
+Note: Now is the time to take files to be added and paste them into the cloned storage
+directory. Do not paste them into the _build folder, but rather the base directory.
 
 .. code-block:: python
 
     import matplotlib.pyplot as plt
-    from regolith.broker import Broker
 
-    db = Broker.from_rc()
     plt.plot(range(10), range(10))
     plt.savefig('hello_world.png')
     doc = db['projects']['regro']
@@ -53,7 +59,7 @@ This will:
 Retrieving files from the store
 *******************************
 
-To retrieve files from the store you can use the ``get_file`` interface.
+To retrieve files from the store you can use the ``get_file_path`` interface.
 Importantly, this will only retrieve the path to the file.
 
 .. code-block:: python
@@ -62,7 +68,7 @@ Importantly, this will only retrieve the path to the file.
 
     db = Broker.from_rc()
     doc = db['projects']['regro']
-    path = db.get_file(doc, 'hw_file')
+    path = db.get_file_path(doc, 'hw_file')
 
 This can be used inside tex documents via the ``FigureBuilder`` class/CLI
 
@@ -78,19 +84,19 @@ Here is an example tex document
     \affiliation{Department of Applied Physics
     and Applied Mathematics, Columbia University, New York, NY 10027}
 
-    \includegraphics{ {{-get_file(db['projects']['regro'], 'hw_file')-}} }
+    \includegraphics{ {{-get_file_path(db['projects']['regro'], 'hw_file')-}} }
     \end{document}
 
 After running ``regolith build figure`` in the directory
-``{{-get_file(db['projects']['regro'], 'hw_file')-}}`` will be replaced with
+``{{-get_file_path(db['projects']['regro'], 'hw_file')-}}`` will be replaced with
 the path to the file in the store.
 This way the figure can be accessed across machines in a uniform way.
 
 Note that this isn't limited to figures, any file can be stored in the store,
-so if there were boilerplate or short chuncks which could be re-used then
-they could be stored centraly and retrieved as needed.
+so if there were boilerplate or short chunks which could be re-used then
+they could be stored centrally and retrieved as needed.
 
 Also note that we could have also used the builder to replace other pieces of
 the document, eg ``\author{ {{-db['people']['cwright']['name']-}} }`` would
-have been replaced with the full name of the auther.
+have been replaced with the full name of the author.
 

--- a/regolith/broker.py
+++ b/regolith/broker.py
@@ -25,7 +25,7 @@ class Broker:
     >>> # Store a file
     >>> db.add_file(ergs, 'myfile', '/path/to/file/hello.txt')
     >>> # Get a file from the store
-    >>> path = db.get_file(ergs, 'myfile')
+    >>> path = db.get_file_path(ergs, 'myfile')
     """
 
     def __init__(self, rc=DEFAULT_RC):
@@ -63,7 +63,7 @@ class Broker:
         """Return a Broker instance"""
         return load_db(rc_file)
 
-    def get_file(self, document, name):
+    def get_file_path(self, document, name):
         """ Get a file from the file storage associated with the document and
         name
 

--- a/regolith/broker.py
+++ b/regolith/broker.py
@@ -2,6 +2,7 @@
 from regolith.database import dump_database, open_dbs
 from regolith.runcontrol import DEFAULT_RC, load_rcfile, filter_databases
 from regolith.storage import store_client, push
+from os import getcwd
 
 
 def load_db(rc_file="regolithrc.json"):
@@ -80,8 +81,9 @@ class Broker:
         path : str or None
             The file path, if not in the storage None
         """
+        cwd = getcwd()
         if "files" in document:
-            return self.store.retrieve(document["files"][name])
+            return cwd + '\\' + self.store.retrieve(document["files"][name])
         else:
             return None
 

--- a/regolith/broker.py
+++ b/regolith/broker.py
@@ -2,7 +2,6 @@
 from regolith.database import dump_database, open_dbs
 from regolith.runcontrol import DEFAULT_RC, load_rcfile, filter_databases
 from regolith.storage import store_client, push
-from os import getcwd
 
 
 def load_db(rc_file="regolithrc.json"):
@@ -81,9 +80,8 @@ class Broker:
         path : str or None
             The file path, if not in the storage None
         """
-        cwd = getcwd()
         if "files" in document:
-            return cwd + '\\' + self.store.retrieve(document["files"][name])
+            return self.store.retrieve(document["files"][name])
         else:
             return None
 

--- a/regolith/builders/figurebuilder.py
+++ b/regolith/builders/figurebuilder.py
@@ -22,7 +22,7 @@ class FigureBuilder(LatexBuilderBase):
         super().construct_global_ctx()
         gtx = self.gtx
         gtx["db"] = self.db.md
-        gtx["get_file"] = self.db.get_file
+        gtx["get_file_path"] = self.db.get_file_path
         gtx["fuzzy_retrieval"] = fuzzy_retrieval
 
     def latex(self):

--- a/regolith/storage.py
+++ b/regolith/storage.py
@@ -149,10 +149,13 @@ class StorageClient(object):
         """
         ret = os.path.join(self.path, file_name)
         temp = (self.path + file_name).find(self.path, 1, -1)
-        if temp != -1:
-            return file_name
         if os.path.exists(ret):
             return os.path.join(self.path, file_name)
+        elif temp != -1:
+            if os.name == "posix":
+                return os.getcwd() + '/' + file_name
+            else:
+                return os.getcwd() + '\\' + file_name
         else:
             return None
 

--- a/regolith/storage.py
+++ b/regolith/storage.py
@@ -1,6 +1,8 @@
 """Tools for document storgage."""
 import os
 import shutil
+from warnings import warn
+
 from xonsh.lib import subprocess
 from contextlib import contextmanager
 

--- a/regolith/storage.py
+++ b/regolith/storage.py
@@ -150,14 +150,8 @@ class StorageClient(object):
             The path, if the file is not in the store None
         """
         ret = os.path.join(self.path, file_name)
-        temp = (self.path + file_name).find(self.path, 1, -1)
         if os.path.exists(ret):
             return os.path.join(self.path, file_name)
-        elif temp != -1:
-            if os.name == "posix":
-                return os.getcwd() + '/' + file_name
-            else:
-                return os.getcwd() + '\\' + file_name
         else:
             return None
 

--- a/regolith/storage.py
+++ b/regolith/storage.py
@@ -148,6 +148,9 @@ class StorageClient(object):
             The path, if the file is not in the store None
         """
         ret = os.path.join(self.path, file_name)
+        temp = (self.path + file_name).find(self.path, 1, -1)
+        if temp != -1:
+            return file_name
         if os.path.exists(ret):
             return os.path.join(self.path, file_name)
         else:

--- a/tests/bootstrap_builders.py
+++ b/tests/bootstrap_builders.py
@@ -27,7 +27,7 @@ builder_map = [
 def prep_figure():
     # Make latex file with some jinja2 in it
     text = r"""
-    \include{ {{-get_file(db['groups']['ergs'], 'hello')-}}}"""
+    \include{ {{-get_file_path(db['groups']['ergs'], 'hello')-}}}"""
     with open("figure.tex", "w") as f:
         f.write(text)
     # make file to be loaded
@@ -36,8 +36,8 @@ def prep_figure():
         f.write("hello world")
     # load the db and register the file
     db = load_db()
-    print(db.get_file(db["groups"]["ergs"], "hello"))
-    if not db.get_file(db["groups"]["ergs"], "hello"):
+    print(db.get_file_path(db["groups"]["ergs"], "hello"))
+    if not db.get_file_path(db["groups"]["ergs"], "hello"):
         db.add_file(db["groups"]["ergs"], "hello", "fig/hello.txt")
 
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -14,5 +14,5 @@ def test_round_trip(make_db, tmpdir):
     subprocess.check_call(["touch", "myfile.tex"], cwd=tmpdir)
     db = load_db()
     db.add_file(db["projects"]["Cyclus"], "myfile", os.path.join(tmpdir, "myfile.tex"))
-    ret = db.get_file(db["projects"]["Cyclus"], "myfile")
+    ret = db.get_file_path(db["projects"]["Cyclus"], "myfile")
     assert ret == os.path.join(repo, "myfile.tex")

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -29,7 +29,7 @@ recent_collabs_xlsx_check = ["A51", "B51", "C51"]
 def prep_figure():
     # Make latex file with some jinja2 in it
     text = r"""
-    \include{ {{-get_file(db['groups']['ergs'], 'hello')-}}}"""
+    \include{ {{-get_file_path(db['groups']['ergs'], 'hello')-}}}"""
     with open("figure.tex", "w") as f:
         f.write(text)
     # make file to be loaded
@@ -38,8 +38,8 @@ def prep_figure():
         f.write("hello world")
     # load the db and register the file
     db = load_db()
-    print(db.get_file(db["groups"]["ergs"], "hello"))
-    if not db.get_file(db["groups"]["ergs"], "hello"):
+    print(db.get_file_path(db["groups"]["ergs"], "hello"))
+    if not db.get_file_path(db["groups"]["ergs"], "hello"):
         db.add_file(db["groups"]["ergs"], "hello", "fig/hello.txt")
 
 


### PR DESCRIPTION
The broker was misbehaving when run from the command line and utilizing the filesystem. The path coming up for the storage would always be relative when retrieved by the storageclient, and this would make the figurebuilder unusable. I have now tested this fix on both windows and linux and seen that it works. I have also run_tests.py and seen that it works.