### PR TITLE
Add build docs .yml on release and by workflow dispatch

### DIFF
--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -1,0 +1,16 @@
+name: Deploy Documentation on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    permissions:
+      contents: write
+    uses: Billingegroup/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
+    with:
+      project: regolith
+      c_extension: false
+      headless: false


### PR DESCRIPTION
Closes #https://github.com/regro/regolith/issues/1068 - make github workflow for building docs on merge to main

In our cookiecutting standard, we deploy docs when released., instead of when merged to main as the issue suggests.
