### PR TITLE
u_milestonehelper.py: only one milestone uuid input allowed now.

### DIFF
--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -29,9 +29,7 @@ def subparser(subpi):
 
     subpi.add_argument("-i", "--milestone_uuid",
                        help="The uuid of a milestone. "
-                            "Takes a full or partial uuid. "
-                            "Multiple uuids may be entered.",
-                       nargs='+')
+                            "Takes a full or partial uuid.")
     subpi.add_argument("-p", "--projectum_id", help="The id of the projectum. If you "
                                             "opt for this the program will assume "
                                             "you are adding a new milestone "
@@ -105,8 +103,8 @@ class MilestoneUpdaterHelper(DbHelperBase):
         gtx["zip"] = zip
 
     def db_updater(self):
-        failure = False
         rc = self.rc
+        updated, zero, multiple = [],[],[]
         if rc.date:
             now = date_parser.parse(rc.date).date()
         else:
@@ -185,101 +183,109 @@ class MilestoneUpdaterHelper(DbHelperBase):
             rc.client.update_one(rc.database, rc.coll, {'_id': rc.projectum_id}, pdoc)
             print(f"{rc.projectum_id} has been updated in projecta")
         else:
-            for uuid in rc.milestone_uuid:
-                pdoc, upd_mil, all_miles, id = {},[],[],[]
-                target_mil = fragment_retrieval(self.gtx["projecta"], ["milestones"], uuid)
-                target_del = fragment_retrieval(self.gtx["projecta"], ["_id"], uuid)
-                target_ko = fragment_retrieval(self.gtx["projecta"], ["_id"], uuid[2:])
-                if target_mil and not target_del and not target_ko:
-                    for prum in target_mil:
-                        milestones = prum['milestones']
-                        for milestone in milestones:
-                            if milestone.get('uuid')[0:len(uuid)] == uuid:
-                                upd_mil.append(milestone)
-                            else:
-                                all_miles.append(milestone)
-                        if upd_mil:
-                            pid = prum.get('_id')
-                            id.append(pid)
-                if target_del:
-                    for prum in target_del:
-                        if prum.get('_id')[0:len(uuid)] == uuid:
-                            deliverable = prum['deliverable']
-                            upd_mil.append(deliverable)
-                        if upd_mil:
-                            pid = prum.get('_id')
-                            id.append(pid)
-                if target_ko and uuid[:2] == 'ko':
-                    for prum in target_ko:
-                        if prum.get('_id')[0:len(uuid)-2] == uuid[2:]:
-                            kickoff = prum['kickoff']
-                            upd_mil.append(kickoff)
-                        if upd_mil:
-                            pid = prum.get('_id')
-                            id.append(pid)
-                if len (upd_mil) == 0:
-                    print(f"No ids were found that match your entry ({uuid}).\n"
-                          "Make sure you have entered the correct uuid or uuid fragment and rerun the helper.")
-                    return
-                elif len(upd_mil) == 1:
-                    for dict in upd_mil:
-                        pdoc.update(dict)
-                    if not pdoc.get('type') and not rc.type and not target_del and not target_ko:
+            pdoc, upd_mil, all_miles, id = {},[],[],[]
+            target_mil = fragment_retrieval(self.gtx["projecta"], ["milestones"], rc.milestone_uuid)
+            target_del = fragment_retrieval(self.gtx["projecta"], ["_id"], rc.milestone_uuid)
+            target_ko = fragment_retrieval(self.gtx["projecta"], ["_id"], rc.milestone_uuid[2:])
+            if target_mil and not target_del and not target_ko:
+                for prum in target_mil:
+                    milestones = prum['milestones']
+                    for milestone in milestones:
+                        if milestone.get('uuid')[0:len(rc.milestone_uuid)] == rc.milestone_uuid:
+                            upd_mil.append(milestone)
+                        else:
+                            all_miles.append(milestone)
+                    if upd_mil:
+                        pid = prum.get('_id')
+                        id.append(pid)
+            if target_del:
+                for prum in target_del:
+                    if prum.get('_id')[0:len(rc.milestone_uuid)] == rc.milestone_uuid:
+                        deliverable = prum['deliverable']
+                        upd_mil.append(deliverable)
+                    if upd_mil:
+                        pid = prum.get('_id')
+                        id.append(pid)
+            if target_ko and rc.milestone_uuid[:2] == 'ko':
+                for prum in target_ko:
+                    if prum.get('_id')[0:len(rc.milestone_uuid)-2] == rc.milestone_uuid[2:]:
+                        kickoff = prum['kickoff']
+                        upd_mil.append(kickoff)
+                    if upd_mil:
+                        pid = prum.get('_id')
+                        id.append(pid)
+            if len (upd_mil) == 0:
+                zero.append(rc.milestone_uuid)
+            elif len(upd_mil) == 1:
+                for dict in upd_mil:
+                    pdoc.update(dict)
+                if not pdoc.get('type') and not rc.type and not target_del and not target_ko:
+                    raise ValueError(
+                        f"Milestone ({rc.milestone_uuid}) does not have a type set and this is required.\n"
+                        "Specify '--type' and rerun the helper to update this milestone.\n")
+                if rc.type:
+                    if rc.type in MILESTONE_TYPES:
+                        pdoc.update({'type': rc.type})
+                    else:
                         raise ValueError(
-                            f"Milestone ({uuid}) does not have a type set and this is required.\n"
-                            "Specify '--type' and rerun the helper to update this milestone.\n")
-                    if rc.type:
-                        if rc.type in MILESTONE_TYPES:
-                            pdoc.update({'type': rc.type})
-                        else:
-                            raise ValueError(
-                                "The type you have specified is not recognized. \n"
-                                "Please rerun your command adding '--type' \n"
-                                f"and giving a type from this list:\n{MILESTONE_TYPES}\n")
-                    for i in all_miles:
-                        i['due_date'] = get_due_date(i)
-                    if rc.finish:
-                        rc.status = "finished"
-                        pdoc.update({'end_date': now})
-                        if pdoc.get('notes'):
-                            notes = pdoc.get("notes", [])
-                            notes_with_closed_items = [note.replace('()', '(x)', 1) for note in notes]
-                            pdoc["notes"] = notes_with_closed_items
-                        if pdoc.get('name'):
-                            print(f"The milestone '{pdoc.get('name')}' has been marked as finished in prum {id[0]}.")
-                        else:
-                            name = 'deliverable'
-                            print(f"The milestone '{name}' has been marked as finished in prum {id[0]}.")
-                    if rc.audience:
-                        pdoc.update({'audience': rc.audience})
-                    if rc.due_date:
-                        pdoc.update({'due_date': rc.due_date})
-                    if rc.name and pdoc.get('name'):
-                        pdoc.update({'name': rc.name})
-                    elif rc.name and not pdoc.get('name'):
-                        print(f"Ignoring 'name' assignment for deliverable uuid ({uuid})")
-                    if rc.objective and pdoc.get('name'):
-                        pdoc.update({'objective': rc.objective})
-                    elif rc.objective and not pdoc.get('name'):
-                        print(f"Ignoring 'objective' assignment for deliverable uuid ({uuid})")
-                    if rc.status:
-                        pdoc.update({'status': rc.status})
-                    if rc.notes:
-                        pdoc.update({'notes': rc.notes})
-                    doc = {}
-                    pdoc['due_date'] = get_due_date(pdoc)
-                    all_miles.append(pdoc)
-                    all_miles.sort(key=lambda x: x['due_date'], reverse=False)
-                    if target_mil and not target_del and not target_ko:
-                        doc.update({'milestones': all_miles})
-                    if target_del:
-                        doc.update({'deliverable': pdoc})
-                    if target_ko and uuid[:2] == 'ko':
-                        doc.update({'kickoff': pdoc})
-                    rc.client.update_one(rc.database, rc.coll, {'_id': id[0]}, doc)
-                    if not rc.finish:
-                        print(f"The milestone uuid {uuid} in {id[0]} has been updated in projecta.")
-                else:
-                    print(f"Multiple ids match your entry ({uuid}).\n"
-                          "Try entering six or more characters of the uuid and rerunning the helper.")
+                            "The type you have specified is not recognized. \n"
+                            "Please rerun your command adding '--type' \n"
+                            f"and giving a type from this list:\n{MILESTONE_TYPES}\n")
+                for i in all_miles:
+                    i['due_date'] = get_due_date(i)
+                if rc.finish:
+                    rc.status = "finished"
+                    pdoc.update({'end_date': now})
+                    if pdoc.get('notes'):
+                        notes = pdoc.get("notes", [])
+                        notes_with_closed_items = [note.replace('()', '(x)', 1) for note in notes]
+                        pdoc["notes"] = notes_with_closed_items
+                    if pdoc.get('name'):
+                        updated.append(f"The milestone '{pdoc.get('name')}' has been marked as finished in prum {id[0]}.")
+                    else:
+                        name = 'deliverable'
+                        updated.append(f"The milestone '{name}' has been marked as finished in prum {id[0]}.")
+                if rc.audience:
+                    pdoc.update({'audience': rc.audience})
+                if rc.due_date:
+                    pdoc.update({'due_date': rc.due_date})
+                if rc.name and pdoc.get('name'):
+                    pdoc.update({'name': rc.name})
+                elif rc.name and not pdoc.get('name'):
+                    print(f"Ignoring 'name' assignment for deliverable uuid ({rc.milestone_uuid})")
+                if rc.objective and pdoc.get('name'):
+                    pdoc.update({'objective': rc.objective})
+                elif rc.objective and not pdoc.get('name'):
+                    print(f"Ignoring 'objective' assignment for deliverable uuid ({rc.milestone_uuid})")
+                if rc.status:
+                    pdoc.update({'status': rc.status})
+                if rc.notes:
+                    pdoc.update({'notes': rc.notes})
+                doc = {}
+                pdoc['due_date'] = get_due_date(pdoc)
+                all_miles.append(pdoc)
+                all_miles.sort(key=lambda x: x['due_date'], reverse=False)
+                if target_mil and not target_del and not target_ko:
+                    doc.update({'milestones': all_miles})
+                if target_del:
+                    doc.update({'deliverable': pdoc})
+                if target_ko and rc.milestone_uuid[:2] == 'ko':
+                    doc.update({'kickoff': pdoc})
+                rc.client.update_one(rc.database, rc.coll, {'_id': id[0]}, doc)
+                if not rc.finish:
+                    updated.append(f"The milestone uuid {rc.milestone_uuid} in {id[0]} has been updated in projecta.")
+            else:
+                multiple.append(rc.milestone_uuid)
+        if updated:
+            for msg in updated:
+                print(f"{msg}\n")
+        else:
+            print(f"Failed to update projecta.")
+        if zero:
+            print(f"No ids were found that match your milestone_uuid entry ({zero[0]}).\n"
+                    "Make sure you have entered the correct uuid or uuid fragment and rerun the helper.\n")
+        if multiple:
+            print(f"Multiple ids match your milestone_uuid entry ({multiple[0]}).\n"
+                  "Try entering six or more characters of the uuid and rerunning the helper.\n")
         return
