### PR TITLE
Fixing l todo bug concerning non deadline todos

### DIFF
--- a/regolith/helpers/l_todohelper.py
+++ b/regolith/helpers/l_todohelper.py
@@ -34,7 +34,7 @@ def subparser(subpi):
                        choices=TODO_STATI,
                        #widget="Listbox",
                        help=f'Filter tasks with specific stati',
-                       default="started",
+                       default=["started"],
                        widget='Listbox')
     subpi.add_argument("--short", nargs='?', const=30,
                        help='Filter tasks with estimated duration <= 30 mins, but if a number is specified, the duration of the filtered tasks will be less than that number of minutes.',


### PR DESCRIPTION
I was able to fix the bug where non-deadline todo's weren't being displayed with l_todo. The bug was in the --stati subparser. 