### PR TITLE
WIP allowing helper_gui to be run on mac by editing setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 # coding=utf-8
 """The regolith installer."""
 from __future__ import print_function
+from pathlib import Path
 import os
 import sys
+import platform
 
 try:
     from setuptools import setup
@@ -16,7 +18,6 @@ except ImportError:
     HAVE_SETUPTOOLS = False
 
 from regolith import __version__ as RG_VERSION
-
 
 def main():
     try:
@@ -49,12 +50,17 @@ def main():
                 "*.xsh",
             ]
         },
-        scripts=["scripts/regolith", "scripts/helper_gui"],
+        scripts=["scripts/regolith"],
         zip_safe=False,
     )
     if HAVE_SETUPTOOLS:
         skw["setup_requires"] = []
         # skw['install_requires'] = ['Jinja2', 'pymongo']
+    setup(**skw)
+
+    if 'macOS' in platform.platform():
+        sys.executable = Path('/usr/bin/env pythonw')
+    skw['scripts'] = ['scripts/helper_gui']
     setup(**skw)
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main():
     setup(**skw)
 
 
-    if platform.system() == 'Darwin':
+    if platform.system().lower() == 'darwin':
     #The following lines find the python.app script, parses the script to find the path of its executable, and sets
     #the sys.executable to that executable. The shebang line created will be that of the new sys.executable
         import subprocess

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main():
     setup(**skw)
 
 
-    if 'macOS' in platform.platform():
+    if platform.system() == 'Darwin':
     #The following lines find the python.app script, parses the script to find the path of its executable, and sets
     #the sys.executable to that executable. The shebang line created will be that of the new sys.executable
         import subprocess

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ except ImportError:
     HAVE_SETUPTOOLS = False
 
 from regolith import __version__ as RG_VERSION
+PW_AFFECTED_OSX_SYSTEMS = ["darwin"]
 
 def main():
     try:
@@ -59,7 +60,7 @@ def main():
     setup(**skw)
 
 
-    if platform.system().lower() == 'darwin':
+    if platform.system().lower() in PW_AFFECTED_OSX_SYSTEMS:
     #The following lines find the python.app script, parses the script to find the path of its executable, and sets
     #the sys.executable to that executable. The shebang line created will be that of the new sys.executable
         import subprocess

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,19 @@ def main():
         # skw['install_requires'] = ['Jinja2', 'pymongo']
     setup(**skw)
 
+
     if 'macOS' in platform.platform():
-        sys.executable = Path('/usr/bin/env pythonw')
+    #The following lines find the python.app script, parses the script to find the path of its executable, and sets
+    #the sys.executable to that executable. The shebang line created will be that of the new sys.executable
+        import subprocess
+        py_app_path = subprocess.check_output('which python.app', shell=True)
+        py_app_path = py_app_path.decode('utf-8')[:-1]
+        py_app_contents = subprocess.check_output('cat ' + py_app_path, shell=True)
+        py_app_contents = py_app_contents.decode('utf-8')
+        new_sys_executable = py_app_contents.splitlines()[-1]
+        new_sys_executable = new_sys_executable.split(' ')[0]
+        sys.executable = new_sys_executable
+
     skw['scripts'] = ['scripts/helper_gui']
     setup(**skw)
 


### PR DESCRIPTION
There is currently one bug, which is that when the shebang line created in the helper_gui entry_point in the packages folder is #!/"usr/bin/env pythonw", instead of #!/usr/bin/env/pythonw.