+

--- a/tests/outputs/f_prum/projecta.yaml
+++ b/tests/outputs/f_prum/projecta.yaml
@@ -186,10 +186,8 @@ sb_firstprojectum:
     - pdirac
   deliverable:
     audience:
-      - lead
-      - pi
-      - group_members
-    due_date: 2020-06-01
+      - beginning grad in chemistry
+    due_date: '2021-05-05'
     success_def: audience is happy
     scope:
       - UCs that are supported or some other scope description if it is software
@@ -200,10 +198,8 @@ sb_firstprojectum:
       - steps that the audience will take to access and interact with the deliverable
       - not needed for paper submissions
     notes:
-      - do this
-      - do that
+      - deliverable note
     status: finished
-    type: meeting
   description: My first projectum
   end_date: 2020-07-01
   grants: SymPy-1.1
@@ -211,8 +207,8 @@ sb_firstprojectum:
     - ascopatz
   kickoff:
     date: '2020-05-05'
-    due_date: '2020-05-06'
-    end_date: '2020-05-07'
+    due_date: 2020-06-01
+    end_date: 2020-05-07
     name: Kick off meeting
     objective: introduce project to the lead
     audience:
@@ -220,12 +216,14 @@ sb_firstprojectum:
       - pi
       - group_members
     notes:
