### PR TITLE
changed positions on webpage to title case

### DIFF
--- a/regolith/templates/people.html
+++ b/regolith/templates/people.html
@@ -9,7 +9,7 @@
   </a>
   <h1><a href="{{root}}/people/{{p['_id']}}.html">{{p['title']}} {{p['name']}}</a></h1>
   <ul>
-    <li><b>Position:</b> {{p['position'].capitalize()}}</li>
+    <li><b>Position:</b> {{p['position'].title()}}</li>
   </ul>
 {%- endfor -%}
 {% endblock content %}


### PR DESCRIPTION
I think the change is as simple as this. It is also labeled as .capitalize on the person's page instead of title case, but since it is in a heading font it overwrites the capitalization to make everything capital.