### PR TITLE
Mongodb Test on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,11 +73,6 @@ def make_db():
         rmtree(repo)
 
 
-# @pytest.fixture(scope="session")
-# def mongodb_skip_flag():
-#     skip_flag = False
-#     return skip_flag
-
 @pytest.fixture(scope="session")
 def make_mongodb():
     """A test fixutre that creates and destroys a git repo in a temporary

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -73,7 +73,10 @@ def test_builder(bm, db_src, make_db, make_mongodb):
     if db_src == "fs":
         repo = make_db
     elif db_src == "mongo":
-        repo = make_mongodb
+        if make_mongodb is False:
+            pytest.skip("Mongoclient failed to start")
+        else:
+            repo = make_mongodb
     else:
         raise ValueError("Unknown database source: {}".format(db_src))
     os.chdir(repo)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -138,7 +138,13 @@ def test_builder(bm, db_src, make_db, make_mongodb):
 @pytest.mark.parametrize("db_src", db_srcs)
 @pytest.mark.parametrize("bm", builder_map)
 def test_builder_python(bm, db_src, make_db, make_mongodb):
-    repo = make_db
+    if db_src == "fs":
+        repo = make_db
+    elif db_src == "mongo":
+        if make_mongodb is False:
+            pytest.skip("Mongoclient failed to start")
+        else:
+            repo = make_mongodb
     os.chdir(repo)
     if bm == "figure":
         prep_figure()

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -132,8 +132,9 @@ def test_builder(bm, db_src, make_db, make_mongodb):
                         assert expected == actual
 
 
+@pytest.mark.parametrize("db_src", db_srcs)
 @pytest.mark.parametrize("bm", builder_map)
-def test_builder_python(bm, make_db):
+def test_builder_python(bm, db_src, make_db, make_mongodb):
     repo = make_db
     os.chdir(repo)
     if bm == "figure":


### PR DESCRIPTION
Modified the tests such that windows will now run mongodb tests if mongodb is installed, and all computers will now be able to selectively run filesystem tests and skip mongo tests. There will be a printout saying that the mongo tests were skipped, a link to where to install mongo, and a xonsh shell error saying that the mongo commands do not exist if the user has not installed mongodb community edition.