### PR TITLE
add news item

### DIFF
--- a/news/cookie-news.rst
+++ b/news/cookie-news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Repo structure modified to the new diffpy standard
+
+**Security:**
+
+* <news item>

--- a/news/cookie-news.rst
+++ b/news/cookie-news.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Repo structure modified to the new diffpy standard
+* Repo structure modified to the new diffpy (cookiecutter) standard
 
 **Security:**
 


### PR DESCRIPTION
fix #1214. I added `cookie-news.rst` to the `news/` folder per cookiecutting instruction. Let me know if we need anything else here!