### PR TITLE
WIP Adding keyboard interrupt signal delay to fsclient.py

### DIFF
--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -17,17 +17,19 @@ import signal
 import logging
 
 
+signal_received = False
 def DelayedKeyboardInterrupt(func):
 
-    signal_received = False
     def handler(sig, frame):
+        global signal_received
         signal_received = (sig, frame)
         logging.debug('SIGINT received. Delaying KeyboardInterrupt.')
-        
+
     def wrap(*args, **kwargs):
         old_handler = signal.signal(signal.SIGINT, handler)
         func(*args, **kwargs)
         signal.signal(signal.SIGINT, old_handler)
+        global signal_received
         if signal_received:
             old_handler(*signal_received)
     return wrap

--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -20,16 +20,19 @@ import logging
 def DelayedKeyboardInterrupt(func):
 
     signal_received = False
+    def handler(sig, frame):
+        signal_received = (sig, frame)
+        logging.debug('SIGINT received. Delaying KeyboardInterrupt.')
+        
     def wrap(*args, **kwargs):
         old_handler = signal.signal(signal.SIGINT, handler)
         func(*args, **kwargs)
         signal.signal(signal.SIGINT, old_handler)
         if signal_received:
             old_handler(*signal_received)
+    return wrap
 
-    def handler(sig, frame):
-        signal_received = (sig, frame)
-        logging.debug('SIGINT received. Delaying KeyboardInterrupt.')
+
 
 YAML_BASE_MAP = {CommentedMap: dict,
                  CommentedSeq: list}

--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -24,8 +24,8 @@ def DelayedKeyboardInterrupt(func):
         old_handler = signal.signal(signal.SIGINT, handler)
         func(*args, **kwargs)
         signal.signal(signal.SIGINT, old_handler)
-        if self.signal_received:
-            self.old_handler(*self.signal_received)
+        if signal_received:
+            old_handler(*signal_received)
 
     def handler(sig, frame):
         signal_received = (sig, frame)
@@ -100,7 +100,7 @@ def dump_yaml(filename, docs, inst=None):
     inst.representer.ignore_aliases = lambda *data: True
     inst.indent(mapping=2, sequence=4, offset=2)
     sorted_dict = ruamel.yaml.comments.CommentedMap()
-        for k in sorted(docs):
+    for k in sorted(docs):
         doc = docs[k]
         _id = doc.pop("_id")
         sorted_dict[k] = ruamel.yaml.comments.CommentedMap()

--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -17,20 +17,20 @@ import signal
 import logging
 
 
-class DelayedKeyboardInterrupt:
+def DelayedKeyboardInterrupt(func):
 
-    def __enter__(self):
-        self.signal_received = False
-        self.old_handler = signal.signal(signal.SIGINT, self.handler)
-
-    def handler(self, sig, frame):
-        self.signal_received = (sig, frame)
-        logging.debug('SIGINT received. Delaying KeyboardInterrupt.')
-
-    def __exit__(self, type, value, traceback):
-        signal.signal(signal.SIGINT, self.old_handler)
+    signal_received = False
+    def wrap(*args, **kwargs):
+        old_handler = signal.signal(signal.SIGINT, handler)
+        func(*args, **kwargs)
+        signal.signal(signal.SIGINT, old_handler)
         if self.signal_received:
             self.old_handler(*self.signal_received)
+
+    def handler(sig, frame):
+        signal_received = (sig, frame)
+        logging.debug('SIGINT received. Delaying KeyboardInterrupt.')
+
 YAML_BASE_MAP = {CommentedMap: dict,
                  CommentedSeq: list}
 
@@ -93,21 +93,21 @@ def load_yaml(filename, return_inst=False, loader=None):
     return (docs, inst) if return_inst else docs
 
 
+@DelayedKeyboardInterrupt
 def dump_yaml(filename, docs, inst=None):
     """Dumps a dict of documents into a file."""
-    with DelayedKeyboardInterrupt():
-        inst = YAML() if inst is None else inst
-        inst.representer.ignore_aliases = lambda *data: True
-        inst.indent(mapping=2, sequence=4, offset=2)
-        sorted_dict = ruamel.yaml.comments.CommentedMap()
+    inst = YAML() if inst is None else inst
+    inst.representer.ignore_aliases = lambda *data: True
+    inst.indent(mapping=2, sequence=4, offset=2)
+    sorted_dict = ruamel.yaml.comments.CommentedMap()
         for k in sorted(docs):
-            doc = docs[k]
-            _id = doc.pop("_id")
-            sorted_dict[k] = ruamel.yaml.comments.CommentedMap()
-            for kk in sorted(doc.keys()):
-                sorted_dict[k][kk] = doc[kk]
-        with open(filename, "w", encoding="utf-8") as fh:
-            inst.dump(sorted_dict, stream=fh)
+        doc = docs[k]
+        _id = doc.pop("_id")
+        sorted_dict[k] = ruamel.yaml.comments.CommentedMap()
+        for kk in sorted(doc.keys()):
+            sorted_dict[k][kk] = doc[kk]
+    with open(filename, "w", encoding="utf-8") as fh:
+        inst.dump(sorted_dict, stream=fh)
 
 
 def json_to_yaml(inp, out):


### PR DESCRIPTION
I just added a DelayedKeyboardInterrupt context manager to fsclient that I copied and pasted from stackoverflow. I put the context manager inside the code for the dump_yaml() function. When I tried to do a keyboard interupt during dumping, it seems to work properly on my end. Can you add the fork as a remote and see if it works for you too?