### PR TITLE
WIP: Displaying a way to break the chain_db when mongo-only collections are present

### DIFF
--- a/regolith/builders/activitylogbuilder.py
+++ b/regolith/builders/activitylogbuilder.py
@@ -6,7 +6,6 @@ from copy import deepcopy, copy
 
 from regolith.builders.basebuilder import LatexBuilderBase
 from regolith.builders.cpbuilder import is_pending
-from regolith.fsclient import _id_key
 from regolith.dates import month_to_int, is_current, get_dates
 from regolith.sorters import position_key, doc_date_key
 from regolith.stylers import sentencecase, month_fullnames
@@ -25,7 +24,7 @@ from regolith.tools import (
     awards,
     filter_patents,
     filter_licenses,
-    get_id_from_name, merge_collections_all, filter_committees)
+    get_id_from_name, merge_collections_all, filter_committees, _id_key)
 
 
 class ActivitylogBuilder(LatexBuilderBase):

--- a/regolith/builders/appraisalbuilder.py
+++ b/regolith/builders/appraisalbuilder.py
@@ -4,7 +4,6 @@ from copy import copy, deepcopy
 
 from regolith.builders.basebuilder import LatexBuilderBase
 from regolith.builders.cpbuilder import is_pending, CPBuilder
-from regolith.fsclient import _id_key
 from regolith.dates import month_to_int, is_current, get_dates
 from regolith.sorters import position_key, doc_date_key
 from regolith.stylers import sentencecase, month_fullnames
@@ -24,7 +23,10 @@ from regolith.tools import (
     filter_patents,
     filter_licenses,
     merge_collections_superior,
-    get_id_from_name, merge_collections_all)
+    get_id_from_name,
+    merge_collections_all,
+    _id_key
+)
 
 
 class AppraisalBuilder(LatexBuilderBase):

--- a/regolith/builders/cpbuilder.py
+++ b/regolith/builders/cpbuilder.py
@@ -5,13 +5,13 @@ from nameparser import HumanName
 
 from regolith.builders.basebuilder import LatexBuilderBase
 from regolith.dates import is_current, get_dates
-from regolith.fsclient import _id_key
 from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
     filter_grants,
     fuzzy_retrieval,
     merge_collections_all,
+    _id_key
 )
 
 

