### PR TITLE
Chattyclient

### DIFF
--- a/docs/commands/fs-to-mongo.rst
+++ b/docs/commands/fs-to-mongo.rst
@@ -15,7 +15,7 @@ https://www.mongodb.com/try/download/community
 .. code-block:: JSON
 {"groupname": "Example Group Name",
  "databases": [
-    "name": "<databasename>"
+    "name": "<databasename>",
     "dst_url": "mongodb+srv://<username>:<password>@<clustername>.uc5ro.mongodb.net/<databasename>?w=majority",
     "url": "..",
     "public": false,

--- a/regolith/builders/activitylogbuilder.py
+++ b/regolith/builders/activitylogbuilder.py
@@ -118,7 +118,6 @@ class ActivitylogBuilder(LatexBuilderBase):
         pi = fuzzy_retrieval(
             self.gtx["people"], ["aka", "name", "_id"], build_target
         )
-        #        pi['initials'] = "SJLB"
 
         grants = merge_collections_superior(self.gtx["proposals"], self.gtx["grants"],
                                    "proposal_id")

--- a/regolith/builders/appraisalbuilder.py
+++ b/regolith/builders/appraisalbuilder.py
@@ -1,7 +1,5 @@
 """Builder for CVs."""
 import datetime as dt
-import os
-import sys
 from copy import copy, deepcopy
 
 from regolith.builders.basebuilder import LatexBuilderBase
@@ -118,7 +116,6 @@ class AppraisalBuilder(LatexBuilderBase):
         pi = fuzzy_retrieval(
             self.gtx["people"], ["aka", "name", "_id"], build_target
         )
-        #        pi['initials'] = "SJLB"
 
         grants = merge_collections_superior(self.gtx["proposals"], self.gtx["grants"],
                                    "proposal_id")
@@ -143,14 +140,12 @@ class AppraisalBuilder(LatexBuilderBase):
         current_grants, _, _ = filter_grants(
             current_grants, {pi["name"]}, pi=False, multi_pi=True
         )
-        #        print("current: {}".format(current_grants))
 
         pending_grants = [
             g
             for g in self.gtx["proposals"]
             if g["status"] == "pending"
         ]
-        #        print("pending: {}".format(pending_grants))
         for g in pending_grants:
             for person in g["team"]:
                 rperson = fuzzy_retrieval(

--- a/regolith/builders/basebuilder.py
+++ b/regolith/builders/basebuilder.py
@@ -124,10 +124,6 @@ class LatexBuilderBase(BuilderBase):
     def pdf(self, base):
         """Compiles latex files to PDF"""
         if self.rc.pdf:
-            #TODO determine what these commands are and why my machine won't run them
-            #self.run(["latex"] + LATEX_OPTS + [base + ".tex"])
-            #self.run(["bibtex"] + [base + ".aux"])
-            #self.run(["latex"] + LATEX_OPTS + [base + ".tex"])
             if os.name == 'nt':
                 self.run(["pdflatex"] + LATEX_OPTS + [base + ".tex"])
             else:

--- a/regolith/builders/coabuilder.py
+++ b/regolith/builders/coabuilder.py
@@ -66,7 +66,6 @@ def get_advisees_name_inst(coll, advisor, rc):
         for edu in edus:
             if 'advisor' in edu and edu['advisor'] in advisor_names:
 
-#                if edu['status'] == 'postdoc'
                 person_name = HumanName(person.get("name"))
                 inst_name = edu.get("institution")
                 inst = fuzzy_retrieval(

--- a/regolith/builders/cpbuilder.py
+++ b/regolith/builders/cpbuilder.py
@@ -1,6 +1,5 @@
 """Builder for Current and Pending Reports."""
 import datetime as dt
-import time
 from copy import copy
 from nameparser import HumanName
 

--- a/regolith/builders/cvbuilder.py
+++ b/regolith/builders/cvbuilder.py
@@ -9,7 +9,6 @@ from regolith.tools import (
     filter_grants,
     awards_grants_honors,
     make_bibtex_file,
-    fuzzy_retrieval,
     dereference_institution,
 )
 

--- a/regolith/builders/htmlbuilder.py
+++ b/regolith/builders/htmlbuilder.py
@@ -79,7 +79,6 @@ class HtmlBuilder(BuilderBase):
                          person_dir=self.bldir,
                          )
 
-
     def people(self):
         """Render people, former members, and each person"""
         rc = self.rc
@@ -88,7 +87,6 @@ class HtmlBuilder(BuilderBase):
         os.makedirs(peeps_dir, exist_ok=True)
         os.makedirs(former_peeps_dir, exist_ok=True)
         peeps = self.gtx["people"]
-        #peeps = all_docs_from_collection(rc.client), "people")
         for p in peeps:
             names = frozenset(p.get("aka", []) + [p["name"]])
             pubs = filter_publications(

--- a/regolith/builders/manuscriptreviewbuilder.py
+++ b/regolith/builders/manuscriptreviewbuilder.py
@@ -1,15 +1,9 @@
 """Builder for Current and Pending Reports."""
-import datetime
-import time
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.dates import month_to_int
 from regolith.fsclient import _id_key
-from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    filter_grants,
-    fuzzy_retrieval,
 )
 
 

--- a/regolith/builders/postdocadbuilder.py
+++ b/regolith/builders/postdocadbuilder.py
@@ -1,15 +1,9 @@
 """Builder for Current and Pending Reports."""
-import datetime
-import time
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.dates import month_to_int
 from regolith.fsclient import _id_key
-from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    filter_grants,
-    fuzzy_retrieval,
 )
 
 

--- a/regolith/builders/preslistbuilder.py
+++ b/regolith/builders/preslistbuilder.py
@@ -18,8 +18,7 @@ the presentations.yml.
 
 The presentations are output in a ./_build directory."""
 
-from copy import deepcopy, copy
-import datetime, sys
+from copy import deepcopy
 
 from regolith.builders.basebuilder import LatexBuilderBase
 from regolith.fsclient import _id_key
@@ -29,10 +28,10 @@ from regolith.tools import (
     fuzzy_retrieval,
     get_person_contact,
     number_suffix,
-    group_member_ids, latex_safe
+    group_member_ids
 )
 from regolith.stylers import sentencecase, month_fullnames
-from regolith.dates import month_to_int, get_dates
+from regolith.dates import get_dates
 
 class PresListBuilder(LatexBuilderBase):
     """Build list of talks and posters (presentations) from database entries"""
@@ -86,8 +85,6 @@ class PresListBuilder(LatexBuilderBase):
                         continue
                 presentations = deepcopy(self.gtx["presentations"])
                 types = ["all"]
-                #                types = ['invited']
-                #statuses = ["all"]
                 statuses = ['accepted']
 
                 firstclean = list()
@@ -143,7 +140,6 @@ class PresListBuilder(LatexBuilderBase):
                     pres["authors"] = authorlist
                     presdates = get_dates(pres)
                     pres["date"] = presdates.get("begin_date")
-#                    all_date_objects = ['day', 'month', 'year']
                     beg_end = ['begin', 'end']
                     for be in beg_end:
                         if presdates.get(f"{be}_date"):
@@ -177,11 +173,6 @@ class PresListBuilder(LatexBuilderBase):
                         except:
                              print("no institute {} in institutions collection".format(inst))
                              pres["institution"] = {"_id": inst, "department": {"name": ""}}
-#                            sys.exit(
-#                                "ERROR: institution {} not found in "
-#                                "institutions.yml.  Please add and "
-#                                "rerun".format(pres["institution"])
-#                            )
                         if "department" in pres:
                             try:
                                 pres["department"] = pres["institution"][

--- a/regolith/builders/proposalreviewbuilder.py
+++ b/regolith/builders/proposalreviewbuilder.py
@@ -1,15 +1,10 @@
 """Builder for Proposal Reivews."""
-import datetime
-import time
 from nameparser import HumanName
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.dates import month_to_int
 from regolith.fsclient import _id_key
-from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    filter_grants,
     fuzzy_retrieval,
 )
 

--- a/regolith/builders/publistbuilder.py
+++ b/regolith/builders/publistbuilder.py
@@ -1,6 +1,5 @@
 """Builder for publication lists."""
 import os
-import datetime as dt
 
 try:
     from bibtexparser.bwriter import BibTexWriter
@@ -11,11 +10,9 @@ except ImportError:
     HAVE_BIBTEX_PARSER = False
 
 from regolith.tools import all_docs_from_collection, filter_publications
-from regolith.sorters import doc_date_key, ene_date_key, position_key
-from regolith.builders.basebuilder import LatexBuilderBase, latex_safe
-from datetime import date
+from regolith.sorters import ene_date_key, position_key
+from regolith.builders.basebuilder import LatexBuilderBase
 from dateutil import parser as date_parser
-from regolith.dates import is_between
 
 LATEX_OPTS = ["-halt-on-error", "-file-line-error"]
 

--- a/regolith/builders/readinglistsbuilder.py
+++ b/regolith/builders/readinglistsbuilder.py
@@ -47,10 +47,6 @@ class ReadingListsBuilder(LatexBuilderBase):
             for paper in rlist['papers']:
                 doi = paper.get('doi')
                 url = paper.get('url')
-#                if doi == 'tbd':
-#                    pass
-#                    print(
-#                        "  doi needed for paper: {}".format(paper.get('text')))
                 if doi and doi != 'tbd':
                     ref, ref_date = get_formatted_crossref_reference(doi)
                     paper.update({'reference': ref, 'ref_date': ref_date, 'n': n, 'label': 'DOI'})
@@ -68,11 +64,3 @@ class ReadingListsBuilder(LatexBuilderBase):
                 outfile_bib + ".txt",
                 rlist=rlist,
             )
-
-
-"""            self.render(
-                "rlist_word.docx",
-                outfile_bib + ".docx",
-                rlist=rlist,
-            )
-"""

--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -25,11 +25,6 @@ class ClientManager:
                 database["backend"] = rc.backend
         for database in databases:
             if "backend" not in database:
-#TODO re-insert this message or remove the many redundant client.open calls in a way that doesn't break commands
-
-                # print("INFO: Backend client set to default of filesystem.\n "
-                #       "      Specify backend in regolithrc.json (databases: [{key=\'backend\'}]) if you want different "
-                #       "behavior")
                 database["backend"] = 'filesystem'
             backend_object_type = CLIENTS[database["backend"]]
             # Checks to see if the clients tuple contains a client with the database's backend

--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -25,9 +25,11 @@ class ClientManager:
                 database["backend"] = rc.backend
         for database in databases:
             if "backend" not in database:
-                print("INFO: Backend client set to default of filesystem.\n "
-                      "      Specify backend in regolithrc.json (databases: [{key=\'backend\'}]) if you want different "
-                      "behavior")
+#TODO re-insert this message or remove the many redundant client.open calls in a way that doesn't break commands
+
+                # print("INFO: Backend client set to default of filesystem.\n "
+                #       "      Specify backend in regolithrc.json (databases: [{key=\'backend\'}]) if you want different "
+                #       "behavior")
                 database["backend"] = 'filesystem'
             backend_object_type = CLIENTS[database["backend"]]
             # Checks to see if the clients tuple contains a client with the database's backend

--- a/regolith/dates.py
+++ b/regolith/dates.py
@@ -1,9 +1,7 @@
 """Date based tools"""
-import calendar
 import datetime
 from dateutil import parser as date_parser
 
-import datetime as dt
 import calendar
 
 MONTHS = {

--- a/regolith/deploy.py
+++ b/regolith/deploy.py
@@ -1,9 +1,7 @@
 """Helps deploy what we have built."""
 import os
 import time
-import shutil
 from xonsh.lib import subprocess
-from glob import iglob
 from warnings import warn
 from distutils.dir_util import copy_tree
 

--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -120,9 +120,10 @@ class FileSystemClient:
         return not self.closed
 
     def open(self):
-        self.dbs = defaultdict(lambda: defaultdict(dict))
-        self.chained_db = {}
-        self.closed = False
+        if self.closed:
+            self.dbs = defaultdict(lambda: defaultdict(dict))
+            self.chained_db = {}
+            self.closed = False
 
     def load_json(self, db, dbpath):
         """Loads the JSON part of a database."""

--- a/regolith/helpers/a_expensehelper.py
+++ b/regolith/helpers/a_expensehelper.py
@@ -3,8 +3,6 @@ Helper to add expenses.
 """
 import datetime as dt
 import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key
@@ -211,8 +209,6 @@ class ExpenseAdderHelper(DbHelperBase):
         pdoc.update({
             'status': rc.status
         })
-
-
 
         rc.client.insert_one(rc.database, rc.coll, pdoc)
 

--- a/regolith/helpers/a_grppub_readlisthelper.py
+++ b/regolith/helpers/a_grppub_readlisthelper.py
@@ -2,7 +2,7 @@
 import datetime as dt
 import dateutil.parser as date_parser
 
-from regolith.helpers.basehelper import SoutHelperBase, DbHelperBase
+from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
@@ -96,7 +96,6 @@ class GrpPubReadListAdderHelper(DbHelperBase):
             raise KeyError("ERROR: a title is required for a new list.  Please rerun specifying -t")
 
         for cite in self.gtx["citations"]:
-            #print(f"{cite.get('_id')}: {cite.get('tags', '')}")  # save for filtering for untagged entries
             for tag in rc.tags:
                 if tag in cite.get("tags", ""):
                     dupe_doi = [paper for paper in pdoc.get("papers", []) if cite.get("doi") == paper.get("doi")]

--- a/regolith/helpers/a_manurevhelper.py
+++ b/regolith/helpers/a_manurevhelper.py
@@ -1,5 +1,4 @@
 """Builder for manuscript reviews."""
-import datetime as dt
 import sys
 from dateutil import parser as dateparser
 

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -1,9 +1,6 @@
 """Helper for adding a presentation to the presentation collection.
 """
-import datetime as dt
 import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key

--- a/regolith/helpers/a_projectumhelper.py
+++ b/regolith/helpers/a_projectumhelper.py
@@ -6,7 +6,6 @@
 import datetime as dt
 import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key

--- a/regolith/helpers/a_proposalhelper.py
+++ b/regolith/helpers/a_proposalhelper.py
@@ -4,7 +4,6 @@ import datetime as dt
 import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
 from math import floor
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key

--- a/regolith/helpers/a_proprevhelper.py
+++ b/regolith/helpers/a_proprevhelper.py
@@ -1,19 +1,14 @@
 """Builder for Current and Pending Reports."""
 import datetime as dt
 import sys
-import time
-from argparse import RawTextHelpFormatter
 
 import nameparser
 
-from regolith.helpers.basehelper import SoutHelperBase, DbHelperBase
-from regolith.dates import month_to_int, month_to_str_int
+from regolith.helpers.basehelper import DbHelperBase
+from regolith.dates import month_to_str_int
 from regolith.fsclient import _id_key
-from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    filter_grants,
-    fuzzy_retrieval,
 )
 
 ALLOWED_TYPES = ["nsf", "doe", "other"]

--- a/regolith/helpers/a_todohelper.py
+++ b/regolith/helpers/a_todohelper.py
@@ -4,14 +4,12 @@
 import datetime as dt
 import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    document_by_value,
 )
 
 TARGET_COLL = "todos"

