### PR TITLE
WIP: closes #910, enhancement for --expense-db flag in presentation adder

### DIFF
--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -144,7 +144,7 @@ class PresentationAdderHelper(DbHelperBase):
             if not db_known:
                  raise RuntimeError(
                     "WARNING: The expense database provided does not exist. "
-                    "Please rerun specifying a known private database, "
+                    "Please rerun specifying a known private database."
                 )
 
             # if the specified expense database is public and the --force option wasn't passed, exit with a warning message
@@ -161,7 +161,7 @@ class PresentationAdderHelper(DbHelperBase):
         if not rc.expense_db:
             if rc.force:
                 rc.expense_db = rc.databases[0]["name"] # defaults to first entry under databases in regolithrc.json file
-                if rc.databases[0]["public"]
+                if rc.databases[0]["public"]:
                     print(f"{key} has been added in {EXPENSES_COLL} in database {rc.expense_db}")
             else:
                 for db in rc.databases:

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -144,7 +144,8 @@ class PresentationAdderHelper(DbHelperBase):
             if not db_known:
                  raise RuntimeError(
                     "WARNING: The expense database provided does not exist. "
-                    "Please rerun specifying a known private database."
+                    "Please rerun specifying a known private database. "
+                    "(Consider checking your spelling against the known databases listed in regolithrc.json.)"
                 )
 
             # if the specified expense database is public and the --force option wasn't passed, exit with a warning message

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -92,6 +92,10 @@ def subparser(subpi):
                        help="The database that will be updated.  Defaults to "
                             "first database in the regolithrc.json file.",
                        )
+    subpi.add_argument("--expense-db",
+                       help="The database where the expense collection will be updated. "
+                            "Defaults to first database in the regolithrc.json file.",
+                       )
     subpi.add_argument("--id",
                        help="Override the default id created from the date, "
                             "speaker and place by specifying an id here",
@@ -119,6 +123,8 @@ class PresentationAdderHelper(DbHelperBase):
         rc.coll = f"{TARGET_COLL}"
         if not rc.database:
             rc.database = rc.databases[0]["name"]
+        if not rc.expense_db:
+            rc.expense_db = rc.databases[0]["name"]
         gtx[rc.coll] = sorted(
             all_docs_from_collection(rc.client, rc.coll), key=_id_key
         )
@@ -218,7 +224,7 @@ class PresentationAdderHelper(DbHelperBase):
             rc.where = "tbd"
             rc.status = "unsubmitted"
             edoc = expense_constructor(key, begin_date, end_date, rc)
-            rc.client.insert_one(rc.database, EXPENSES_COLL, edoc)
-            print(f"{key} has been added in {EXPENSES_COLL}")
+            rc.client.insert_one(rc.expense_db, EXPENSES_COLL, edoc)
+            print(f"{key} has been added in {EXPENSES_COLL} in database {rc.expense_db}")
 
         return

--- a/regolith/helpers/a_presentationhelper.py
+++ b/regolith/helpers/a_presentationhelper.py
@@ -143,7 +143,7 @@ class PresentationAdderHelper(DbHelperBase):
             # If the database is not known, exit with descriptive error message
             if not db_known:
                  raise RuntimeError(
-                    "WARNING: The expense database provided does not exist. "
+                    f"WARNING: The expense database provided, {rc.expense_db}, does not exist. "
                     "Please rerun specifying a known private database. "
                     "(Consider checking your spelling against the known databases listed in regolithrc.json.)"
                 )
@@ -155,11 +155,12 @@ class PresentationAdderHelper(DbHelperBase):
                     "or, at your own risk, use the --force option to add the presentation expense data to a public database"
                 )
         
-        # if no expense database is specified, set it as the first private database listed in rc. 
+        # if no expense database is specified (but there is still expense data associatied with the presentation,
+        # i.e., the --no-expense flag was not passed), set it as the first private database listed in rc. 
         # If no private database is found/known, exit with a warning message. If, however, the 
         # --force option was passed, the expense database is set to be the first entry under databases
         # in regolithrc.json file, even if that database is public. 
-        if not rc.expense_db:
+        if (not rc.expense_db) and (not rc.no_expense):
             if rc.force:
                 rc.expense_db = rc.databases[0]["name"] # defaults to first entry under databases in regolithrc.json file
                 if rc.databases[0]["public"]:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,7 +64,7 @@ helper_map = [
       "--notes", "this is a sample added presentation",
       "--presentation-url", "http://drive.google.com/SEV356DV",
       "--no_cal"],
-     "2006as_mars has been added in presentations\n2006as_mars has been added in expenses\n"),
+     "2006as_mars has been added in presentations\n2006as_mars has been added in expenses in database test\n"),
     (["helper", "l_progress", "-l", "ascopatz", "--date", "2022-01-09"],
      "\nProgress report for ascopatz, generated 2022-01-09\n"
      "*************************[Orphan Projecta]*************************\n"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import copy
 
+
 from regolith.main import main
 
 dash = "-"
@@ -64,7 +65,23 @@ helper_map = [
       "--notes", "this is a sample added presentation",
       "--presentation-url", "http://drive.google.com/SEV356DV",
       "--no_cal"],
-     "2006as_mars has been added in presentations\n2006as_mars has been added in expenses in database test\n"),
+     pytest.raises(RuntimeError)),
+    (["helper", "a_presentation", "Testing bad expense db", "test", "2020-08-29", "2020-08-29",
+      "--type", "contributed_oral", "--person", "nasker", "--grants", "mmmmmmm",
+      "--authors", "sbillinge", "nasker", "--abstract", "the earth is square as seen from mercury",
+      "--title", "testing unknown expenseDB specification", "--status", "in-prep", "--expense-db", "test2",
+      "--notes", "this is a test added presentation to test specifying an unknown expense database",
+      "--presentation-url", "http://drive.google.com/placeholder/broken-link",
+      "--no_cal"],
+     pytest.raises(RuntimeError)),
+    (["helper", "a_presentation", "testing_no_expense flag", "test", "2020-07-26", "2020-07-26",
+      "--type", "contributed_oral", "--person", "nasker", "--grants", "nnnnnn",
+      "--authors", "sbillinge", "nasker", "--abstract", "the earth is round as seen from mars",
+      "--title", "testing no-expense flag", "--status", "in-prep",
+      "--notes", "this is a sample added presentation without expense data",
+      "--presentation-url", "http://drive.google.com/SEV356lll",
+      "--no_cal", "--no-expense"],
+     "2007na_test has been added in presentations\n"),
     (["helper", "l_progress", "-l", "ascopatz", "--date", "2022-01-09"],
      "\nProgress report for ascopatz, generated 2022-01-09\n"
      "*************************[Orphan Projecta]*************************\n"


### PR DESCRIPTION
Added --expense-db flag to a_presentation adder. If specified, it adds the expense item generated for the presentation to the specified database instead of the default one (first database in the regolithrc.json file)

closes #910.