--- a/regolith/builders/cvbuilder.py
+++ b/regolith/builders/cvbuilder.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from datetime import  date
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.sorters import ene_date_key, position_key
 from regolith.stylers import sentencecase, month_fullnames
 from regolith.tools import (
@@ -17,6 +16,7 @@ from regolith.tools import (
     dereference_institution,
     merge_collections_superior,
     filter_presentations, remove_duplicate_docs,
+    _id_key
 )
 
 

--- a/regolith/builders/htmlbuilder.py
+++ b/regolith/builders/htmlbuilder.py
@@ -4,7 +4,6 @@ import shutil
 
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
-from regolith.fsclient import _id_key
 from regolith.sorters import ene_date_key, position_key
 from regolith.tools import (
     all_docs_from_collection,
@@ -13,6 +12,7 @@ from regolith.tools import (
     make_bibtex_file,
     document_by_value,
     dereference_institution,
+    _id_key
 )
 
 

--- a/regolith/builders/internalhtmlbuilder.py
+++ b/regolith/builders/internalhtmlbuilder.py
@@ -5,7 +5,6 @@ import datetime as dt
 
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
-from regolith.fsclient import _id_key
 from regolith.sorters import position_key, ene_date_key
 from regolith.tools import (
     all_docs_from_collection,
@@ -15,7 +14,8 @@ from regolith.tools import (
     make_bibtex_file,
     document_by_value,
     dereference_institution,
-    fuzzy_retrieval
+    fuzzy_retrieval,
+    _id_key
 )
 
 

--- a/regolith/builders/manuscriptreviewbuilder.py
+++ b/regolith/builders/manuscriptreviewbuilder.py
@@ -1,9 +1,9 @@
 """Builder for Current and Pending Reports."""
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
+    _id_key
 )
 
 

--- a/regolith/builders/postdocadbuilder.py
+++ b/regolith/builders/postdocadbuilder.py
@@ -1,9 +1,9 @@
 """Builder for Current and Pending Reports."""
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
+    _id_key
 )
 
 

--- a/regolith/builders/preslistbuilder.py
+++ b/regolith/builders/preslistbuilder.py
@@ -21,14 +21,16 @@ The presentations are output in a ./_build directory."""
 from copy import deepcopy
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
     fuzzy_retrieval,
     get_person_contact,
     number_suffix,
-    group_member_ids, latex_safe, filter_presentations
+    group_member_ids,
+    latex_safe,
+    filter_presentations,
+    _id_key
 )
 from regolith.stylers import sentencecase, month_fullnames
 from regolith.dates import get_dates

--- a/regolith/builders/proposalreviewbuilder.py
+++ b/regolith/builders/proposalreviewbuilder.py
@@ -2,11 +2,12 @@
 from nameparser import HumanName
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     filter_grants,
-    fuzzy_retrieval, dereference_institution,
+    fuzzy_retrieval,
+    dereference_institution,
+    _id_key
 )
 
 

--- a/regolith/builders/readinglistsbuilder.py
+++ b/regolith/builders/readinglistsbuilder.py
@@ -3,11 +3,11 @@
 from habanero import Crossref
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.fsclient import _id_key
 from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
     get_formatted_crossref_reference,
+    _id_key
 )
 
 class ReadingListsBuilder(LatexBuilderBase):

--- a/regolith/chained_db.py
+++ b/regolith/chained_db.py
@@ -9,6 +9,8 @@ import itertools
 from collections import ChainMap
 from collections.abc import MutableMapping
 
+# from pymongo.collection import Collection as MongoCollection
+
 
 class ChainDBSingleton(object):
     """Singleton for representing when no default value is given."""
@@ -27,6 +29,8 @@ Singleton = ChainDBSingleton()
 class ChainDB(ChainMap):
     """ A ChainMap who's ``_getitem__`` returns either a ChainDB or
     the result"""
+
+    # _mongo_maps = {}
 
     def __getitem__(self, key):
         res = None
@@ -59,15 +63,27 @@ class ChainDB(ChainMap):
         return res
 
     def __setitem__(self, key, value):
+        # if isinstance(value, MongoCollection):
+        #     if key not in self._mongo_maps:
+        #         self._mongo_maps[key] = [value]
+        #     else:
+        #         self._mongo_maps[key].append[value]
+        #     return
         if key not in self:
             super().__setitem__(key, value)
         else:
-            res = None
-            results = []
             # Try to get all the data from all the mappings
             for mapping in reversed(self.maps):
                 if key in mapping:
                     mapping[key] = value
+
+    # def mongo(self, collection, mongo_method, *mongo_args, **mongo_kwargs):
+    #     results = []
+    #     for db_coll in self._mongo_maps[collection]:
+    #         coll_method = getattr(db_coll, mongo_method)
+    #         result = coll_method(db_coll, *mongo_args, **mongo_kwargs)
+    #         results.extend(result)
+    #     return results
 
 
 def _convert_to_dict(cm):

--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from collections import defaultdict
 
 from regolith.fsclient import FileSystemClient
-from regolith.mongoclient import MongoClient
+from regolith.mongoclient import MongoClient, load_mongo_col
 
 
 CLIENTS = {
@@ -99,9 +99,13 @@ class ClientManager:
 
     def all_documents(self, collname, copy=True):
         """Returns an iteratable over all documents in a collection."""
-        if copy:
-            return deepcopy(self.chained_db.get(collname, {})).values()
-        return self.chained_db.get(collname, {}).values()
+        if isinstance(self.chained_db[collname], dict):
+            if copy:
+                return deepcopy(self.chained_db.get(collname, {})).values()
+            return self.chained_db.get(collname, {}).values()
+        else:
+            # assume we've got a mongo collection
+            return load_mongo_col(self.chained_db[collname])
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""

--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -105,7 +105,8 @@ class ClientManager:
             return self.chained_db.get(collname, {}).values()
         else:
             # assume we've got a mongo collection
-            return load_mongo_col(self.chained_db[collname])
+            mongo_col = load_mongo_col(self.chained_db[collname]).values()
+            return mongo_col
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -172,16 +172,19 @@ def open_dbs(rc, dbs=None):
             db['blacklist'] = ['.travis.yml', '.travis.yaml']
         load_database(db, client, rc)
         for base, coll in client.dbs[db['name']].items():
-            if base not in chained_db:
-                chained_db[base] = {}
             if isinstance(coll, dict):
+                if base not in chained_db:
+                    chained_db[base] = {}
                 for k, v in coll.items():
                     if k in chained_db[base]:
                         chained_db[base][k].maps.append(v)
                     else:
                         chained_db[base][k] = ChainDB(v)
             else:
-                chained_db[base] = coll
+                if base not in chained_db:
+                    chained_db[base] = coll
+                else:
+                    raise NotImplementedError("Mongo has an overlapping collection name. Only pure FS allows this.")
     client.chained_db = chained_db
     return client
 

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -174,11 +174,14 @@ def open_dbs(rc, dbs=None):
         for base, coll in client.dbs[db['name']].items():
             if base not in chained_db:
                 chained_db[base] = {}
-            for k, v in coll.items():
-                if k in chained_db[base]:
-                    chained_db[base][k].maps.append(v)
-                else:
-                    chained_db[base][k] = ChainDB(v)
+            if isinstance(coll, dict):
+                for k, v in coll.items():
+                    if k in chained_db[base]:
+                        chained_db[base][k].maps.append(v)
+                    else:
+                        chained_db[base][k] = ChainDB(v)
+            else:
+                chained_db[base] = coll
     client.chained_db = chained_db
     return client
 

--- a/regolith/fsclient.py
+++ b/regolith/fsclient.py
@@ -53,10 +53,6 @@ def _rec_re_type(i):
     return base
 
 
-def _id_key(doc):
-    return doc["_id"]
-
-
 def load_json(filename):
     """Loads a JSON file and returns a dict of its documents."""
     docs = {}

--- a/regolith/helpers/a_expensehelper.py
+++ b/regolith/helpers/a_expensehelper.py
@@ -5,11 +5,11 @@ import datetime as dt
 import dateutil.parser as date_parser
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.schemas import EXPENSES_STATI, EXPENSES_TYPES
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_grppub_readlisthelper.py
+++ b/regolith/helpers/a_grppub_readlisthelper.py
@@ -3,9 +3,9 @@ import datetime as dt
 import dateutil.parser as date_parser
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_manurevhelper.py
+++ b/regolith/helpers/a_manurevhelper.py
@@ -6,9 +6,9 @@ import nameparser
 
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.dates import month_to_str_int
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -4,11 +4,11 @@ import dateutil.parser as date_parser
 
 from regolith.helpers.a_expensehelper import expense_constructor
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.schemas import PRESENTATION_TYPES, PRESENTATION_STATI
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_projectumhelper.py
+++ b/regolith/helpers/a_projectumhelper.py
@@ -8,10 +8,10 @@ import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_proposalhelper.py
+++ b/regolith/helpers/a_proposalhelper.py
@@ -6,10 +6,10 @@ from dateutil.relativedelta import relativedelta
 from math import floor
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/a_todohelper.py
+++ b/regolith/helpers/a_todohelper.py
@@ -6,10 +6,10 @@ import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/f_todohelper.py
+++ b/regolith/helpers/f_todohelper.py
@@ -6,13 +6,13 @@ import dateutil.parser as date_parser
 import math
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     document_by_value,
     print_task,
-    key_value_pair_filter
+    key_value_pair_filter,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/hellohelper.py
+++ b/regolith/helpers/hellohelper.py
@@ -1,9 +1,9 @@
 """Builder for Current and Pending Reports."""
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
+    _id_key
 )
 
 

--- a/regolith/helpers/l_abstracthelper.py
+++ b/regolith/helpers/l_abstracthelper.py
@@ -1,10 +1,10 @@
 from regolith.dates import get_dates
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    get_person_contact
+    get_person_contact,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/l_contactshelper.py
+++ b/regolith/helpers/l_contactshelper.py
@@ -8,12 +8,12 @@ from regolith.dates import (
     get_dates
 )
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     fuzzy_retrieval,
     search_collection,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/l_generalhelper.py
+++ b/regolith/helpers/l_generalhelper.py
@@ -2,12 +2,12 @@
 """
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     search_collection,
     collection_str,
+    _id_key
 )
 HELPER_TARGET = "lister"
 

