### PR TITLE
build bghtml

### DIFF
--- a/regolith/builder.py
+++ b/regolith/builder.py
@@ -2,6 +2,7 @@
 
 from regolith.builders.cvbuilder import CVBuilder
 from regolith.builders.htmlbuilder import HtmlBuilder
+from regolith.builders.bghtmlbuilder import BGHtmlBuilder
 from regolith.builders.postdocadbuilder import PostdocadBuilder
 from regolith.builders.preslistbuilder import PresListBuilder
 from regolith.builders.publistbuilder import PubListBuilder
@@ -21,6 +22,7 @@ from regolith.builders.internalhtmlbuilder import InternalHtmlBuilder
 BUILDERS = {
     "annual-activity": ActivitylogBuilder,
     "beamplan": BeamPlanBuilder,
+    "bghtml": BGHtmlBuilder,
     "current-pending": CPBuilder,
     "cv": CVBuilder,
     "figure": FigureBuilder,

--- a/regolith/builders/bghtmlbuilder.py
+++ b/regolith/builders/bghtmlbuilder.py
@@ -15,24 +15,24 @@ from regolith.tools import (
 )
 
 
-class HtmlBuilder(BuilderBase):
+class BGHtmlBuilder(BuilderBase):
     """Build HTML files for website"""
 
-    btype = "html"
+    btype = "bghtml"
 
     def __init__(self, rc):
         super().__init__(rc)
         # TODO: get this from the RC
         self.cmds = [
             "root_index",
-            "people",
-            "projects",
-            "blog",
-            "jobs",
-            "abstracts",
-            "nojekyll",
-            "cname",
-            "finish",
+            # "people",
+            # "projects",
+            # "blog",
+            # "jobs",
+            # "abstracts",
+            # "nojekyll",
+            # "cname",
+            # "finish",
         ]
 
     def construct_global_ctx(self):
@@ -49,6 +49,9 @@ class HtmlBuilder(BuilderBase):
         gtx["abstracts"] = list(
             all_docs_from_collection(rc.client, "abstracts")
         )
+        gtx["projecta"] = list(
+            all_docs_from_collection(rc.client, "projecta")
+        )
         gtx["group"] = document_by_value(
             all_docs_from_collection(rc.client, "groups"), "name", rc.groupname
         )
@@ -57,29 +60,40 @@ class HtmlBuilder(BuilderBase):
             all_docs_from_collection(rc.client, "institutions"), key=_id_key
         )
 
-    def finish(self):
-        """Move files over to their destination and remove them from the
-        source"""
-        # static
-        stsrc = os.path.join(
-            getattr(self.rc, "static_source", "templates"), "static"
-        )
-        stdst = os.path.join(self.bldir, "static")
-        if os.path.isdir(stdst):
-            shutil.rmtree(stdst)
-        if os.path.isdir(stsrc):
-            shutil.copytree(stsrc, stdst)
-
     def root_index(self):
         """Render root index"""
-        self.render("root_index.html", "index.html", title="Home")
-        make_bibtex_file(list(all_docs_from_collection(self.rc.client,
-                                                       "citations")),
-                         pid='group',
-                         person_dir=self.bldir,
-                         )
+        headerinfo = {"title": "BillingeGroup"}
+        text = "The PDF in the cloud platform provides services for chemists, materials scientists, geologists and physicists interested in the structure of matter."
+        image = "1i5OZD45-9K2yH28FkL3dK8JeZaUbTi9D"
+        pruminfo = {"text": text, "image": "https://drive.google.com/uc?export=view&id={}".format(image)}
+        # filterid = {'_id': key}
+        # found_projectum = rc.client.find_one(rc.database, rc.coll, filterid)
+        # pruminfo = {"text": found_projectum['public_story'].get('text'),
+        #             "image":"https://drive.google.com/uc?export=view&id="+found_projectum['public_story'].get('image')}
+        self.render("bghtmltemplate.html", "bgindex.html", headerinfo=headerinfo, pruminfo=pruminfo)
+
+        # make_bibtex_file(list(all_docs_from_collection(self.rc.client,
+        #                                                "citations")),
+        #                  pid='group',
+        #                  person_dir=self.bldir,
+        #                  )
 
 
+    # def finish(self):
+    #     """Move files over to their destination and remove them from the
+    #     source"""
+    #     # static
+    #     stsrc = os.path.join(
+    #         getattr(self.rc, "static_source", "templates"), "static"
+    #     )
+    #     stdst = os.path.join(self.bldir, "static")
+    #     if os.path.isdir(stdst):
+    #         shutil.rmtree(stdst)
+    #     if os.path.isdir(stsrc):
+    #         shutil.copytree(stsrc, stdst)
+
+
+'''
     def people(self):
         """Render people, former members, and each person"""
         rc = self.rc
@@ -207,3 +221,4 @@ class HtmlBuilder(BuilderBase):
             os.path.join(self.bldir, "CNAME"), "w", encoding="utf-8"
         ) as f:
             f.write(rc.cname)
+'''

--- a/regolith/templates/bghtmltemplate.html
+++ b/regolith/templates/bghtmltemplate.html
@@ -9,7 +9,7 @@
 <!-- Navbar (sit on top) -->
 <div class="w3-top">
   <div class="w3-bar w3-white w3-wide w3-padding w3-card">
-    <a href="#home" class="w3-bar-item w3-button"><b>BG</b> BillingeGroup</a>
+    <a href="#home" class="w3-bar-item w3-button"><b>BG</b> {{ headerinfo.get("title") }}</a>
     <!-- Float links to the right. Hide them on small screens -->
     <div class="w3-right w3-hide-small">
       <a href="#news" class="w3-bar-item w3-button">News</a>
@@ -41,7 +41,9 @@
     <div class="w3-col l3 m6 w3-margin-bottom">
       <div class="w3-display-container">
         <div class="w3-display-topleft w3-black w3-padding">PDFitc</div>
-        <img src="/w3images/house5.jpg" alt="House" style="width:100%">
+        <p>{{ pruminfo.get('text') }}</p>
+        <img src="{{ pruminfo.get('image') }}" style="width:100%">
+{#        <img src="https://drive.google.com/uc?export=view&id=1i5OZD45-9K2yH28FkL3dK8JeZaUbTi9D" style="width:100%">#}
       </div>
     </div>
     <div class="w3-col l3 m6 w3-margin-bottom">


### PR DESCRIPTION
Hi @sbillinge , I succeeded in passing the Google drive images to the html, and it can appear properly now.

I did some testing, lionmail google drive doesn't work, so we need to use a general gmail's google drive to save figures.

What I don't quite know is how to get values from yaml to the `bghtmlbuilder.py` level. So currently in this PR, I just write the texts and image id in the function to show you it works as you expected.

You can try running `regolith build bghtml` and click at the `html` file and see a figure (the PDFitc home page scrernshot) showing up.