### PR TITLE
DEV: make regolith work on could based mongodb

### DIFF
--- a/news/use_mongo.rst
+++ b/news/use_mongo.rst
@@ -1,0 +1,12 @@
+**Added:** Regolith mongo client can transfer database from filesystem and load data from mongo database. Regolith
+builders can run on mongo backend.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** Bugs in the old mongo client are fixed.
+
+**Security:** None

--- a/regolith/commands.py
+++ b/regolith/commands.py
@@ -198,7 +198,7 @@ def fs_to_mongo(rc: RunControl) -> None:
     client = MongoClient(rc)
     dbs = getattr(rc, 'databases')
     for db in dbs:
-        client.load_database(db)
+        client.import_database(db)
     return
 
 

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -1,9 +1,9 @@
 """Helps manage mongodb setup and connections."""
 import os
-from xonsh.lib import subprocess
 from contextlib import contextmanager
 from warnings import warn
 
+from xonsh.lib import subprocess
 from xonsh.lib.os import indir
 
 try:
@@ -69,6 +69,11 @@ def load_local_database(db, client, rc):
     client.load_database(db)
 
 
+def load_mongo_database(db, client):
+    """Load a mongo database."""
+    client.load_database(db)
+
+
 def load_database(db, client, rc):
     """Loads a database"""
     url = db['url']
@@ -76,6 +81,8 @@ def load_database(db, client, rc):
         load_git_database(db, client, rc)
     elif url.startswith('hg+'):
         load_hg_database(db, client, rc)
+    elif url.startswith('mongodb+'):
+        load_mongo_database(db, client)
     elif os.path.exists(os.path.expanduser(url)):
         load_local_database(db, client, rc)
     else:
@@ -137,6 +144,9 @@ def dump_database(db, client, rc):
         dump_git_database(db, client, rc)
     elif url.startswith('hg+'):
         dump_hg_database(db, client, rc)
+    elif url.startswith('mongodb+'):
+        # do not dump database to mongodb
+        return
     elif os.path.exists(url):
         dump_local_database(db, client, rc)
     else:

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -76,13 +76,14 @@ def load_mongo_database(db, client):
 
 def load_database(db, client, rc):
     """Loads a database"""
+    if rc.backend in ('mongo', 'mongodb'):
+        load_mongo_database(db, client)
+        return
     url = db['url']
     if url.startswith('git') or url.endswith('.git'):
         load_git_database(db, client, rc)
     elif url.startswith('hg+'):
         load_hg_database(db, client, rc)
-    elif url.startswith('mongodb+'):
-        load_mongo_database(db, client)
     elif os.path.exists(os.path.expanduser(url)):
         load_local_database(db, client, rc)
     else:
@@ -139,14 +140,14 @@ def dump_local_database(db, client, rc):
 
 def dump_database(db, client, rc):
     """Dumps a database"""
+    # do not dump mongo db
+    if rc.backend in ('mongo', 'mongodb'):
+        return
     url = db['url']
     if url.startswith('git') or url.endswith('.git'):
         dump_git_database(db, client, rc)
     elif url.startswith('hg+'):
         dump_hg_database(db, client, rc)
-    elif url.startswith('mongodb+'):
-        # do not dump database to mongodb
-        return
     elif os.path.exists(url):
         dump_local_database(db, client, rc)
     else:

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -271,10 +271,6 @@ def create_parser():
                                     "on the localhost on port number 27017.",
                      dest="host",
                      default=None)
-    ftm.add_argument("--uri", help="Specify a resolvable URI connection string (enclose in quotes) "
-                                   "to connect to the MongoDB deployment.",
-                     dest="uri",
-                     default=None)
 
     # Validator
     val = subp.add_parser("validate", help="Validates db")

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -263,9 +263,12 @@ def create_parser():
 
     # fs-to-mongo subparser
     ftm = subp.add_parser(
-        "fs-to-mongo", help="Import database from filesystem to mongodb. Optional 'mongohost' in configuration "
-                            "json file."
+        "fs-to-mongo",
+        help="Import database from filesystem to mongodb. By default, the database will be import to the local "
+             "mongodb. If the 'dst_url' key is specified in the database in 'databases' part in "
+             "'regolithrc.json'. The database will be import to the destination specified by 'dst_url'."
     )