-      - kickoff note
+      - do this
+      - do that
     status: finished
+    type: meeting
   lead: ascopatz
   log_url: https://docs.google.com/document/d/1pQMFpuI
   milestones:
-    - due_date: 2020-05-20
+    - due_date: '2020-05-20'
       name: Project lead presentation
       notes:
         - do background reading
@@ -248,7 +246,7 @@ sb_firstprojectum:
           - url to slides describing the development, e.g. Google slides url
       uuid: milestone_uuid_sb1
       end_date: 2020-07-01
-    - due_date: 2020-06-01
+    - due_date: '2020-05-27'
       name: planning meeting
       objective: develop a detailed plan with dates
       audience:
@@ -256,11 +254,8 @@ sb_firstprojectum:
         - pi
         - group_members
       status: finished
-      type: meeting
+      type: mergedpr
       uuid: milestone_uuid_sb1_2
-      notes:
-        - do this
-        - do that
       end_date: 2020-07-01
   name: First Projectum
   other_urls:

--- a/tests/outputs/u_logurl/projecta.yaml
+++ b/tests/outputs/u_logurl/projecta.yaml
@@ -186,10 +186,8 @@ sb_firstprojectum:
     - pdirac
   deliverable:
     audience:
-      - lead
-      - pi
-      - group_members
-    due_date: 2020-06-01
+      - beginning grad in chemistry
+    due_date: '2021-05-05'
     success_def: audience is happy
     scope:
       - UCs that are supported or some other scope description if it is software
