### PR TITLE
Fixed issues regarding allowed doi entries and how different tags are handled

### DIFF
--- a/regolith/builders/internalhtmlbuilder.py
+++ b/regolith/builders/internalhtmlbuilder.py
@@ -113,9 +113,16 @@ class InternalHtmlBuilder(BuilderBase):
                         "WARNING: {} presenter {} not found in people".format(mtg["_id"],mtg["presentation"].get("presenter")))
                     prsn = {"name": prsn_id }
                 mtg["journal_club"]["presenter"] = prsn["name"]
-                if mtg["journal_club"].get("doi", "tbd").casefold() != 'tbd':
-                    ref, _ = get_formatted_crossref_reference(mtg["journal_club"].get("doi"))
-                    mtg["journal_club"]["doi"] = ref
+                mtg_jc_doi = mtg["journal_club"].get("doi", "tbd")
+                mtg_jc_doi_casefold = mtg_jc_doi.casefold()
+                if mtg_jc_doi_casefold == 'na':
+                    mtg["journal_club"]["doi"] = 'N/A'
+                elif mtg_jc_doi_casefold != 'tbd':
+                    if not mtg_jc_doi_casefold.startswith('arxiv'):
+                        ref, _ = get_formatted_crossref_reference(mtg["journal_club"].get("doi"))
+                        mtg["journal_club"]["doi"] = ref
+                    else:
+                        ref = mtg_jc_doi
                     jclub_cumulative.append((ref, get_dates(mtg).get("date","no date")))
 
             if mtg.get("presentation"):


### PR DESCRIPTION
Updated allowed tags in the `doi` field of journal clubs. Now `na` is allowed and will appear as "N/A" in the html. Also, temporary journal article identifiers for arXiv papers are permitted (without being incorrectly cross-referenced through habanero) but will instead appear as simply the arXiv tag in the journal club entries rather than a full citation.