--- a/regolith/helpers/f_todohelper.py
+++ b/regolith/helpers/f_todohelper.py
@@ -3,8 +3,6 @@
 
 import datetime as dt
 import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 import math
 
 from regolith.helpers.basehelper import DbHelperBase

--- a/regolith/helpers/hellohelper.py
+++ b/regolith/helpers/hellohelper.py
@@ -1,22 +1,17 @@
 """Builder for Current and Pending Reports."""
-import datetime
-import time
-from argparse import RawTextHelpFormatter
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.dates import month_to_int
 from regolith.fsclient import _id_key
-from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    filter_grants,
-    fuzzy_retrieval,
 )
+
 
 def subparser(subpi):
     subpi.add_argument("--person", help="pi first name space last name in quotes",
                         default=None)
     return subpi
+
 
 class HelloHelper(SoutHelperBase):
     """Build a helper"""
@@ -39,7 +34,6 @@ class HelloHelper(SoutHelperBase):
     def sout(self):
         person = self.rc.person
         return print(f"hello {person}")
-
 
     def latex(self):
         """Render latex template"""

--- a/regolith/helpers/l_membershelper.py
+++ b/regolith/helpers/l_membershelper.py
@@ -1,18 +1,13 @@
 """Helper for listing group members.
 
 """
