### PR TITLE
Remote mongo updates

### DIFF
--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -187,12 +187,23 @@ class MongoClient:
         elif ON_PYMONGO_V2:
             return self.client.alive()
         elif ON_PYMONGO_V3:
-            cmd = ["mongostat", "--host", "localhost", "-n", "1"]
-            try:
-                subprocess.check_call(cmd)
-                alive = True
-            except subprocess.CalledProcessError:
-                alive = False
+            alive = False
+            if self.rc.local is False:
+                from pymongo.errors import ConnectionFailure
+                try:
+                    # The ismaster command is cheap and does not require auth.
+                    self.client.admin.command('ismaster')
+                    alive = True
+                except ConnectionFailure:
+                    print("Server not available")
+                    alive = False
+            else:
+                cmd = ["mongostat", "--host", "localhost", "-n", "1"]
+                try:
+                    subprocess.check_call(cmd)
+                    alive = True
+                except subprocess.CalledProcessError:
+                    alive = False
             return alive
         else:
             return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def make_mongodb():
                         "url": 'localhost',
                         "path": repo,
                         "public": True,
-                        "local": False,
+                        "local": True,
                     }
                 ],
                 "stores": [


### PR DESCRIPTION
Updated the mongo functionality such that it should work without requiring that compass is installed on windows. Next step is to add the missing find_one method to the mongo_client. 

FS and Mongo tests are passing locally for all builders other than html on my windows pc.