### PR TITLE
pl_rego_helper_no_folder, closes #751

### DIFF
--- a/regolith/helpers/basehelper.py
+++ b/regolith/helpers/basehelper.py
@@ -88,7 +88,6 @@ class HelperBase(object):
     def hlp(self):
         """run the helper, note this runs any of the commands
         listed in ``self.cmds``"""
-        os.makedirs(self.bldir, exist_ok=True)
         for cmd in self.cmds:
             getattr(self, cmd)()
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -595,17 +595,11 @@ def test_helper_python(hm, make_db, capsys):
     out, err = capsys.readouterr()
     assert out == hm[1]
 
-    builddir = repo / "_build" / hm[0][1]
     expecteddir = testfile.parent / "outputs" / hm[0][1]
-    are_outfiles = any(builddir.iterdir())
-    if are_outfiles and not expecteddir.is_dir():
-        print("WARNING: there are built outputs that are not being tested")
-    if are_outfiles and expecteddir.is_dir():
-        assert_outputs(builddir, expecteddir)
 
-    builddir = repo / "db"
     if expecteddir.is_dir():
-        assert_outputs(builddir, expecteddir)
+        test_dir = repo / "db"
+        assert_outputs(test_dir, expecteddir)
 
 helper_map_loose = [
     (["helper", "l_abstract"],


### PR DESCRIPTION
Solving the issue where helpers make an unneeded empty folder in the _build directory. Fixed a larger issue where helper outputs were not being tested in test_helpers. closes #751 