-import datetime as dt
-import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
-from regolith.dates import get_due_date, is_current
+from regolith.dates import is_current
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
 from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
-    get_pi_id, search_collection,
     key_value_pair_filter, collection_str,
     get_pi_id,
     fuzzy_retrieval,

--- a/regolith/helpers/l_milestoneshelper.py
+++ b/regolith/helpers/l_milestoneshelper.py
@@ -3,10 +3,6 @@
    Projecta are small bite-sized project quanta that typically will result in
    one manuscript.
 """
-import datetime as dt
-import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
 from regolith.dates import get_due_date
 from regolith.helpers.basehelper import SoutHelperBase
@@ -14,7 +10,6 @@ from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    search_collection,
     key_value_pair_filter,
     collection_str
 )

--- a/regolith/helpers/l_progressreporthelper.py
+++ b/regolith/helpers/l_progressreporthelper.py
@@ -3,20 +3,13 @@
    Projecta are small bite-sized project quanta that typically will result in
    one manuscript.
 """
-import datetime as dt
-import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
-from regolith.dates import get_due_date
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    search_collection,
     key_value_pair_filter,
-    collection_str
 )
 
 TARGET_COLL = "projecta"

--- a/regolith/helpers/l_projectahelper.py
+++ b/regolith/helpers/l_projectahelper.py
@@ -5,16 +5,12 @@
 """
 import datetime as dt
 import dateutil.parser as date_parser
-from dateutil.relativedelta import relativedelta
-import sys
 
-from regolith.dates import get_due_date, get_dates, is_current, has_finished
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    search_collection,
     key_value_pair_filter,
     collection_str
 )

--- a/regolith/helpers/l_todohelper.py
+++ b/regolith/helpers/l_todohelper.py
@@ -4,10 +4,8 @@
 import datetime as dt
 import dateutil.parser as date_parser
 import math
-import sys
-from dateutil.relativedelta import *
 
-from regolith.dates import get_due_date, get_dates
+from regolith.dates import get_due_date
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
 from regolith.schemas import (

--- a/regolith/helpers/makeappointmentshelper.py
+++ b/regolith/helpers/makeappointmentshelper.py
@@ -6,13 +6,11 @@
    - Suggests appointments to make for these members
    - Suggests new appointments
 """