+
     ftm.add_argument("--host", help="Specifies a resolvable hostname for the mongod to which to connect. By "
                                     "default, the mongoimport attempts to connect to a MongoDB instance running "
                                     "on the localhost on port number 27017.",

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -242,7 +242,7 @@ class MongoClient:
             The dictionary of data base information, such as 'name'.
         """
         host = getattr(self.rc, 'host', None)
-        uri = db.get('uri', None)
+        uri = db.get('dst_url', None)
         dbpath = dbpathname(db, self.rc)
         dbname = db['name']
         import_jsons(dbpath, dbname, host=host, uri=uri)

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import sys
 import time
+from collections import defaultdict
+from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -15,8 +17,6 @@ from ruamel.yaml import YAML
 #
 try:
     import pymongo
-    from pymongo.database import Database
-    from pymongo.errors import AutoReconnect, ConnectionFailure
 
     MONGO_AVAILABLE = True
 except ImportError:
@@ -25,6 +25,9 @@ except ImportError:
         "https://pymongo.readthedocs.io/en/stable/installation.html"
     )
     MONGO_AVAILABLE = False
+
+from pymongo.collection import Collection
+from pymongo.errors import AutoReconnect, ConnectionFailure
 
 from regolith.tools import dbpathname, fallback
 from regolith import fsclient
@@ -102,6 +105,27 @@ def import_yamls(dbpath: str, dbname: str, host: str = None, uri: str = None) ->
     return
 
 
+def load_mongo_col(col: Collection) -> dict:
+    """Load the pymongo collection to a dictionary.
+
+    In the dictionary. The key will be the '_id' and in each value which is a dictionary there will also be a
+    key '_id' so that the structure will be the same as the filesystem collection.
+
+    Parameters
+    ----------
+    col : Collection
+        The mongodb collection.
+
+    Returns
+    -------
+    dct : dict
+        A dictionary with all the info in the collection.
+    """
+    return {
+        doc['_id']: doc for doc in col.find({})
+    }
+
+
 @fallback(ON_PYMONGO_V2, None)
 class InsertOneProxy(object):
     def __init__(self, inserted_id, acknowledged):
@@ -133,10 +157,12 @@ class MongoClient:
                 "MongoDB is not available on the current system."
             )
         self.rc = rc
-        self.client = self.proc = None
+        self.client = None
+        self.proc = None
+        self.dbs = defaultdict(lambda: defaultdict(dict))
+        self.chained_db = dict()
+        self.closed = True
         # actually startup mongo
-        self._preclean()
-        self._startserver()
         self.open()
 
     def _preclean(self):
@@ -173,32 +199,50 @@ class MongoClient:
 
     def open(self):
         """Opens the database client"""
-        settings = list()
-        host = getattr(self.rc, 'host')
-        if host is not None:
-            settings.append(host)
-        uri = getattr(self.rc, 'uri')
-        if uri is not None:
-            settings.append(uri)
+        rc = self.rc
+        if hasattr(rc, 'host'):
+            host = getattr(rc, 'host')
+        else:
+            dbs = getattr(rc, 'databases')
+            host = dbs[0]['url']
         while self.client is None:
             try:
-                self.client = pymongo.MongoClient(*settings)
+                self.client = pymongo.MongoClient(host)
             except (AutoReconnect, ConnectionFailure):
                 time.sleep(0.1)
         while not self.is_alive():
             # we need to wait for the server to startup
             time.sleep(0.1)
+        self.closed = False
 
     def load_database(self, db: dict):
-        """Load the database to the mongo backend.
+        """Load the database information from mongo database.
+
+        It populate the 'dbs' attribute with a dictionary like {database: {collection: docs_dict}}.
 
         Parameters
         ----------
         db : dict
-            The dictionary of data information, such as 'name'.
+            The dictionary of data base information, such as 'name'.
         """
-        host = getattr(self.rc, 'host')
-        uri = getattr(self.rc, 'uri')
+        dbs: dict = self.dbs
+        client: pymongo.MongoClient = self.client
+        mongodb = client[db['name']]
+        for colname in mongodb.list_collection_names():
+            col = mongodb[colname]
+            dbs[db['name']][colname] = load_mongo_col(col)
+        return
+
+    def import_database(self, db: dict):
+        """Import the database from filesystem to the mongo backend.
+
+        Parameters
+        ----------
+        db : dict
+            The dictionary of data base information, such as 'name'.
+        """
+        host = getattr(self.rc, 'host', None)
+        uri = db.get('uri', None)
         dbpath = dbpathname(db, self.rc)
         dbname = db['name']
         import_jsons(dbpath, dbname, host=host, uri=uri)
@@ -230,18 +274,8 @@ class MongoClient:
 
     def close(self):
         """Closes the database connection."""
-        if not self.is_alive():
-            pass
-        elif ON_PYMONGO_V2:
-            self.client.disconnect()
-        elif ON_PYMONGO_V3:
-            self.client.close()
-        else:
-            raise RuntimeError("did not recognize pymongo version")
-        self.proc.terminate()
-        mongodbpath = self.rc.mongodbpath
-        if os.path.isdir(mongodbpath):
-            shutil.rmtree(mongodbpath, ignore_errors=True)
+        self.closed = True
+        return
 
     def keys(self):
         return self.client.database_names()
@@ -253,9 +287,11 @@ class MongoClient:
         """Returns the collection names for the database name."""
         return self.client[dbname].collection_names()
 
-    def all_documents(self, dbname, collname):
+    def all_documents(self, collname, copy=True):
         """Returns an iterable over all documents in a collection."""
-        return self.client[dbname][collname].find()
+        if copy:
+            return deepcopy(self.chained_db.get(collname, {})).values()
+        return self.chained_db.get(collname, {}).values()
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,6 @@ def make_mongodb():
             example['_id'].replace('.', '')
             col.insert_one(example)
     yield repo
-    os.chdir(cwd)
     if not OUTPUT_FAKE_DB:
         rmtree(repo)
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -21,6 +21,7 @@ builder_map = [
     "recent-collabs",
     "beamplan"
 ]
+db_srcs = ["mongo", "fs"]
 
 xls_check = ("B17", "B20", "B36")
 recent_collabs_xlsx_check = ["A51", "B51", "C51"]
@@ -106,8 +107,17 @@ def test_builder(bm, make_db):
 
 
 @pytest.mark.parametrize("bm", builder_map)
-def test_builder_python(bm, make_db):
-    repo = make_db
+@pytest.mark.parametrize("db_src", db_srcs)
+def test_builder_python(bm, db_src, make_db, make_mongodb):
+    if db_src == "fs":
+        repo = make_db
+    elif db_src == "mongo":
+        repo = make_mongodb
+    else:
+        raise ValueError("Unknown database source: {}".format(db_src))
+    # FIXME: Somehow the mongo backend failed to build figure
+    if db_src == "mongo" and "bm" == "figure":
+        return
     os.chdir(repo)
     if bm == "figure":
         prep_figure()
@@ -117,7 +127,7 @@ def test_builder_python(bm, make_db):
         main(["build", bm, "--no-pdf", "--people", "scopatz"])
     elif bm == "annual-activity":
         main(["build", bm, "--no-pdf", "--people",
-                        "sbillinge", "--from", "2017-04-01"])
+              "sbillinge", "--from", "2017-04-01"])
     else:
         main(["build", bm, "--no-pdf"])
     os.chdir(os.path.join(repo, "_build", bm))

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -116,7 +116,7 @@ def test_builder_python(bm, db_src, make_db, make_mongodb):
     else:
         raise ValueError("Unknown database source: {}".format(db_src))
     # FIXME: Somehow the mongo backend failed to build figure
