### PR TITLE
added --current, fixed --all

### DIFF
--- a/regolith/helpers/l_projectahelper.py
+++ b/regolith/helpers/l_projectahelper.py
@@ -25,9 +25,14 @@ HELPER_TARGET = "l_projecta"
 
 def subparser(subpi):
     subpi.add_argument("--all", action="store_true",
-                       help="Lists all projecta that have not ended"
+                       help="Lists all projecta in general"
                        )
-    subpi.add_argument("-v", "--verbose", action="store_true", help='increase verbosity of output')
+    subpi.add_argument("-c", "--current", action="store_true",
+                       help='List ongoing projecta'
+                       )
+    subpi.add_argument("-v", "--verbose", action="store_true",
+                       help='Increase verbosity of output'
+                       )
     subpi.add_argument("-l", "--lead",
                        help="Filter milestones for this project lead"
                        )
@@ -102,7 +107,7 @@ class ProjectaListerHelper(SoutHelperBase):
         else:
             collection = self.gtx["projecta"]
 
-        if (not rc.lead) and (not rc.person) and (not rc.ended) and (not rc.grant) and (not rc.verbose) and (not rc.grp_by_lead) and (not rc.filter) and (not rc.all):
+        if (not rc.lead) and (not rc.person) and (not rc.ended) and (not rc.grant) and (not rc.verbose) and (not rc.grp_by_lead) and (not rc.filter) and (not rc.all) and (not rc.current):
             return
         if rc.date:
             desired_date = date_parser.parse(rc.date).date()
@@ -118,13 +123,17 @@ class ProjectaListerHelper(SoutHelperBase):
         end_projecta = []
         grouped_projecta = {}
         if rc.lead and rc.person:
-            raise RuntimeError(f"please specify either lead or person, not both")
+            raise RuntimeError(
+                f"please specify either lead or person, not both")
         for projectum in collection:
-            if rc.all and projectum.get('status') != "finished":
-                projecta.append(projectum)
-                continue
             if isinstance(projectum.get('group_members'), str):
                 projectum['group_members'] = [projectum.get('group_members')]
+            if rc.all and (projectum.get('status') == True):
+                projecta.append(projectum)
+                continue
+            if rc.current and (projectum.get('status') == "proposed" or "started"):
+                projecta.append(projectum)
+                continue
             if rc.lead and projectum.get('lead') != rc.lead:
                 continue
             if rc.person:
@@ -161,8 +170,10 @@ class ProjectaListerHelper(SoutHelperBase):
                 if p.get("collaborators"):
                     collaborators = ', '.join(p.get("collaborators"))
                 print("{}    {}\n    Lead: {}    Members: {}    Collaborators: {}".format(p.get("_id"),
-                                                                                          p.get("description"),
-                                                                                          p.get("lead"), members,
+                                                                                          p.get(
+                                                                                              "description"),
+                                                                                          p.get(
+                                                                                              "lead"), members,
                                                                                           collaborators))
             return
 
@@ -175,7 +186,8 @@ class ProjectaListerHelper(SoutHelperBase):
                     else:
                         grants = p.get('grants')
                 print(p.get('_id'))