-from copy import copy
 
 import numpy
 from dateutil.relativedelta import relativedelta
 from dateutil import parser as date_parser
 from datetime import timedelta, date
-import sys
 
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
@@ -24,10 +22,8 @@ from regolith.tools import (
     grant_burn, group_member_employment_start_end,
 )
 from regolith.dates import (
-    is_current,
     get_dates,
 )
-import matplotlib
 import matplotlib.pyplot as plt
 
 TARGET_COLL = "people"
@@ -57,7 +53,6 @@ _future_grant = {
 }
 
 
-
 def subparser(subpi):
 
     subpi.add_argument("run",
@@ -83,6 +78,7 @@ def subparser(subpi):
                        help="The database that will be updated. Defaults to first database in regolithrc.json")
 
     return subpi
+
 
 def plotter(datearray, student=None, pd=None, ss=None, title=None):
     fig,ax = plt.subplots()
@@ -138,7 +134,6 @@ class MakeAppointmentsHelper(SoutHelperBase):
         gtx["float"] = float
         gtx["str"] = str
         gtx["zip"] = zip
-
 
     def sout(self):
         rc = self.rc

--- a/regolith/helpers/u_finishprumhelper.py
+++ b/regolith/helpers/u_finishprumhelper.py
@@ -2,7 +2,7 @@
 """
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval, collection_str
+from regolith.tools import all_docs_from_collection, fragment_retrieval
 import datetime as dt
 from dateutil import parser as date_parser
 

--- a/regolith/helpers/u_institutionshelper.py
+++ b/regolith/helpers/u_institutionshelper.py
@@ -4,7 +4,6 @@ Helper for updating/adding  to the projecta collection.
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import all_docs_from_collection, fragment_retrieval
-from itertools import chain
 import uuid
 import datetime as dt
 

--- a/regolith/helpers/u_todohelper.py
+++ b/regolith/helpers/u_todohelper.py
@@ -5,7 +5,6 @@ import datetime as dt
 import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
 import math
-import sys
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.fsclient import _id_key

--- a/regolith/helpers/v_meetingshelper.py
+++ b/regolith/helpers/v_meetingshelper.py
@@ -1,19 +1,12 @@
 """Validator for meetings
 """
 import datetime as dt
-import dateutil
-import dateutil.parser as date_parser
-from regolith.dates import (
-    is_current,
-    get_dates
-)
+
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    fuzzy_retrieval,
-    search_collection,
     validate_meeting
 )
 

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -161,8 +161,6 @@ class MongoClient:
         self.dbs = defaultdict(lambda: defaultdict(dict))
         self.chained_db = dict()
         self.closed = True
-        # actually startup mongo
-        # self.open()
 
     def _preclean(self):
         mongodbpath = self.rc.mongodbpath
@@ -327,7 +325,7 @@ class MongoClient:
     def __getitem__(self, key):
         return self.client[key]
 
-    def collection_names(self, dbname):
+    def collection_names(self, dbname, include_system_collections=True):
         """Returns the collection names for the database name."""
         return self.client[dbname].collection_names()
 

--- a/regolith/runcontrol.py
+++ b/regolith/runcontrol.py
@@ -273,6 +273,7 @@ def filter_databases(rc):
         rc.db = dbs[0]["name"]
     rc.databases = dbs
 
+
 def connect_db(rc, colls=None):
     '''
     Load up the db's

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -33,8 +33,6 @@ if sys.version_info[0] >= 3:
     unicode_type = str
 else:
     pass
-    # string_types = (str, unicode)
-    # unicode_type = unicode
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
@@ -519,18 +517,6 @@ def filter_activities(people, begin_period, type, verbose=False):
         svc = copy(p.get("activities", []))
         for i in svc:
             if i.get("type") == type:
-                # if i.get('year'):
-                #     end_year = i.get('year')
-                #     if verbose: print("end_year from 'year' = {}".format(end_year))
-                # elif i.get('end_year'):
-                #     end_year = i.get('end_year')
-                #     if verbose: print("end_year from 'end_year' = {}".format(end_year))
-                # else:
-                #     end_year = date.today().year
-                #     if verbose: print("no end_year, using today = {}".format(end_year))                                i.get("end_month", 12),
-                #                 i.get("end_day", last_day(end_year,  i.get("end_month")))
-                # if verbose: print("end_date = {} and begin_period = {}".format(end_date,begin_period))
-                # if verbose: print("condition end_date >= begin_period will be used")
                 idates = get_dates(i)
                 if idates["end_date"] >= begin_period:
                     usedate = idates.get('begin_date', idates.get('date'))
@@ -1913,16 +1899,6 @@ def print_task(task_list, stati, index=True):
             for note in task.get('notes'):
                 print(f"     - {note}")
     print(f"{'-' * 30}\nDeadlines:\n{'-' * 30}")
-
-    #        else:
-    #            for task in task_list:
-    #                if task.get('status') == status:
-    #                    print(
-    #                        f"{task.get('description').strip()} ({task.get('days_to_due')}|{task.get('importance')}|{str(task.get('duration'))}|{','.join(task.get('tags',[]))}|{task.get('assigned_by')})")
-    #                    if task.get('notes'):
-    #                        for note in task.get('notes'):
-    #                            print(f"     - {note}")
-
     return
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,10 +15,6 @@ def test_fs_to_mongo_python(make_db):
         repo = str(Path(__file__).parent.parent.parent.joinpath('rg-db-group', 'local'))
     else:
         repo = make_db
-    #    dbpath = Path(repo).joinpath('_dbpath')
-    #    dbpath.mkdir()
-    #    cp0 = subprocess.run(['mongod', '--fork', '--syslog', '--dbpath', dbpath])
-    #    assert cp0.returncode == 0
     cp1 = subprocess.run(['regolith', 'fs-to-mongo'], cwd=repo)
     assert cp1.returncode == 0
 

--- a/tests/test_runcontrol.py
+++ b/tests/test_runcontrol.py
@@ -1,10 +1,5 @@
-import json
 import os
-import sys
-from io import StringIO
 
-from regolith.main import main
-from regolith.broker import load_db
 from regolith.runcontrol import DEFAULT_RC, load_rcfile, filter_databases, \
     connect_db
 from regolith.database import connect

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,7 +1,6 @@
 import habanero
 import pytest
 import datetime as dt
-from requests import HTTPError
 
 from regolith.tools import (
     filter_publications,


### PR DESCRIPTION
removed the annoying messages being sent that remind you to put a backend key in your regolithrc so that regolith no longer has to assume. This was meant to be the equivalent of a deprecation message, but because client.open gets called on init and by the context manager (for every database in a list), it gets printed excessively. Maybe I should instead just put a flag on it to say its been printed?