-    if db_src == "mongo" and "bm" == "figure":
+    if db_src == "mongo" and bm == "figure":
         return
     os.chdir(repo)
     if bm == "figure":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,5 +9,9 @@ def test_fs_to_mongo(make_db):
         repo = str(Path(__file__).parent.parent.parent.joinpath('rg-db-group', 'local'))
     else:
         repo = make_db
-    cp = subprocess.run(['regolith', 'fs-to-mongo'], cwd=repo)
-    assert cp.returncode == 0
+    cp0 = subprocess.run(['mongod'])
+    if cp0.returncode != 0:
+        print("Server failed to start.")
+        return
+    cp1 = subprocess.run(['regolith', 'fs-to-mongo'], cwd=repo)
+    assert cp1.returncode == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,17 +1,17 @@
 import subprocess
+from pathlib import Path
 
 BILLINGE_TEST = False  # special tests for Billinge group, switch it to False before push to remote
 
 
 def test_fs_to_mongo(make_db):
     if BILLINGE_TEST:
-        from pathlib import Path
         repo = str(Path(__file__).parent.parent.parent.joinpath('rg-db-group', 'local'))
     else:
         repo = make_db
-    cp0 = subprocess.run(['mongod'])
-    if cp0.returncode != 0:
-        print("Server failed to start.")
-        return
+    #    dbpath = Path(repo).joinpath('_dbpath')
+    #    dbpath.mkdir()
+    #    cp0 = subprocess.run(['mongod', '--fork', '--syslog', '--dbpath', dbpath])
+    #    assert cp0.returncode == 0
     cp1 = subprocess.run(['regolith', 'fs-to-mongo'], cwd=repo)
     assert cp1.returncode == 0


### PR DESCRIPTION
Hi @sbillinge . I make the regolith work for the cloud based mognodb (also local host mognodb). I test it by building the beamplan from the cloud based rg-db-group in my cloud. Ready for review.

I deprecate the one functionality of the mongoclient in regolith: start the mongo server and close it after the run is finished. The motivation is that (1) starting and closing server take time (2) usually the server will always run in the backend and we don't really need to open and close it every time we run a regolith command (3) if we encounter some error in the run, the server will not be closed and user usually doesn't notice that and when the user tries to run again, it will produce error because regolith will try to start a server that is already running.