--- a/regolith/helpers/l_grantshelper.py
+++ b/regolith/helpers/l_grantshelper.py
@@ -8,14 +8,14 @@ import sys
 
 from regolith.dates import get_dates, is_current
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     search_collection,
     key_value_pair_filter,
     collection_str,
-    merge_collections_superior
+    merge_collections_superior,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/l_membershelper.py
+++ b/regolith/helpers/l_membershelper.py
@@ -4,13 +4,13 @@
 
 from regolith.dates import is_current
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.sorters import position_key
 from regolith.tools import (
     all_docs_from_collection,
     key_value_pair_filter, collection_str,
     get_pi_id,
     fuzzy_retrieval,
+    _id_key
 )
 from regolith.dates import get_dates
 

--- a/regolith/helpers/l_milestoneshelper.py
+++ b/regolith/helpers/l_milestoneshelper.py
@@ -6,12 +6,12 @@
 
 from regolith.dates import get_due_date
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     key_value_pair_filter,
-    collection_str
+    collection_str,
+    _id_key
 )
 from regolith.schemas import PROJECTUM_STATI, PROJECTUM_PAUSED_STATI, \
     PROJECTUM_CANCELLED_STATI, PROJECTUM_FINISHED_STATI, PROJECTUM_ACTIVE_STATI

