### PR TITLE
Client-side Cerberus validation added to inserts and updates

### DIFF
--- a/news/mongo_validation.rst
+++ b/news/mongo_validation.rst
@@ -1,0 +1,13 @@
+**Added:**
+ * Validation on all updates and insertion to mongo databases due to potential for lack of PR review
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+ * Testing mongo backend added for all helpers as well as a single doc validation tool test
+
+**Security:** None

--- a/regolith/dates.py
+++ b/regolith/dates.py
@@ -129,6 +129,33 @@ def last_day(year, month):
     """
     return calendar.monthrange(year, month_to_int(month))[1]
 
+
+def convert_doc_iso_to_date(doc):
+    def convert_date(obj):
+        """
+        Recursively goes through the dictionary obj and converts date from iso to datetime.date
+        """
+        if isinstance(obj, str):
+            try:
+                date = datetime.datetime.strptime(obj, '%Y-%m-%d').date()
+            except ValueError:
+                return obj
+            else:
+                return date
+        if isinstance(obj, (int, float)):
+            return obj
+        if isinstance(obj, dict):
+            new = obj.__class__()
+            for k, v in obj.items():
+                new[k] = convert_date(v)
+        elif isinstance(obj, (list, set, tuple)):
+            new = obj.__class__(convert_date(v) for v in obj)
+        else:
+            return obj
+        return new
+    return convert_date(doc)
+
+
 def get_dates(thing, date_field_prefix=None):
     '''
     given a dict like thing, return the date items

--- a/regolith/helpers/l_abstracthelper.py
+++ b/regolith/helpers/l_abstracthelper.py
@@ -55,11 +55,6 @@ class AbstractListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]
-        except BaseException:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_contactshelper.py
+++ b/regolith/helpers/l_contactshelper.py
@@ -82,11 +82,6 @@ class ContactsListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except BaseException:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_generalhelper.py
+++ b/regolith/helpers/l_generalhelper.py
@@ -48,11 +48,6 @@ class GeneralListerHelper(SoutHelperBase):
         needed_dbs = [rc.coll]
         if "groups" in needed_dbs:
             rc.pi_id = get_pi_id(rc)
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except BaseException:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_grantshelper.py
+++ b/regolith/helpers/l_grantshelper.py
@@ -53,11 +53,6 @@ class GrantsListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_membershelper.py
+++ b/regolith/helpers/l_membershelper.py
@@ -47,11 +47,6 @@ class MembersListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_milestoneshelper.py
+++ b/regolith/helpers/l_milestoneshelper.py
@@ -81,11 +81,6 @@ class MilestonesListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_progressreporthelper.py
+++ b/regolith/helpers/l_progressreporthelper.py
@@ -110,11 +110,6 @@ class ProgressReportHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_projectahelper.py
+++ b/regolith/helpers/l_projectahelper.py
@@ -77,11 +77,6 @@ class ProjectaListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/l_todohelper.py
+++ b/regolith/helpers/l_todohelper.py
@@ -62,11 +62,6 @@ class TodoListerHelper(SoutHelperBase):
         if "groups" in self.needed_dbs:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        try:
-            if not rc.database:
-                rc.database = rc.databases[0]["name"]
-        except:
-            pass
         colls = [
             sorted(
                 all_docs_from_collection(rc.client, collname), key=_id_key

--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -251,9 +251,10 @@ class MilestoneUpdaterHelper(DbHelperBase):
                     pdoc.update({'milestones': new_mil})
                 else:
                     pdoc.update({identifier: doc})
+            pdoc[identifier].pop('identifier', None)
             rc.client.update_one(rc.database, rc.coll, filterid, pdoc)
         for i in all_milestones:
-            del i['identifier']
+            i.pop('identifier', None)
         print("{} has been updated in projecta".format(key))
 
         return

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -433,7 +433,7 @@ class MongoClient:
     def find_one(self, dbname, collname, filter):
         """Finds the first document matching filter."""
         coll = self.dbs[dbname][collname]
-        filter.replace('.', '')
+        filter['_id'].replace('.', '')
         doc = coll.find_one(filter)
         return doc
 

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -11,9 +11,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ruamel.yaml import YAML
-from cerberus.errors import ValidationError
 
-from regolith.tools import validate_col
+from regolith.tools import validate_doc
 
 #
 # setup mongo
@@ -341,9 +340,9 @@ class MongoClient:
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""
         try:
-            validate_col(collname, doc, self.rc)
-        except ValidationError:
-            sys.exit("Validation failed. Upload cancelled... exiting program")
+            valid = validate_doc(collname, doc, self.rc)
+            if not valid:
+                sys.exit("Validation failed. Upload cancelled... exiting program")
         except Exception as e:
             print(e)
             sys.exit("Validation failed unexpectedly. Upload cancelled... exiting program")
@@ -360,9 +359,9 @@ class MongoClient:
         screened_docs = []
         for doc in docs:
             try:
-                validate_col(collname, doc, self.rc)
-            except ValidationError:
-                screened_docs.append(doc)
+                valid = validate_doc(collname, doc, self.rc)
+                if not valid:
+                    screened_docs.append(doc)
             except Exception as e:
                 print(e)
                 sys.exit("Validation failed unexpectedly... exiting program")

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -1966,3 +1966,24 @@ def get_formatted_crossref_reference(doi):
     ref_date = date(*ref_date_list)
 
     return ref, ref_date
+
+
+def validate_col(collection_name, collection_dict, rc):
+    from regolith.schemas import validate
+    from pprint import pprint
+    from cerberus.errors import ValidationError
+    any_errors = False
+    for doc_id, doc in collection_dict.items():
+        v = validate(collection_name, doc, rc.schemas)
+        if v[0] is False:
+            any_errors = True
+            print("ERROR in {}:".format(doc_id))
+            pprint(v[1])
+            for vv in v[1]:
+                pprint(doc.get(vv))
+            print("-" * 15)
+            print("\n")
+    if not any_errors:
+        print("\nNO ERRORS IN DBS\n" + "=" * 15)
+    else:
+        raise ValidationError

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -1970,13 +1970,16 @@ def get_formatted_crossref_reference(doi):
 
 def validate_doc(collection_name, doc, rc):
     from regolith.schemas import validate
-    from pprint import pprint
+    from pprint import pformat
     v = validate(collection_name, doc, rc.schemas)
+    error_message = ""
     if v[0] is False:
-        print("ERROR in {}:".format(doc['_id']))
-        pprint(v[1])
+        error_message += "ERROR in {}:\n".format(doc['_id'])
+        error_message += pformat(v[1])
+        error_message += "\n"
         for vv in v[1]:
-            pprint(doc.get(vv))
-        print("-" * 15)
-        print("\n")
-    return v[0]
+            error_message += pformat(doc.get(vv))
+            error_message += "\n"
+        error_message += ("-" * 15)
+        error_message += "\n"
+    return v[0], error_message

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -1968,22 +1968,15 @@ def get_formatted_crossref_reference(doi):
     return ref, ref_date
 
 
-def validate_col(collection_name, collection_dict, rc):
+def validate_doc(collection_name, doc, rc):
     from regolith.schemas import validate
     from pprint import pprint
-    from cerberus.errors import ValidationError
-    any_errors = False
-    for doc_id, doc in collection_dict.items():
-        v = validate(collection_name, doc, rc.schemas)
-        if v[0] is False:
-            any_errors = True
-            print("ERROR in {}:".format(doc_id))
-            pprint(v[1])
-            for vv in v[1]:
-                pprint(doc.get(vv))
-            print("-" * 15)
-            print("\n")
-    if not any_errors:
-        print("\nNO ERRORS IN DBS\n" + "=" * 15)
-    else:
-        raise ValidationError
+    v = validate(collection_name, doc, rc.schemas)
+    if v[0] is False:
+        print("ERROR in {}:".format(doc['_id']))
+        pprint(v[1])
+        for vv in v[1]:
+            pprint(doc.get(vv))
+        print("-" * 15)
+        print("\n")
+    return v[0]

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -1974,12 +1974,9 @@ def validate_doc(collection_name, doc, rc):
     v = validate(collection_name, doc, rc.schemas)
     error_message = ""
     if v[0] is False:
-        error_message += "ERROR in {}:\n".format(doc['_id'])
-        error_message += pformat(v[1])
-        error_message += "\n"
+        error_message += f"ERROR in {doc['_id']}:\n{pformat(v[1])}\n"
         for vv in v[1]:
-            error_message += pformat(doc.get(vv))
-            error_message += "\n"
+            error_message += f"{pformat(doc.get(vv))}\n"
         error_message += ("-" * 15)
         error_message += "\n"
     return v[0], error_message

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def main():
         author_email="scopatz@gmail.com",
         url="https://github.com/scopatz/regolith",
         platforms="Cross Platform",
+        python_requires='>=3.6',
         classifiers=["Programming Language :: Python :: 3"],
         packages=["regolith", "regolith.builders", "regolith.helpers"],
         package_dir={"regolith": "regolith"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def make_db():
         rmtree(repo)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def make_mongodb():
     """A test fixture that creates and destroys a git repo in a temporary
     directory, as well as a mongo database.
