### PR TITLE
Fixed Issue with GIT backends

### DIFF
--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -82,12 +82,13 @@ class ClientManager:
 
     def dump_database(self, db):
         to_add = []
+        # Iterate through the clients just in case databases on different backends have same name
         for client in self.clients:
             if isinstance(client, CLIENTS[db["backend"]]):
-                temp_add = client.dump_database(db)
-                if temp_add:
-                    to_add.extend(temp_add)
-        # need to take into consideration multiple databases
+                if db["name"] in client.keys():
+                    temp_add = client.dump_database(db)
+                    if temp_add:
+                        to_add.extend(temp_add)
         return to_add
 
     def keys(self):

--- a/regolith/client_manager.py
+++ b/regolith/client_manager.py
@@ -81,9 +81,14 @@ class ClientManager:
                 client.export_database(db)
 
     def dump_database(self, db):
+        to_add = []
         for client in self.clients:
             if isinstance(client, CLIENTS[db["backend"]]):
-                client.dump_database(db)
+                temp_add = client.dump_database(db)
+                if temp_add:
+                    to_add.extend(temp_add)
+        # need to take into consideration multiple databases
+        return to_add
 
     def keys(self):
         keys = []

--- a/regolith/database.xsh
+++ b/regolith/database.xsh
@@ -88,8 +88,9 @@ def dump_git_database(db, client, rc):
     # dump all of the data
     to_add = client.dump_database(db)
     # update the repo
-    cmd = ['git', 'add'] + to_add
-    subprocess.check_call(cmd, cwd=dbdir)
+    for file in to_add:
+        cmd = ['git', 'add'] + file
+        subprocess.check_call(cmd, cwd=dbdir)
     cmd = ['git', 'commit', '-m', 'regolith auto-commit']
     try:
         subprocess.check_call(cmd, cwd=dbdir)


### PR DESCRIPTION
Git remotes can now be utilized and chained, which was accidentally broken previously. Tests not added.

Regolith currently has no tests for the git backend. Functionality with the GIT backend broke because the client_manager object was not returning the files that git would need to add before pushing. 

This issue was found via the rg-db-public build failure.

The delay in rg-db-public build failure was likely because building from a git backend repo was failing silently, since the repo was failing to get push rights to the website. These permissions must have recently changed, allowing this to fail loudly.

This has been sorted out logically, but is yet to be tested.

A test could involve creating a public git repository specifically for testing purposes. All that we would need to test (in order to prevent this specific issue in the future) is a builder, so there would never be a change to the remote test repository.

We could also simply add the set of commands from rg-db-public to the regolith travis. However, in this case these issues would/could not be caught with local testing. Therefore, there is potential to waste CI time. Should consult @connorjbracy on whether or not this is a good idea.