@@ -200,18 +198,16 @@ sb_firstprojectum:
       - steps that the audience will take to access and interact with the deliverable
       - not needed for paper submissions
     notes:
-      - do this
-      - do that
-    status: converged
-    type: meeting
+      - deliverable note
+    status: proposed
   description: My first projectum
   grants: SymPy-1.1
   group_members:
     - ascopatz
   kickoff:
     date: '2020-05-05'
-    due_date: '2020-05-06'
-    end_date: '2020-05-07'
+    due_date: 2020-06-01
+    end_date: 2020-05-07
     name: Kick off meeting
     objective: introduce project to the lead
     audience:
@@ -219,12 +215,14 @@ sb_firstprojectum:
       - pi
       - group_members
     notes:
-      - kickoff note
+      - do this
+      - do that
     status: finished
+    type: meeting
   lead: ascopatz
   log_url: https://docs.google.com/document/d/1pQMFpuI
   milestones:
-    - due_date: 2020-05-20
+    - due_date: '2020-05-20'
       name: Project lead presentation
       notes:
         - do background reading
@@ -246,19 +244,16 @@ sb_firstprojectum:
         slides_urls:
           - url to slides describing the development, e.g. Google slides url
       uuid: milestone_uuid_sb1
-    - due_date: 2020-06-01
+    - due_date: '2020-05-27'
       name: planning meeting
       objective: develop a detailed plan with dates
       audience:
         - lead
         - pi
         - group_members
-      status: converged
-      type: meeting
+      status: proposed
+      type: mergedpr
       uuid: milestone_uuid_sb1_2
-      notes:
-        - do this
-        - do that
   name: First Projectum
   other_urls:
     - https://docs.google.com/document/d/analysis

--- a/tests/outputs/u_milestone/projecta.yaml
+++ b/tests/outputs/u_milestone/projecta.yaml
@@ -186,10 +186,8 @@ sb_firstprojectum:
     - pdirac
   deliverable:
     audience:
-      - lead
-      - pi
-      - group_members
-    due_date: 2020-06-01
+      - beginning grad in chemistry
+    due_date: '2021-05-05'
     success_def: audience is happy
     scope:
       - UCs that are supported or some other scope description if it is software
@@ -200,18 +198,16 @@ sb_firstprojectum:
       - steps that the audience will take to access and interact with the deliverable
       - not needed for paper submissions
     notes:
-      - do this
-      - do that
-    status: converged
-    type: meeting
+      - deliverable note
+    status: proposed
   description: My first projectum
   grants: SymPy-1.1
   group_members:
     - ascopatz
   kickoff:
     date: '2020-05-05'
-    due_date: '2020-05-06'
-    end_date: '2020-05-07'
+    due_date: 2020-06-01
+    end_date: 2020-05-07
     name: Kick off meeting
     objective: introduce project to the lead
     audience:
@@ -219,12 +215,14 @@ sb_firstprojectum:
       - pi
       - group_members
     notes:
-      - kickoff note
+      - do this
+      - do that
     status: finished
+    type: meeting
   lead: ascopatz
   log_url: https://docs.google.com/document/d/1YC_wtW5Q
   milestones:
