### PR TITLE
add assigned_by and update sorting in todolist

### DIFF
--- a/regolith/helpers/a_todohelper.py
+++ b/regolith/helpers/a_todohelper.py
@@ -29,14 +29,17 @@ def subparser(subpi):
     subpi.add_argument("duration",
                        help="The estimated duration the task will take in minutes.",
                        )
-    subpi.add_argument("-i", "--importance",
+    subpi.add_argument("-p", "--importance",
                        help=f"The importance of the task from {ALLOWED_IMPORTANCE}. Default is 1.",
                        default=1
                        )
     subpi.add_argument("-n", "--notes", nargs="+", help="Additional notes for this task. Each note should be enclosed "
                                                         "in quotation marks.")
-    subpi.add_argument("-a", "--assigned_to", help="ID of the member to whom the task is assigned. Default id is saved in user.json. ")
-    subpi.add_argument("-b", "--begin_date",
+    subpi.add_argument("-t", "--assigned_to",
+                       help="ID of the member to whom the task is assigned. Default id is saved in user.json. ")
+    subpi.add_argument("-b", "--assigned_by",
+                       help="ID of the member that assigns the task. Default id is saved in user.json. ")
+    subpi.add_argument("--begin_date",
                        help="Begin date of the task in format YYYY-MM-DD. Default is today."
                        )
     subpi.add_argument("-c", "--certain_date",
@@ -84,6 +87,11 @@ class TodoAdderHelper(DbHelperBase):
         person = rc.client.find_one(rc.database, rc.coll, filterid)
         if not person:
             raise TypeError(f"The id {rc.assigned_to} can't be found in the people collection")
+        if not rc.assigned_by:
+            rc.assigned_by = rc.default_user_id
+        find_person = rc.client.find_one(rc.database, rc.coll, {'_id': rc.assigned_by})
+        if not find_person:
+            raise TypeError(f"The id {rc.assigned_by} can't be found in the people collection")
         now = dt.date.today()
         if not rc.begin_date:
             begin_date = now
@@ -110,7 +118,8 @@ class TodoAdderHelper(DbHelperBase):
             'begin_date': begin_date,
             'duration': float(rc.duration),
             'importance': importance,
-            'status': "started"})
+            'status': "started",
+            'assigned_by': rc.assigned_by})
         if rc.notes:
             todolist[-1]['notes'] = rc.notes
         indices = [todo.get("running_index", 0) for todo in todolist]

--- a/regolith/helpers/u_todohelper.py
+++ b/regolith/helpers/u_todohelper.py
@@ -18,17 +18,15 @@ from regolith.tools import (
 
 TARGET_COLL = "people"
 ALLOWED_IMPORTANCE = [0, 1, 2]
-ALLOWED_STATUS = ["started", "finished", "cancelled"]
+ALLOWED_STATI = ["started", "finished", "cancelled"]
 
 
 def subparser(subpi):
     subpi.add_argument("-i", "--index",
-                       help="Enter the running_index of a certain task in the enumerated list to update that task.",
+                       help="Enter the index of a certain task in the enumerated list to update that task.",
                        type=int)
-    subpi.add_argument("--all", action="store_true",
-                       help="List both finished and unfinished tasks. Without this flag, the helper will only display "
-                            "unfinished tasks. "
-                       )
+    subpi.add_argument("-s", "--stati", nargs='+', help=f'Filter tasks with specific status from {ALLOWED_STATI}. '
+                                                        f'Default is started.', default=["started"])
     subpi.add_argument("-r", "--running_index", action="store_true",
                        help="Reorder and update the indices."
                        )
@@ -48,19 +46,21 @@ def subparser(subpi):
                        help=f"Change the importance of the task from {ALLOWED_IMPORTANCE}.",
                        type=int
                        )
