### PR TITLE
Mongo to fs backup added

### DIFF
--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -75,6 +75,11 @@ class ClientManager:
             if isinstance(client, MongoClient):
                 client.import_database(db)
 
+    def export_database(self, db: dict):
+        for client in self.clients:
+            if isinstance(client, MongoClient):
+                client.export_database(db)
+
     def dump_database(self, db):
         for client in self.clients:
             if isinstance(client, CLIENTS[db["backend"]]):

--- a/regolith/commands.py
+++ b/regolith/commands.py
@@ -202,6 +202,21 @@ def fs_to_mongo(rc: RunControl) -> None:
     return
 
 
+def mongo_to_fs(rc: RunControl) -> None:
+    """Convert database collection from filesystem to mongo db.
+
+    Parameters
+    ----------
+    rc : RunControl
+        The RunControl. The mongo client will be created according to 'mongodbpath' in it. The databases will
+        be loaded according to the 'databases' in it.
+    """
+    dbs = getattr(rc, 'databases')
+    for db in dbs:
+        rc.client.export_database(db)
+    return
+
+
 def validate(rc):
     """Validate the combined database against the schemas"""
     from regolith.schemas import validate

--- a/regolith/main.py
+++ b/regolith/main.py
@@ -34,7 +34,8 @@ CONNECTED_COMMANDS = {
     "classlist": commands.classlist,
     "validate": commands.validate,
     "helper": commands.helper,
-    "fs-to-mongo": commands.fs_to_mongo
+    "fs-to-mongo": commands.fs_to_mongo,
+    "mongo-to-fs": commands.mongo_to_fs
 }
 
 NEED_RC = set(CONNECTED_COMMANDS.keys())
@@ -261,13 +262,26 @@ def create_parser():
     )
     ytj.add_argument("files", nargs="+", help="file names to convert")
 
+    # mongo-to-fs subparser
+    mtf = subp.add_parser(
+        "mongo-to-fs",
+        help="Backup database from mongodb to filesystem as json. The database will be imported to the destination "
+             "specified by the 'database':'dst_url' key. For this to work, ensure that the database is included in the "
+             "dst_url, and that local is set to true."
+    )
+
+    mtf.add_argument("--host", help="Specifies a resolvable hostname for the mongod to which to connect. By "
+                                    "default, the mongoexport attempts to connect to a MongoDB instance running "
+                                    "on the localhost on port number 27017.",
+                     dest="host",
+                     default=None)
+
     # fs-to-mongo subparser
     ftm = subp.add_parser(
         "fs-to-mongo",
         help="Import database from filesystem to mongodb. By default, the database will be import to the local "
              "mongodb. The database can also be imported to the destination specified by the 'database':'dst_url' key."
-             " For this to work, ensure that the username, password, and database are included in the dst_url, and that"
-             " local is set to true."
+             " For this to work, ensure that the database is included in the dst_url, and that local is set to true."
     )
 
     ftm.add_argument("--host", help="Specifies a resolvable hostname for the mongod to which to connect. By "

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -37,6 +37,17 @@ def test_mongo_to_fs_python(make_mongo_to_fs_backup_db):
         assert True == False
     else:
         assert True == True
+    replace_rc_dbs(repo)
+    os.chdir(repo)
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    with connect(rc) as rc.client:
+        fs_db = rc.client[FS_DB_NAME]
+        mongo_db = rc.client[ALTERNATE_REGOLITH_MONGODB_NAME]
+        for coll in mongo_db.list_collection_names():
+            migrated_fs_collection = fs_db[coll]
+            original_mongo_collection = load_mongo_col(mongo_db[coll])
+            assert migrated_fs_collection == original_mongo_collection
 
 
 def test_fs_to_mongo_python(make_fs_to_mongo_migration_db):
@@ -59,7 +70,7 @@ def test_fs_to_mongo_python(make_fs_to_mongo_migration_db):
     with connect(rc) as rc.client:
         fs_db = rc.client[FS_DB_NAME]
         mongo_db = rc.client[ALTERNATE_REGOLITH_MONGODB_NAME]
-        for coll in mongo_db.list_collection_names():
+        for coll in fs_db.keys():
             original_fs_collection = fs_db[coll]
             migrated_mongo_collection = load_mongo_col(mongo_db[coll])
             for k, v in migrated_mongo_collection.items():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -27,6 +27,18 @@ def test_fs_to_mongo_python(make_db):
     assert cp1.returncode == 0
 
 
+def test_mongo_to_fs_python(make_mongo_to_fs_backup_db):
+    repo = make_mongo_to_fs_backup_db
+    os.chdir(repo)
+    try:
+        main(['mongo-to-fs'])
+    except Exception as e:
+        print(e)
+        assert True == False
+    else:
+        assert True == True
+
+
 def test_fs_to_mongo_python(make_fs_to_mongo_migration_db):
     if BILLINGE_TEST:
         repo = str(Path(__file__).parent.parent.parent.joinpath('rg-db-group', 'local'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -567,7 +567,10 @@ helper_map = [
     (["helper", "v_meetings", "--test"], "Meeting validator helper\n")
 ]
 
-db_srcs = ["mongo", "fs"]
+db_srcs = [
+    # "mongo",
+    "fs"
+]
 
 
 @pytest.mark.parametrize("db_src", db_srcs)


### PR DESCRIPTION
After @sbillinge comment yesterday asking if they should upload their todo list and work on mongo, I realized that I should prioritize the ability to periodically backup mongo to the filesystem. 

This commit allows the user to backup a mongo database with the directory they dedicate for fs-to-mongo porting. They simply go to local and type "regolith mongo-to-fs" into the terminal with the develop banch active. The entirety of the database will be pulled from the dst_url database into their local db folder in the form of json files. 

I've also commented out the running of mongo helper tests, because they seem to be taking a relatively long time. 

All mongo helper tests have been run locally on windows and ubuntu before submitting this PR.