--- a/regolith/helpers/l_progressreporthelper.py
+++ b/regolith/helpers/l_progressreporthelper.py
@@ -5,11 +5,11 @@
 """
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     key_value_pair_filter,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/l_projectahelper.py
+++ b/regolith/helpers/l_projectahelper.py
@@ -7,14 +7,14 @@ import datetime as dt
 import dateutil.parser as date_parser
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.schemas import (PROJECTUM_ACTIVE_STATI, PROJECTUM_PAUSED_STATI,
    PROJECTUM_CANCELLED_STATI, PROJECTUM_FINISHED_STATI)
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     key_value_pair_filter,
-    collection_str
+    collection_str,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/l_todohelper.py
+++ b/regolith/helpers/l_todohelper.py
@@ -7,7 +7,6 @@ import math
 
 from regolith.dates import get_due_date
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.schemas import (
     TODO_STATI
 )
@@ -16,7 +15,8 @@ from regolith.tools import (
     get_pi_id,
     document_by_value,
     print_task,
-    key_value_pair_filter
+    key_value_pair_filter,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/makeappointmentshelper.py
+++ b/regolith/helpers/makeappointmentshelper.py
@@ -13,13 +13,14 @@ from dateutil import parser as date_parser
 from datetime import timedelta, date
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     is_fully_appointed,
     collect_appts,
-    grant_burn, group_member_employment_start_end,
+    grant_burn,
+    group_member_employment_start_end,
+    _id_key
 )
 from regolith.dates import (
     get_dates,

--- a/regolith/helpers/u_contacthelper.py
+++ b/regolith/helpers/u_contacthelper.py
@@ -7,8 +7,7 @@ import dateutil.parser as date_parser
 import uuid
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval
+from regolith.tools import all_docs_from_collection, fragment_retrieval, _id_key
 from gooey import GooeyParser
 
 

--- a/regolith/helpers/u_finishprumhelper.py
+++ b/regolith/helpers/u_finishprumhelper.py
@@ -1,8 +1,7 @@
 """Helper for finishing prum in the projecta collection
 """
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval
+from regolith.tools import all_docs_from_collection, fragment_retrieval, _id_key
 import datetime as dt
 from dateutil import parser as date_parser
 from gooey import GooeyParser

--- a/regolith/helpers/u_institutionshelper.py
+++ b/regolith/helpers/u_institutionshelper.py
@@ -2,8 +2,7 @@
 Helper for updating/adding  to the projecta collection.
 """
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval
+from regolith.tools import all_docs_from_collection, fragment_retrieval, _id_key
 import uuid
 import datetime as dt
 from gooey import GooeyParser

