### PR TITLE
WIP: Regolith Fix #880 v4

### DIFF
--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -189,9 +189,8 @@ class PresentationAdderHelper(DbHelperBase):
                      'authors': authors,
                      'begin_date': begin_date,
                      'end_date': end_date,
+                     'notes': rc.notes,
                      })
-        if rc.notes:
-            pdoc.update({"notes": rc.notes})
         if rc.presentation_url:
             pdoc.update({"presentation_url": rc.presentation_url})
         if rc.webinar:

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -66,7 +66,8 @@ def subparser(subpi):
     subpi.add_argument("-n", "--notes", nargs="+",
                        help="note or notes to be inserted as a list into the notes field, "
                             "separate notes with spaces.  Place inside quotes if the note "
-                            "itself contains spaces."
+                            "itself contains spaces.",
+                       default=[]
                        )
     subpi.add_argument("-s", "--status",
                        choices=PRESENTATION_STATI,


### PR DESCRIPTION
Closes #880 and assigns default behavior for the a_presentation helper --notes option. Default behavior is an empty list. If notes are added, the rc.notes will update the document with a list of strings.  
All tests pass for test_helpers.py as well.  