### PR TITLE
WIP : add lead + remove projectum_id from milestone-updater required args

### DIFF
--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -26,6 +26,9 @@ def subparser(subpi):
     if isinstance(subpi, GooeyParser):
         date_kwargs['widget'] = 'DateChooser'
 
+    subpi.add_argument("lead",
+                       help="Specify the project lead of the prum "
+                            "by id, e.g., sbillinge")
     subpi.add_argument("projectum_id", help="The id of the projectum.  If you just "
                                             "specify this the program will return a "
                                             "numbered list of milestones to select for "


### PR DESCRIPTION
1. lead id has been added as a required argument for the milestone-updater.
2. before I change projectum_id from a required arg to an optional arg, we need a query function to iterate through all projecta ids associated with the lead. the query will return a dictionary or list of key value pairs that combines all projecta documents associated with the lead in the correct syntax (deals with line 120-121)
3. once a dictionary or list of key value pairs is assembled, lines 133-149 copy, identify and list the milestones

- regarding list item 2, this part of the code uses the `find_one` function which returns the first doc that has the projectum_id listed. this is fine when the projectum_id is the key, however, if the functions searches for the lead there will be multiple docs in the projecta collection associated with a lead id and it will only return the first key value match that it finds (only one doc will be returned). I spent some time trying to create code that identified all the projecta associated with a lead and that combined these projecta into a single dictionary. I have been unsuccessful so far. I think the solution is to create a new function like `find_one` but call it `find_many` that returns a dictionary of N zipped projecta dictionaries associated with the lead. this way, line 133-149 will not need to be modified.