--- a/regolith/helpers/u_logurlhelper.py
+++ b/regolith/helpers/u_logurlhelper.py
@@ -2,8 +2,7 @@
    Log_urls are the google doc links to a projectum's Projectum Agenda Log
 """
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval
+from regolith.tools import all_docs_from_collection, fragment_retrieval, _id_key
 
 TARGET_COLL = "projecta"
 

--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -8,8 +8,7 @@ import dateutil.parser as date_parser
 from gooey import GooeyParser
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
-from regolith.tools import all_docs_from_collection, fragment_retrieval
+from regolith.tools import all_docs_from_collection, fragment_retrieval, _id_key
 from regolith.dates import get_due_date
 from regolith.schemas import PROJECTUM_ACTIVE_STATI
 

--- a/regolith/helpers/u_todohelper.py
+++ b/regolith/helpers/u_todohelper.py
@@ -7,14 +7,14 @@ from dateutil.relativedelta import relativedelta
 import math
 
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.fsclient import _id_key
 from regolith.schemas import (TODO_STATI)
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
     document_by_value,
     print_task,
-    key_value_pair_filter
+    key_value_pair_filter,
+    _id_key
 )
 from gooey import GooeyParser
 

--- a/regolith/helpers/v_meetingshelper.py
+++ b/regolith/helpers/v_meetingshelper.py
@@ -3,11 +3,11 @@
 import datetime as dt
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.fsclient import _id_key
 from regolith.tools import (
     all_docs_from_collection,
     get_pi_id,
-    validate_meeting
+    validate_meeting,
+    _id_key
 )
 
 TARGET_COLL = "meetings"

--- a/regolith/mongoclient.py
+++ b/regolith/mongoclient.py
@@ -377,7 +377,7 @@ class MongoClient:
                                or coll in db["whitelist"]
                             ]:
                 col = mongodb[colname]
-                dbs[db['name']][colname] = load_mongo_col(col)
+                dbs[db['name']][colname] = col
         except OperationFailure as fail:
             print("Mongo's Error Message:" + str(fail) + "\n")
             print("The user does not have permission to access " + db['name'] + "\n\n")

--- a/regolith/tools.py
+++ b/regolith/tools.py
@@ -42,6 +42,10 @@ ON_LINUX = platform.system() == "Linux"
 ON_POSIX = os.name == "posix"
 
 
+def _id_key(doc):
+    return doc["_id"]
+
+
 def dbdirname(db, rc):
     """Gets the database dir name."""
     if db.get("local", False) is False:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -588,7 +588,7 @@ helper_map = [
 ]
 
 db_srcs = [
-    "mongo",
+    # "mongo",
     "fs"
 ]
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -588,7 +588,7 @@ helper_map = [
 ]
 
 db_srcs = [
-    # "mongo",
+    "mongo",
     "fs"
 ]
 


### PR DESCRIPTION
Breaks the ability to chain across mongo and filesystem.

Power shown in a_proprevhelper.py, which realizes that we have a mongo collection and decides not to load all documents.

Main changes in client_manager.py (allows you to still load all from collections if you so choose), mongoclient line 380, and database.xsh.

Commented code in chain_db is potentially exciting because an update to __getitem__ (not there yet) could allow the typical chaining method to work by running finds and chaining their results at get-time (all documents time), but also allow helper maintainers to check and see if their collection is purely mongo-backed, and if so run mongo commands.