### PR TITLE
Configure non-reusable Python 3.11 Test on PR GitHub CI

### DIFF
--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Check out diffpy.labpdfproc repository
+      - name: Check out regolith repository
         uses: actions/checkout@v4
 
       - name: Initialize miniconda
@@ -38,14 +38,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
 
-      - name: Install diffpy.labpdfproc and requirements
+      - name: Install regolith and requirements
         run: |
           conda install --file requirements/test.txt
           pip install -r requirements/pip.txt
           python -m pip install . --no-deps
 
 
-      - name: Validate diffpy.labpdfproc
+      - name: Validate regolith
         run: |
           pytest --cov
           coverage report -m

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -3,16 +3,57 @@ name: Tests on PR
 on:
   push:
     branches:
+      - main
       - cookie
   pull_request:
   workflow_dispatch:
 
 jobs:
-  tests-on-pr:
-    uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
-    with:
-      project: regolith
-      c_extension: false
-      headless: false
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  validate:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out diffpy.labpdfproc repository
+        uses: actions/checkout@v4
+
+      - name: Initialize miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          auto-update-conda: true
+          environment-file: environment.yml
+          auto-activate-base: false
+          python-version: 3.11
+
+      - name: Conda config
+        run: >-
+          conda config --set always_yes yes
+          --set changeps1 no
+
+      - name: Install libgtk for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev
+
+      - name: Install diffpy.labpdfproc and requirements
+        run: |
+          conda install --file requirements/test.txt
+          pip install -r requirements/pip.txt
+          python -m pip install . --no-deps
+
+
+      - name: Validate diffpy.labpdfproc
+        run: |
+          pytest --cov
+          coverage report -m
+          codecov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Pytest CI passes:

<img width="479" alt="Screenshot 2024-11-26 at 3 26 20 PM" src="https://github.com/user-attachments/assets/528650e7-6bd4-4a6e-aa27-d6950ae8fce6">

This successfully builds wxPython from sdist like in labpdfproc. Hence, it will take 28 mins to build. 