### PR TITLE
invert fast updater logic so only whitelisted updaters use the behavior.

### DIFF
--- a/news/fix_prop_adder.rst
+++ b/news/fix_prop_adder.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Order of CLI args in u_milestone for greater ease of use
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/regolith/commands.py
+++ b/regolith/commands.py
@@ -9,7 +9,7 @@ from pprint import pprint
 from regolith.builder import builder, BUILDERS
 from regolith.deploy import deploy as dploy
 from regolith.emailer import emailer
-from regolith.helper import HELPERS, helpr, UPDATER_HELPERS, UPDATER_WHITELIST
+from regolith.helper import HELPERS, helpr, UPDATER_HELPERS, FAST_UPDATER_WHITELIST
 from regolith.runcontrol import RunControl
 from regolith.tools import string_types
 
@@ -127,14 +127,14 @@ def build_db_check(rc):
 
 def helper_db_check(rc):
     """Checks which DBs a builder needs"""
-    # if the helper is an updater, only open the database from rc.database
-    rc.updater = False
+    # if the helper is an fast_updater, only open the database from rc.database
+    rc.fast_updater = False
     for helperkey in UPDATER_HELPERS.keys():
-        if helperkey == rc.helper_target and rc.helper_target not in UPDATER_WHITELIST:
-            rc.updater = True
+        if helperkey == rc.helper_target and rc.helper_target in FAST_UPDATER_WHITELIST:
+            rc.fast_updater = True
     if rc.database is None:
         rc.database = rc.databases[0]["name"]
-    if rc.updater:
+    if rc.fast_updater:
         rc.databases = [database for database in rc.databases
                         if database.get('name') == rc.database]
 

--- a/regolith/helper.py
+++ b/regolith/helper.py
@@ -74,9 +74,9 @@ LISTER_HELPERS = {
 
 HELPERS = copy(LISTER_HELPERS)
 HELPERS.update(UPDATER_HELPERS)
-# whitelisted updaters allow load of all the databases whilst updating to just
-# one of them.  Otherwise, the updater only connects to the one requsted db.
-UPDATER_WHITELIST = ["a_grppub_readlist"]
+# fast_updater updaters only connects to the one requested db, not to all dbs
+# in rc.databases which is the default behavior
+FAST_UPDATER_WHITELIST = ["u_milestone"]
 
 def helpr(btype, rc):
     """Returns helper of the appropriate type."""

--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -38,6 +38,13 @@ def subparser(subpi):
                        help="New due date of the milestone. "
                             "Required for a new milestone.",
                        **date_kwargs)
+    # Do not delete --database arg
+    subpi.add_argument("--database",
+                       help="The database that will be updated.  Defaults to "
+                            "first database in the regolithrc.json file.")
+    subpi.add_argument("-f", "--finish", action="store_true",
+                       help="Finish milestone. "
+                       )
     subpi.add_argument("-n", "--name",
                        help="Name of the milestone. "
                             "Required for a new milestone.")
@@ -61,13 +68,6 @@ def subparser(subpi):
                        nargs='+',
                        help="Any notes you want to add to the milestone."
                        )
-    subpi.add_argument("-f", "--finish", action="store_true",
-                       help="Finish milestone. "
-                       )
-    # Do not delete --database arg
-    subpi.add_argument("--database",
-                       help="The database that will be updated.  Defaults to "
-                            "first database in the regolithrc.json file.")
     subpi.add_argument("--date",
                        help="The date that will be used for testing.",
                        **date_kwargs
@@ -175,7 +175,7 @@ class MilestoneUpdaterHelper(DbHelperBase):
             new_mil.sort(key=lambda x: x['due_date'], reverse=False)
             pdoc.update({'milestones': new_mil})
             rc.client.update_one(rc.database, rc.coll, {'_id': rc.projectum_id}, pdoc)
-            print(f"{rc.projectum_id} has been updated in projecta")
+            updated.append(f"{rc.projectum_id} has been updated in projecta")
         else:
             pdoc, upd_mil, all_miles, id = {},[],[],[]
             target_mil = fragment_retrieval(self.gtx["projecta"], ["milestones"], rc.milestone_uuid)
@@ -272,7 +272,7 @@ class MilestoneUpdaterHelper(DbHelperBase):
                 multiple.append(rc.milestone_uuid)
         if updated:
             for msg in updated:
-                print(f"{msg}\n")
+                print(f"{msg}")
         else:
             print(f"Failed to update projecta.")
         if zero:

--- a/regolith/helpers/u_milestonehelper.py
+++ b/regolith/helpers/u_milestonehelper.py
@@ -280,6 +280,6 @@ class MilestoneUpdaterHelper(DbHelperBase):
                     "Make sure you have entered the correct uuid or uuid fragment and rerun the helper.\n")
         if multiple:
             print(f"Multiple ids match your milestone_uuid entry ({multiple[0]}).\n"
-                  "Try entering six or more characters of the uuid and rerunning the helper.\n")
+                  "Try entering more characters of the uuid and rerun the helper.\n")
         return
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -479,7 +479,7 @@ helper_map = [
     (["helper", "u_milestone", "--milestone_uuid", "kosb_fir", "--name", "Kick off meeting",
       "--date", "2020-05-07", "--objective", "introduce project to the lead","--audience", "lead", "pi", "group_members",
       "--status", "converged", "--due-date", "2020-06-01", "--notes", "do this", "do that", "--type", "meeting", "--finish"],
-     "The milestone 'Kick off meeting' has been marked as finished in prum sb_firstprojectum.\n\n"
+     "The milestone 'Kick off meeting' has been marked as finished in prum sb_firstprojectum.\n"
     ),
     (["helper", "u_milestone", "--milestone_uuid", "bad_id"],
      "Failed to update projecta.\n"
@@ -490,7 +490,7 @@ helper_map = [
       "--due-date", "2023-01-01", "--notes", "do this", "do that", "--type", "mergedpr"],
      "Failed to update projecta.\n"
      "Multiple ids match your milestone_uuid entry (pl).\n"
-     "Try entering six or more characters of the uuid and rerunning the helper.\n\n"
+     "Try entering more characters of the uuid and rerun the helper.\n\n"
      ),
     (["helper", "u_milestone", "--projectum_id", "pl", "--name", "new milestone",
       "--due_date", "2023-01-01", "--objective", "do all the things to complete this milestone",


### PR DESCRIPTION
Also, change order of command line args in u_milestone for greater ease of use