-                print(f"    status: {p.get('status')}, begin_date: {p.get('begin_date')}, due_date: {p.get('due_date')}, end_date: {p.get('end_date')}, grant: {grants}")
+                print(
+                    f"    status: {p.get('status')}, begin_date: {p.get('begin_date')}, due_date: {p.get('due_date')}, end_date: {p.get('end_date')}, grant: {grants}")
                 print(f"    description: {p.get('description')}")
                 print("    team:")
                 print(f"        lead: {p.get('lead')}")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -41,7 +41,7 @@ helper_map = [
     (["helper", "l_projecta", "--verbose", "--lead", "ascopatz"],
      "20sb_firstprojectum\n    status: proposed, begin_date: 2020-04-28, due_date: None, end_date: 2020-06-05, grant: SymPy-1.1\n    description: My first projectum\n    team:\n        lead: ascopatz\n        group_members: ascopatz\n        collaborators: aeinstein, pdirac\n"
      ),
-     (["helper", "l_projecta", "--verbose", "--person", "ascopatz"],
+    (["helper", "l_projecta", "--verbose", "--person", "ascopatz"],
      "20ly_newprojectum\n    status: started, begin_date: 2020-04-29, due_date: None, end_date: None, grant: SymPy-1.1\n    description: more work\n    team:\n        lead: lyang\n        group_members: ascopatz\n        collaborators: afriend\n20sb_firstprojectum\n    status: proposed, begin_date: 2020-04-28, due_date: None, end_date: 2020-06-05, grant: SymPy-1.1\n    description: My first projectum\n    team:\n        lead: ascopatz\n        group_members: ascopatz\n        collaborators: aeinstein, pdirac\n"
      ),
     (["helper", "l_projecta", "--grant", "SymPy-1.1"],
@@ -51,6 +51,9 @@ helper_map = [
      "lyang:\n    20ly_newprojectum\nascopatz:\n    20sb_firstprojectum\n"
      ),
     (["helper", "l_projecta", "--all"],
+     "20ly_newprojectum\n20sb_firstprojectum\n"
+     ),
+    (["helper", "l_projecta", "--current"],
      "20ly_newprojectum\n20sb_firstprojectum\n"
      ),
     (["helper", "l_projecta", "--grp_by_lead", "-l", "ascopatz"],
@@ -191,7 +194,7 @@ helper_map = [
      "1. read paper\n"
      "2. prepare the presentation\n"
      ),
-    (["helper", "l_todo", "--all","--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
+    (["helper", "l_todo", "--all", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
      "--------------------------------------------------\n"
      "    action (days to due date|importance|expected duration(mins))\n"
      " 1. read paper(6|2|60.0)\n"
@@ -203,7 +206,7 @@ helper_map = [
      "     - test notes 2\n"
      "--------------------------------------------------\n"
      ),
-    (["helper", "u_todo", "--index", "3", "--assigned_to", "sbillinge", "--description", "update the description", "--due_date", "2020-07-06", "--estimated_duration", "35", "--importance", "2", "--status", "finished","--notes", "some new notes", "notes2", "--begin_date", "2020-06-06", "--end_date", "2020-07-07"],
+    (["helper", "u_todo", "--index", "3", "--assigned_to", "sbillinge", "--description", "update the description", "--due_date", "2020-07-06", "--estimated_duration", "35", "--importance", "2", "--status", "finished", "--notes", "some new notes", "notes2", "--begin_date", "2020-06-06", "--end_date", "2020-07-07"],
      "The task for sbillinge has been updated in people collection.\n"
      ),
     (["helper", "u_todo", "--assigned_to", "sbillinge", "--all"],
@@ -269,7 +272,7 @@ helper_map = [
      "Please rerun the helper specifying '-n list-index' to update item number 'list-index':\n"
      "1. col as a new institution.\n"
      "2. columbiau      Columbia University.\n"),
-    (["helper", "makeappointments", "run", "--no_gui",],
+    (["helper", "makeappointments", "run", "--no_gui", ],
      "WARNING: appointment gap for scopatz from 2019-09-01 to 2019-12-31\n"
      "WARNING: appointment gap for scopatz from 2020-05-16 to 2020-08-31\n"
      "appointments on outdated grants:\n"
@@ -287,7 +290,7 @@ helper_map = [
      "    2020-12-31: grant: abc42, overspend amount: -1.41 months\n"
      "plotting mode is on\n"
      ),
-    (["helper", "makeappointments", "run", "--no_plot",],
+    (["helper", "makeappointments", "run", "--no_plot", ],
      "WARNING: appointment gap for scopatz from 2019-09-01 to 2019-12-31\n"
      "WARNING: appointment gap for scopatz from 2020-05-16 to 2020-08-31\n"
      "appointments on outdated grants:\n"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -194,12 +194,8 @@ helper_map = [
      "1. read paper\n"
      "2. prepare the presentation\n"
      ),
-<<<<<<< HEAD
     (["helper", "l_todo", "--all", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
      "--------------------------------------------------\n"
-=======
-    (["helper", "l_todo", "--verbose", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
->>>>>>> 573fba7dd600e57f0d34f62153a3ded5d80faaf9
      "    action (days to due date|importance|expected duration(mins))\n"
      " 1. read paper(6|2|60.0)\n"
      " 2. prepare the presentation(16|1|30.0)\n"


### PR DESCRIPTION
@sbillinge

So now --current shows everything ongoing (proposed or started), and --all now shows every projecta available. Though it looks like nothing is marked as ended so they both show every projecta for now.

Should any overall projecta be marked finished or anything? Or just certain prums? (assuming I'm understanding prums are the small parts of a bigger projecta)

I guess is this what l_projecta should do in general or something else?