-    - due_date: 2020-05-20
+    - due_date: '2020-05-20'
       name: Project lead presentation
       notes:
         - do background reading
@@ -246,19 +244,16 @@ sb_firstprojectum:
         slides_urls:
           - url to slides describing the development, e.g. Google slides url
       uuid: milestone_uuid_sb1
-    - due_date: 2020-06-01
+    - due_date: '2020-05-27'
       name: planning meeting
       objective: develop a detailed plan with dates
       audience:
         - lead
         - pi
         - group_members
-      status: converged
-      type: meeting
+      status: proposed
+      type: mergedpr
       uuid: milestone_uuid_sb1_2
-      notes:
-        - do this
-        - do that
   name: First Projectum
   other_urls:
     - https://docs.google.com/document/d/analysis

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -476,28 +476,21 @@ helper_map = [
       "--group-members", "ascopatz", "--grants", "SymPy-1.1", "--due-date", "2021-01-01", '--notes', 'new note'],
      "ly_newprojectum has been added in projecta\n"
      ),
-    (["helper", "u_milestone", "--milestone_uuid", "milestone_uuid_sb1_", "sb_firstpro", "--name",
-      "planning meeting", "--objective", "develop a detailed plan with dates","--audience", "lead", "pi", "group_members",
-      "--status", "converged", "--due-date", "2020-06-01", "--notes", "do this", "do that", "--type", "meeting"],
-     "The milestone uuid milestone_uuid_sb1_ in sb_firstprojectum has been updated in projecta.\n"
-     "Ignoring 'name' assignment for deliverable uuid (sb_firstpro)\n"
-     "Ignoring 'objective' assignment for deliverable uuid (sb_firstpro)\n"
-     "The milestone uuid sb_firstpro in sb_firstprojectum has been updated in projecta.\n"
+    (["helper", "u_milestone", "--milestone_uuid", "kosb_fir", "--name", "Kick off meeting",
+      "--date", "2020-05-07", "--objective", "introduce project to the lead","--audience", "lead", "pi", "group_members",
+      "--status", "converged", "--due-date", "2020-06-01", "--notes", "do this", "do that", "--type", "meeting", "--finish"],
+     "The milestone 'Kick off meeting' has been marked as finished in prum sb_firstprojectum.\n\n"
     ),
-    #(["helper", "u_milestone", "--milestone_uuid", "milestone_uuid_pl2", "pl_secondpro", "kopl_second", "--finish",
-    #  "--type", "meeting"],
-    # "The milestone 'Milestone' has been marked as finished in prum pl_secondprojectum.\n"
-    # "The milestone 'deliverable' has been marked as finished in prum pl_secondprojectum.\n"
-    # "The milestone 'Kickoff' has been marked as finished in prum pl_secondprojectum.\n"
-    # ),
     (["helper", "u_milestone", "--milestone_uuid", "bad_id"],
-     "No ids were found that match your entry (bad_id).\n"
-     "Make sure you have entered the correct uuid or uuid fragment and rerun the helper.\n"
+     "Failed to update projecta.\n"
+     "No ids were found that match your milestone_uuid entry (bad_id).\n"
+     "Make sure you have entered the correct uuid or uuid fragment and rerun the helper.\n\n"
      ),
     (["helper", "u_milestone", "--milestone_uuid", "pl", "--status", "finished",
       "--due-date", "2023-01-01", "--notes", "do this", "do that", "--type", "mergedpr"],
-     "Multiple ids match your entry (pl).\n"
-     "Try entering six or more characters of the uuid and rerunning the helper.\n"
+     "Failed to update projecta.\n"
+     "Multiple ids match your milestone_uuid entry (pl).\n"
+     "Try entering six or more characters of the uuid and rerunning the helper.\n\n"
      ),
     (["helper", "u_milestone", "--projectum_id", "pl", "--name", "new milestone",
       "--due_date", "2023-01-01", "--objective", "do all the things to complete this milestone",


### PR DESCRIPTION
Removes loops for uuids. this has to be removed because the database is only updated after the code is executed...meaning only the last uuid entered would actually be updated. we do not want to confuse the use, so it is best to add the functionality to update multiple milestones later. success and fail messages have been added and their logic has been changed so that they are printed after a successful update or a failure. test helpers | output files : these were updated to test the the code that update a kickoff meeting and the --finish argument

closes #1009 