@@ -176,7 +176,7 @@ def make_mongodb():
     if not OUTPUT_FAKE_DB:
         rmtree(repo)
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def make_mixed_db():
     """A test fixture that creates and destroys a git repo in a temporary
     directory, as well as a mongo database.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def make_mongodb():
             subprocess.check_call(cmd, cwd=repo)
         except subprocess.CalledProcessError:
             print(
-                "Mongod likely has not been installed as a service. In order to run mongodb tests, make sure\n"
+                "Mongodb likely has not been installed as a service. In order to run mongodb tests, make sure\n"
                 "to install the mongodb community edition with the following link: \n"
                 "https://docs.mongodb.com/manual/installation/")
             yield False
@@ -138,9 +138,9 @@ def make_mongodb():
     try:
         subprocess.check_call(cmd, cwd=repo)
     except subprocess.CalledProcessError:
-        print("If on linux/mac, Mongod command failed to execute. If on windows, the status of mongo could not be\n"
-              "retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with\n"
-              "the following link:\n"
+        print("If using linux or mac, Mongod command failed to execute. If using windows, the status of mongo could \n"
+              "not be retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with"
+              "\nthe following link:\n"
               "https://docs.mongodb.com/manual/installation/")
         yield False
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,9 +127,9 @@ def make_mongodb():
             subprocess.check_call(cmd, cwd=repo)
         except subprocess.CalledProcessError:
             print(
-                "If on linux or mac, Mongod command failed to execute. If on windows, mongod has not been installed as \n"
-                "a service. In order to run mongodb tests, make sure to install the mongodb community edition\n"
-                "for your OS with the following link: https://docs.mongodb.com/manual/installation/")
+                "Mongod likely has not been installed as a service. In order to run mongodb tests, make sure\n"
+                "to install the mongodb community edition with the following link: \n"
+                "https://docs.mongodb.com/manual/installation/")
             yield False
             return
         cmd = ["mongostat", "--host", "localhost", "-n", "1"]
@@ -138,9 +138,10 @@ def make_mongodb():
     try:
         subprocess.check_call(cmd, cwd=repo)
     except subprocess.CalledProcessError:
-        print("If on linux or mac, Mongod command failed to execute. If on windows, mongod has not been installed as \n"
-              "a service. In order to run mongodb tests, make sure to install the mongodb community edition\n"
-              "for your OS with the following link: https://docs.mongodb.com/manual/installation/")
+        print("If on linux/mac, Mongod command failed to execute. If on windows, the status of mongo could not be\n"
+              "retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with\n"
+              "the following link:\n"
+              "https://docs.mongodb.com/manual/installation/")
         yield False
         return
     # Write collection docs
@@ -241,9 +242,9 @@ def make_mixed_db():
             subprocess.check_call(cmd, cwd=repo)
         except subprocess.CalledProcessError:
             print(
-                "If on linux or mac, Mongod command failed to execute. If on windows, mongod has not been installed as \n"
-                "a service. In order to run mongodb tests, make sure to install the mongodb community edition\n"
-                "for your OS with the following link: https://docs.mongodb.com/manual/installation/")
+                "Mongod likely has not been installed as a service. In order to run mongodb tests, make sure\n"
+                "to install the mongodb community edition with the following link: \n"
+                "https://docs.mongodb.com/manual/installation/")
             yield False
             return
         cmd = ["mongostat", "--host", "localhost", "-n", "1"]
@@ -252,9 +253,10 @@ def make_mixed_db():
     try:
         subprocess.check_call(cmd, cwd=repo)
     except subprocess.CalledProcessError:
-        print("If on linux or mac, Mongod command failed to execute. If on windows, mongod has not been installed as \n"
-              "a service. In order to run mongodb tests, make sure to install the mongodb community edition\n"
-              "for your OS with the following link: https://docs.mongodb.com/manual/installation/")
+        print("If on linux/mac, Mongod command failed to execute. If on windows, the status of mongo could not be\n"
+              "retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with\n"
+              "the following link:\n"
+              "https://docs.mongodb.com/manual/installation/")
         yield False
         return
     # Write one collection doc in mongo

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -8,7 +8,7 @@ from regolith.tools import all_docs_from_collection
 from regolith.schemas import EXEMPLARS
 
 
-def test_builder_python(make_mixed_db):
+def test_collection_retrieval_python(make_mixed_db):
     if make_mixed_db is False:
         pytest.skip("Mongoclient failed to start")
     else:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -624,6 +624,8 @@ def assert_mongo_vs_yaml_outputs(expecteddir, mongo_database):
             edited_collection_dict = load_mongo_col(mongo_coll_pointer)
             for k, v in edited_collection_dict.items():
                 edited_collection_dict[k] = convert_doc_iso_to_date(v)
+            for k, v in expected_collection_dict.items():
+                expected_collection_dict[k] = convert_doc_iso_to_date(v)
             assert edited_collection_dict == expected_collection_dict
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -566,10 +566,21 @@ helper_map = [
     (["helper", "v_meetings", "--test"], "Meeting validator helper\n")
 ]
 
+db_srcs = ["mongo", "fs"]
+
+
+@pytest.mark.parametrize("db_src", db_srcs)
 @pytest.mark.parametrize("hm", helper_map)
-def test_helper_python(hm, make_db, capsys):
-    repo = Path(make_db)
+def test_helper_python(hm, make_db, db_src, make_mongodb, capsys):
     testfile = Path(__file__)
+
+    if db_src == "fs":
+        repo = Path(make_db)
+    elif db_src == "mongo":
+        if make_mongodb is False:
+            pytest.skip("Mongoclient failed to start")
+        else:
+            repo = Path(make_mongodb)
     os.chdir(repo)
 
     main(args=hm[0])
@@ -584,9 +595,36 @@ def test_helper_python(hm, make_db, capsys):
     if are_outfiles and expecteddir.is_dir():
         assert_outputs(builddir, expecteddir)
 
-    builddir = repo / "db"
     if expecteddir.is_dir():
-        assert_outputs(builddir, expecteddir)
+        if db_src == "fs":
+            test_dir = repo / "db"
+            assert_outputs(test_dir, expecteddir)
+        elif db_src == "mongo":
+            from regolith.database import connect
+            from regolith.runcontrol import DEFAULT_RC, load_rcfile
+            os.chdir(repo)
+            rc = DEFAULT_RC
+            rc._update(load_rcfile("regolithrc.json"))
+            with connect(rc) as client:
+                mongo_database = client[rc.db]
+                assert_mongo_vs_yaml_outputs(expecteddir, mongo_database)
+
+
+def assert_mongo_vs_yaml_outputs(expecteddir, mongo_database):
+    from regolith.mongoclient import load_mongo_col
+    from regolith.fsclient import load_yaml
+    from regolith.dates import convert_doc_iso_to_date
+    os.chdir(expecteddir)
+    for root, dirs, files in os.walk("."):
+        for file in files:
+            fn2 = expecteddir / root / file
+            expected_collection_dict = load_yaml(fn2)
+            base, ext = os.path.splitext(file)
+            mongo_coll_pointer = mongo_database[base]
+            edited_collection_dict = load_mongo_col(mongo_coll_pointer)
+            for k, v in edited_collection_dict.items():
+                edited_collection_dict[k] = convert_doc_iso_to_date(v)
+            assert edited_collection_dict == expected_collection_dict
 
 
 def assert_outputs(builddir, expecteddir):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -55,7 +55,7 @@ BAD_PROJECTUM = {
 }
 
 
-def test_mongo_insertion_validation(capsys, make_mongodb):
+def test_mongo_insertion_validation(make_mongodb):
     if make_mongodb is False:
         pytest.skip("Mongoclient failed to start")
     else:
@@ -72,6 +72,5 @@ def test_mongo_insertion_validation(capsys, make_mongodb):
             rc.client.insert_one(only_database_in_test, 'projecta', BAD_PROJECTUM)
         except ValueError as e:
             result = e.args[0]
-    out, err = capsys.readouterr()
     expected = 'ERROR in sb_firstprojectum:\n{\'lead\': [\'required field\'], \'status\': [\'required field\']}\nNone\nNone\n---------------\n'
     assert result == expected

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -55,7 +55,8 @@ BAD_PROJECTUM = {
 }
 
 
-def test_mongo_insertion_validation(make_mongodb):
+def test_mongo_invalid_insertion(make_mongodb):
+    # proof that valid insertion is allowed is provided by helper tests on mongo
     if make_mongodb is False:
         pytest.skip("Mongoclient failed to start")
     else:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,6 @@
 from collections.abc import Sequence
+from pathlib import Path
+import os
 
 import pytest
 
@@ -29,3 +31,47 @@ def test_exemplars(key):
                 print(type(EXEMPLARS[key][vv]))
                 pprint(EXEMPLARS[key][vv])
         assert v[0]
+
+
+BAD_PROJECTUM = {
+    "_id": "sb_firstprojectum",
+    "begin_date": "2020-04-28",
+    "collaborators": ["aeinstein", "pdirac"],
+    "deliverable": {
+        "audience": ["beginning grad in chemistry"],
+        "due_date": "2021-05-05",
+        "success_def": "audience is happy",
+        "scope": ["UCs that are supported or some other scope description "
+                  "if it is software", "sketch of science story if it is paper"
+                  ],
+        "platform": "description of how and where the audience will access "
+                    "the deliverable.  Journal if it is a paper",
+        "roll_out": [
+            "steps that the audience will take to access and interact with "
+            "the deliverable", "not needed for paper submissions"],
+        "notes": ["deliverable note"],
+        "status": "proposed"
+    }
+}
+
+
+def test_mongo_insertion_validation(capsys, make_mongodb):
+    if make_mongodb is False:
+        pytest.skip("Mongoclient failed to start")
+    else:
+        repo = Path(make_mongodb)
+    from regolith.database import connect
+    from regolith.runcontrol import DEFAULT_RC, load_rcfile
+    os.chdir(repo)
+    rc = DEFAULT_RC
+    rc.schemas = SCHEMAS
+    rc._update(load_rcfile("regolithrc.json"))
+    with connect(rc) as rc.client:
+        only_database_in_test = rc.databases[0]['name']
+        try:
+            rc.client.insert_one(only_database_in_test, 'projecta', BAD_PROJECTUM)
+        except ValueError as e:
+            result = e.args[0]
+    out, err = capsys.readouterr()
+    expected = 'ERROR in sb_firstprojectum:\n{\'lead\': [\'required field\'], \'status\': [\'required field\']}\nNone\nNone\n---------------\n'
+    assert result == expected


### PR DESCRIPTION
I added validation via cerberus schemas prior to upload to mongo, since there is no longer going to be a PR review process. 

In the process of doing this I realized I should test the helpers or I would have no idea if the validation was working. So I added testing on mongo db to every helper and fixed every issue that arose.

If you want eyes on every time someone does something specific, like adding a prum, maybe we can insert an automatic email process that asks you to review a new prum added by person x.