### PR TITLE
fix some bugs and add order algorithm in l_todo

### DIFF
--- a/regolith/helpers/u_todohelper.py
+++ b/regolith/helpers/u_todohelper.py
@@ -115,12 +115,12 @@ class TodoUpdaterHelper(DbHelperBase):
         if not rc.index:
             print("-" * 50)
             print("Please choose from one of the following to update:")
-            print("    action (due date|importance|expected duration(mins)|begin date|end date)")
+            print("    action (due date|importance|expected duration(mins))")
             print("started:")
             for todo in todolist:
                 if todo.get('status') == "started":
                     print(
-                        f"{todo.get('index'):>2}. {todo.get('description')}({todo.get('due_date')}|{todo.get('importance')}|{str(todo.get('duration'))}|{todo.get('begin_date')}|{todo.get('end_date')})")
+                        f"{todo.get('index'):>2}. {todo.get('description')}({todo.get('due_date')}|{todo.get('importance')}|{str(todo.get('duration'))})")
                     if todo.get('notes'):
                         for note in todo.get('notes'):
                             print(f"     - {note}")
@@ -129,7 +129,7 @@ class TodoUpdaterHelper(DbHelperBase):
                 for todo in todolist:
                     if todo.get('status') in ["finished", "cancelled"]:
                         print(
-                            f"{todo.get('index'):>2}. {todo.get('description')}({todo.get('due_date')}|{todo.get('importance')}|{str(todo.get('duration'))}|{todo.get('begin_date')}|{todo.get('end_date')}|{todo.get('status')})")
+                            f"{todo.get('index'):>2}. {todo.get('description')}({todo.get('due_date')}|{todo.get('importance')}|{str(todo.get('duration'))})")
                         if todo.get('notes'):
                             for note in todo.get('notes'):
                                 print(f"     - {note}")

--- a/tests/outputs/f_todo/people.yaml
+++ b/tests/outputs/f_todo/people.yaml
@@ -290,6 +290,7 @@ sbillinge:
       notes:
         - test notes 1
         - test notes 2
+      end_date: 2020-07-20
 scopatz:
   aka:
     - Scopatz

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -169,10 +169,13 @@ helper_map = [
      "1. Maria as a new contact\n"
      ),
     (["helper", "l_todo", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
+     "--------------------------------------------------\n"
      "    action (days to due date|importance|expected duration(mins))\n"
      " 1. read paper(6|2|60.0)\n"
      " 2. prepare the presentation(16|1|30.0)\n"
-     "     --notes:[\'about 10 minutes\', \"don't forget to upload to the website\"]\n"
+     "     - about 10 minutes\n"
+     "     - don't forget to upload to the website\n"
+     "--------------------------------------------------\n"
      ),
     (["helper", "l_todo", "--assigned_to", "wrong_id"],
      "The id you entered can't be found in people.yml.\n"
@@ -180,7 +183,7 @@ helper_map = [
     (["helper", "a_todo", "test a_todo", "10", "--assigned_to", "sbillinge", "--begin_date", "2020-07-06",  "--duration", "50", "--importance", "2", "--notes", "test notes 1", "test notes 2"],
      "The task \"test a_todo\" for sbillinge has been added in people collection.\n"
      ),
-    (["helper", "f_todo", "--index", "3", "--assigned_to", "sbillinge"],
+    (["helper", "f_todo", "--index", "3", "--assigned_to", "sbillinge", "--end_date", "2020-07-20"],
      "The task \"test a_todo\" for sbillinge has been marked as finished in people collection.\n"
      ),
     (["helper", "f_todo", "--assigned_to", "sbillinge"],
@@ -188,13 +191,17 @@ helper_map = [
      "1. read paper\n"
      "2. prepare the presentation\n"
      ),
-    (["helper", "l_todo", "--verbose","--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
+    (["helper", "l_todo", "--all","--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
+     "--------------------------------------------------\n"
      "    action (days to due date|importance|expected duration(mins))\n"
      " 1. read paper(6|2|60.0)\n"
      " 2. prepare the presentation(16|1|30.0)\n"
-     "     --notes:[\'about 10 minutes\', \"don't forget to upload to the website\"]\n"
+     "     - about 10 minutes\n"
+     "     - don't forget to upload to the website\n"
      " 3. (finished) test a_todo\n"
-     "     --notes:['test notes 1', 'test notes 2']\n"
+     "     - test notes 1\n"
+     "     - test notes 2\n"
+     "--------------------------------------------------\n"
      ),
     (["helper", "u_todo", "--index", "3", "--assigned_to", "sbillinge", "--description", "update the description", "--due_date", "2020-07-06", "--estimated_duration", "35", "--importance", "2", "--status", "finished","--notes", "some new notes", "notes2", "--begin_date", "2020-06-06", "--end_date", "2020-07-07"],
      "The task for sbillinge has been updated in people collection.\n"
@@ -202,14 +209,14 @@ helper_map = [
     (["helper", "u_todo", "--assigned_to", "sbillinge", "--all"],
      "--------------------------------------------------\n"
      "Please choose from one of the following to update:\n"
-     "    action (due date|importance|expected duration(mins)|begin date|end date)\n"
+     "    action (due date|importance|expected duration(mins))\n"
      "started:\n"
-     " 1. read paper(2020-07-19|2|60.0|2020-06-15|None)\n"
-     " 2. prepare the presentation(2020-07-29|0|30.0|2020-06-22|None)\n"
+     " 1. read paper(2020-07-19|2|60.0)\n"
+     " 2. prepare the presentation(2020-07-29|0|30.0)\n"
      "     - about 10 minutes\n"
      "     - don't forget to upload to the website\n"
      "finished/cancelled:\n"
-     " 3. update the description(2020-07-06|2|35.0|2020-06-06|2020-07-07|finished)\n"
+     " 3. update the description(2020-07-06|2|35.0)\n"
      "     - some new notes\n"
      "     - notes2\n"
      "--------------------------------------------------\n"


### PR DESCRIPTION
Hi @sbillinge! I haven't sync printed lists in l_todo, f_todo and u_todo. I will do it soon after we decide which way to choose (please see comments in issue#572). 
In this PR, there are several things:
1. delete begin-date and end-date in u_todo. 
2. add flag --end_date in f_todo, cuz when we use f_todo to mark a task as finished, I think it's better to set end_date as today automatically, or specify an end_date.
3. add an algorithm in l_todo to sort tasks. I tried:  order = importance + 1/[1 + exp(|days to due date|)]. The second part  "1/[1 + exp(|days to due date|)] " ranges from 0 to 0.5. So by using that algorithm, importance 2 will always stay top, importance 1 is at the middle, and 0 is at the bottom. In each importance level, the tasks will be sorted by the absolute value of "days to due date", and list from small to large.  We can try this first and discuss if there are other things to consider.