-    subpi.add_argument("-s", "--status",
-                       help=f"Change the status of the task from {ALLOWED_STATUS}."
+    subpi.add_argument("--status",
+                       help=f"Change the status of the task from {ALLOWED_STATI}."
                        )
     subpi.add_argument("-n", "--notes", nargs="+", help="Change the notes for this task. Each note should be enclosed "
                                                         "in quotation marks.")
-    subpi.add_argument("-b", "--begin_date",
+    subpi.add_argument("--begin_date",
                        help="Change the begin date of the task in format YYYY-MM-DD."
                        )
     subpi.add_argument("--end_date",
                        help="Change the end date of the task in format YYYY-MM-DD."
                        )
-    subpi.add_argument("-a", "--assigned_to",
-                       help="ID of the member to whom the task is assigned. Default id is saved in user.json. ")
+    subpi.add_argument("-t", "--assigned_to",
+                       help="Filter tasks that are assigned to this user id. Default id is saved in user.json. ")
+    subpi.add_argument("-b", "--assigned_by", nargs='?', const="default_id",
+                       help="Filter tasks that are assigned to other members by this user id. Default id is saved in user.json. ")
     subpi.add_argument("-c", "--certain_date",
                        help="Enter a certain date so that the helper can calculate how many days are left from that date to the deadline. Default is today.")
 
@@ -105,7 +105,6 @@ class TodoUpdaterHelper(DbHelperBase):
         filterid = {'_id': rc.assigned_to}
         if rc.running_index:
             index = 1
-            index_finished = -1
             for i in range(0, len(rc.databases)):
                 db_name = rc.databases[i]["name"]
                 person_idx = rc.client.find_one(db_name, rc.coll, filterid)
@@ -117,12 +116,8 @@ class TodoUpdaterHelper(DbHelperBase):
                     continue
                 else:
                     for todo in todolist_idx:
-                        if todo.get('status') == "started":
-                            todo["running_index"] = index
-                            index += 1
-                        if todo.get('status') in ["finished", "cancelled"]:
-                            todo["running_index"] = index_finished
-                            index_finished += -1
+                        todo["running_index"] = index
+                        index += 1
         person = document_by_value(all_docs_from_collection(rc.client, "people"), "_id", rc.assigned_to)
         if not person:
             raise TypeError(f"Id {rc.assigned_to} can't be found in people collection")
@@ -135,21 +130,31 @@ class TodoUpdaterHelper(DbHelperBase):
         else:
             today = date_parser.parse(rc.certain_date).date()
         if not rc.index:
+            started_todo = 0
             for todo in todolist:
+                if todo["status"] == 'started':
+                    started_todo += 1
                 if not todo.get('importance'):
                     todo['importance'] = 1
                 if type(todo["due_date"]) == str:
                     todo["due_date"] = date_parser.parse(todo["due_date"]).date()
+                if type(todo.get("end_date")) == str:
+                    todo["end_date"] = date_parser.parse(todo["end_date"]).date()
                 todo["days_to_due"] = (todo.get('due_date') - today).days
+                todo["sort_finished"] = (todo.get("end_date", dt.date(1900, 1, 1)) - dt.date(1900, 1, 1)).days
                 todo["order"] = todo['importance'] + 1 / (1 + math.exp(abs(todo["days_to_due"]-0.5)))-(todo["days_to_due"] < -7)*10
-            todolist = sorted(todolist, key=lambda k: (-k['order'], k.get('duration', 10000), k['status']))
-            index_match={}
+            todolist = sorted(todolist, key=lambda k: (k['status'], k['order'], -k.get('duration', 10000)), reverse=True)
+            todolist[started_todo:] = sorted(todolist[started_todo:], key=lambda k: (-k["sort_finished"]))
+            index_match = {}
             if rc.running_index:
-                new_index = 1
-                for todo in todolist:
-                    if todo["status"] == 'started':
-                        index_match[todo["running_index"]] = new_index
-                        new_index += 1
+                new_index_started = 1
+                new_index_finished = -1
+                for todo in todolist[:started_todo]:
+                    index_match[todo["running_index"]] = new_index_started
+                    new_index_started += 1
+                for todo in todolist[started_todo:]:
+                    index_match[todo["running_index"]] = new_index_finished
+                    new_index_finished += -1
                 for i in range(0, len(rc.databases)):
                     db_name = rc.databases[i]["name"]
                     person_idx = rc.client.find_one(db_name, rc.coll, filterid)
@@ -159,25 +164,27 @@ class TodoUpdaterHelper(DbHelperBase):
                         continue
                     if len(todolist_idx) != 0:
                         for todo in todolist_idx:
-                            if todo.get('status') == "started":
-                                index = index_match[todo["running_index"]]
-                                todo["running_index"] = index
+                            index = index_match[todo["running_index"]]
+                            todo["running_index"] = index
                         rc.client.update_one(db_name, rc.coll, {'_id': rc.assigned_to}, {"todos": todolist_idx},
                                              upsert=True)
                         print(f"Indices in {db_name} for {rc.assigned_to} have been updated.")
                 return
+            if rc.assigned_by:
+                if rc.assigned_by == "default_id":
+                    rc.assigned_by = rc.default_user_id
+                for todo in todolist[::-1]:
+                    if todo.get('assigned_by') != rc.assigned_by:
+                        print(todo.get('assigned_by'))
+                        todolist.remove(todo)
+                    elif rc.assigned_to == rc.assigned_by:
+                        todolist.remove(todo)
             print("If the indices are far from being in numerical order, please reorder them by running regolith helper u_todo -r")
             print("Please choose from one of the following to update:")
-            print("(index) action (days to due date|importance|expected duration (mins))")
-            print("-" * 70)
-            for todo in todolist:
-                print_task(todo, status=['started'])
-            if rc.all:
-                print("finished/cancelled:")
-                for todo in todolist:
-                    print_task(todo, status=['finished', 'cancelled'])
-            print("-" * 70)
-
+            print("(index) action (days to due date|importance|expected duration (mins)|assigned by)")
+            print("-" * 81)
+            print_task(todolist, stati=rc.stati)
+            print("-" * 81)
         else:
             match_todo = [i for i in todolist if i.get("running_index") == rc.index]
             if len(match_todo) == 0:
@@ -201,10 +208,10 @@ class TodoUpdaterHelper(DbHelperBase):
                     else:
                         raise ValueError(f"Importance should be chosen from{ALLOWED_IMPORTANCE}.")
                 if rc.status:
-                    if rc.status in ALLOWED_STATUS:
+                    if rc.status in ALLOWED_STATI:
                         todo["status"] = rc.status
                     else:
-                        raise ValueError(f"Status should be chosen from{ALLOWED_STATUS}.")
+                        raise ValueError(f"Status should be chosen from {ALLOWED_STATI}.")
                 if rc.notes:
                     todo["notes"] = rc.notes
                 if rc.begin_date:

--- a/regolith/schemas.py
+++ b/regolith/schemas.py
@@ -1196,6 +1196,7 @@ EXEMPLARS = {
              "duration": 60.0,
              "importance": 2,
              "status": "started",
+             "assigned_by": "scopatz",
              "running_index": 1
              },
             {"description": "prepare the presentation",
@@ -1205,6 +1206,7 @@ EXEMPLARS = {
              "importance": 0,
              "status": "started",
              "notes": ["about 10 minutes", "don't forget to upload to the website"],
+             "assigned_by": "sbillinge",
              "running_index": 2
              }
         ],
@@ -3179,6 +3181,10 @@ SCHEMAS = {
                     "running_index": {"description": "Index of a certain task used to update that task in the enumerated todo list.",
                                "required": False,
                                "type": "integer"},
+                    "assigned_by": {
+                        "description": "ID of the member that assigns the task",
+                        "required": False,
+                        "type": "string"},
 
                 }
             }

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from datetime import datetime, date, timedelta
 from dateutil import parser as date_parser
 from dateutil.relativedelta import relativedelta
+import math
 
 from regolith.chained_db import ChainDB
 from regolith.dates import month_to_int, date_to_float, get_dates, last_day, is_current
@@ -1589,33 +1590,37 @@ def validate_meeting(meeting, date):
         raise ValueError(f'{meeting.get("_id")} does not have a presentation title')
 
 
-def print_task(task, status, index = True):
+def print_task(task_list, stati, index = True):
     """
     Print tasks in a nice format.
 
     Parameters
     ----------
-    task: dict
-        The task object that will be printed
+    task_list: list
+        A list of tasks that will be printed.
     status:
         Filter status of the task
 
 
     """
-    if index:
-        if task.get('status') in status:
-            print(
-                f"({task.get('running_index')}) {task.get('description').strip()} ({task.get('days_to_due')}|{task.get('importance')}|{str(task.get('duration'))})")
-            if task.get('notes'):
-                for note in task.get('notes'):
-                    print(f"     - {note}")
-    else:
-        if task.get('status') in status:
-            print(
-                f"{task.get('description').strip()} ({task.get('days_to_due')}|{task.get('importance')}|{str(task.get('duration'))})")
-            if task.get('notes'):
-                for note in task.get('notes'):
-                    print(f"     - {note}")
+    for status in stati:
+        print(f"{status}:")
+        if index:
+            for task in task_list:
+                if task.get('status') == status:
+                    print(
+                        f"({task.get('running_index')}) {task.get('description').strip()} ({task.get('days_to_due')}|{task.get('importance')}|{str(task.get('duration'))}|{task.get('assigned_by')})")
+                    if task.get('notes'):
+                        for note in task.get('notes'):
+                            print(f"     - {note}")
+        else:
+            for task in task_list:
+                if task.get('status') == status:
+                    print(
+                        f"{task.get('description').strip()} ({task.get('days_to_due')}|{task.get('importance')}|{str(task.get('duration'))}|{task.get('assigned_by')})")
+                    if task.get('notes'):
+                        for note in task.get('notes'):
+                            print(f"     - {note}")
 
 
 

--- a/tests/outputs/a_todo/people.yaml
+++ b/tests/outputs/a_todo/people.yaml
@@ -272,6 +272,7 @@ sbillinge:
       duration: 60.0
       importance: 2
       status: started
+      assigned_by: scopatz
       running_index: 1
     - description: prepare the presentation
       due_date: '2020-07-29'
@@ -282,6 +283,7 @@ sbillinge:
       notes:
         - about 10 minutes
         - don't forget to upload to the website
+      assigned_by: sbillinge
       running_index: 2
     - description: test a_todo
       due_date: 2020-07-16
@@ -289,6 +291,7 @@ sbillinge:
       duration: 50.0
       importance: 2
       status: started
+      assigned_by: sbillinge
       notes:
         - test notes 1
         - test notes 2

--- a/tests/outputs/f_todo/people.yaml
+++ b/tests/outputs/f_todo/people.yaml
@@ -272,6 +272,7 @@ sbillinge:
       duration: 60.0
       importance: 2
       status: started
+      assigned_by: scopatz
       running_index: 1
     - description: prepare the presentation
       due_date: '2020-07-29'
@@ -282,6 +283,7 @@ sbillinge:
       notes:
         - about 10 minutes
         - don't forget to upload to the website
+      assigned_by: sbillinge
       running_index: 2
     - description: test a_todo
       due_date: 2020-07-16
@@ -289,6 +291,7 @@ sbillinge:
       duration: 50.0
       importance: 2
       status: finished
+      assigned_by: sbillinge
       notes:
         - test notes 1
         - test notes 2

--- a/tests/outputs/u_todo/people.yaml
+++ b/tests/outputs/u_todo/people.yaml
@@ -272,6 +272,7 @@ sbillinge:
       duration: 60.0
       importance: 2
       status: started
+      assigned_by: scopatz
       running_index: 1
     - description: prepare the presentation
       due_date: '2020-07-29'
@@ -282,6 +283,7 @@ sbillinge:
       notes:
         - about 10 minutes
         - don't forget to upload to the website
+      assigned_by: sbillinge
       running_index: 2
     - description: update the description
       due_date: 2020-07-06
@@ -289,6 +291,7 @@ sbillinge:
       duration: 35.0
       importance: 2
       status: finished
+      assigned_by: sbillinge
       notes:
         - some new notes
         - notes2

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -168,25 +168,24 @@ helper_map = [
      "new contacts --name (-n) and --institution (-o) are required:\n"
      "1. Maria as a new contact\n"
      ),
-    (["helper", "l_todo", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13"],
+    (["helper", "l_todo", "--assigned_to", "sbillinge", "--short_tasks", "65", "--certain_date", "2020-07-13", "--assigned_by", "scopatz"],
      "If the indices are far from being in numerical order, please reorder them by running regolith helper u_todo -r\n"
-     "(index) action (days to due date|importance|expected duration (mins))\n"
-     "----------------------------------------------------------------------\n"
+     "(index) action (days to due date|importance|expected duration (mins)|assigned by)\n"
+     "---------------------------------------------------------------------------------\n"
      "tasks from people collection:\n"
      "------------------------------\n"
-     "(1) read paper (6|2|60.0)\n"
-     "(2) prepare the presentation (16|1|30.0)\n"
-     "     - about 10 minutes\n"
-     "     - don't forget to upload to the website\n"
+     "started:\n"
+     "(1) read paper (6|2|60.0|scopatz)\n"
      "------------------------------------------\n"
      "tasks from projecta and other collections:\n"
      "------------------------------------------\n"
-     "----------------------------------------------------------------------\n"
+     "started:\n"
+     "---------------------------------------------------------------------------------\n"
      ),
     (["helper", "l_todo", "--assigned_to", "wrong_id"],
      "The id you entered can't be found in people.yml.\n"
      ),
-    (["helper", "a_todo", "test a_todo", "6", "50", "--assigned_to", "sbillinge", "--begin_date", "2020-07-06", "--importance", "2", "--notes", "test notes 1", "test notes 2", "--certain_date", "2020-07-10"],
+    (["helper", "a_todo", "test a_todo", "6", "50", "--assigned_to", "sbillinge", "--assigned_by", "sbillinge", "--begin_date", "2020-07-06", "--importance", "2", "--notes", "test notes 1", "test notes 2", "--certain_date", "2020-07-10"],
      "The task \"test a_todo\" for sbillinge has been added in people collection.\n"
      ),
     (["helper", "f_todo", "--index", "3", "--assigned_to", "sbillinge", "--end_date", "2020-07-20", "--certain_date", "2020-07-13"],
@@ -195,31 +194,33 @@ helper_map = [
     (["helper", "f_todo", "--assigned_to", "sbillinge", "--certain_date", "2020-07-13"],
      "If the indices are far from being in numerical order, please reorder them by running regolith helper u_todo -r\n"
      "Please choose from one of the following to update:\n"
-     "(index) action (days to due date|importance|expected duration (mins))\n"
-     "----------------------------------------------------------------------\n"
-     "(1) read paper (6|2|60.0)\n"
-     "(2) prepare the presentation (16|1|30.0)\n"
+     "(index) action (days to due date|importance|expected duration (mins)|assigned by)\n"
+     "---------------------------------------------------------------------------------\n"
+     "started:\n"
+     "(1) read paper (6|2|60.0|scopatz)\n"
+     "(2) prepare the presentation (16|1|30.0|sbillinge)\n"
      "     - about 10 minutes\n"
      "     - don't forget to upload to the website\n"
-     "----------------------------------------------------------------------\n"
+     "---------------------------------------------------------------------------------\n"
      ),
     (["helper", "u_todo", "--index", "3", "--assigned_to", "sbillinge", "--description", "update the description", "--due_date", "2020-07-06", "--estimated_duration", "35", "--importance", "2", "--status", "finished","--notes", "some new notes", "notes2", "--begin_date", "2020-06-06", "--end_date", "2020-07-07", "--certain_date", "2020-07-13"],
      "The task \"(3) test a_todo\" in test for sbillinge has been updated.\n"
      ),
-    (["helper", "u_todo", "--assigned_to", "sbillinge", "--all", "--certain_date", "2020-07-13"],
+    (["helper", "u_todo", "--assigned_to", "sbillinge", "--stati", "started", "finished", "--certain_date", "2020-07-13"],
      "If the indices are far from being in numerical order, please reorder them by running regolith helper u_todo -r\n"
      "Please choose from one of the following to update:\n"
-     "(index) action (days to due date|importance|expected duration (mins))\n"
-     "----------------------------------------------------------------------\n"
-     "(1) read paper (6|2|60.0)\n"
-     "(2) prepare the presentation (16|1|30.0)\n"
+     "(index) action (days to due date|importance|expected duration (mins)|assigned by)\n"
+     "---------------------------------------------------------------------------------\n"
+     "started:\n"
+     "(1) read paper (6|2|60.0|scopatz)\n"
+     "(2) prepare the presentation (16|1|30.0|sbillinge)\n"
      "     - about 10 minutes\n"
      "     - don't forget to upload to the website\n"
-     "finished/cancelled:\n"
-     "(3) update the description (-7|2|35.0)\n"
+     "finished:\n"
+     "(3) update the description (-7|2|35.0|sbillinge)\n"
      "     - some new notes\n"
      "     - notes2\n"
-     "----------------------------------------------------------------------\n"
+     "---------------------------------------------------------------------------------\n"
      ),
     (["helper", "f_prum", "20sb_firstprojectum", "--end_date", "2020-07-01"],
      "20sb_firstprojectum status has been updated to finished\n"


### PR DESCRIPTION
Hi @sbillinge 
This PR mainly updates:
1. sorting of finished tasks
2. add -b,  --assigned_by:
    if enter -b, then helper lists tasks assigned by the id in user.json, if -b jwzang, then lists tasks assigned by jwzang.
3. add -s,  --stati:
    if no -s, then helper lists started tasks, if -s finished, then lists finished tasks, if -s finished started, then lists all tasks.
4. make the shortcuts consistent

I will soon make a separate PR for kv filter after this PR is merged, in case too many codes are changed.