### PR TITLE
ci: add run command to tests-on-pr.yml to run pip install gooey

### DIFF
--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -11,8 +11,6 @@ jobs:
       project: regolith
       c_extension: false
       headless: false
-      run: |
-        pip install gooey
-        echo "Done"
+      run: pip install gooey
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
#1210 can be closed when the ```migration``` branch is merged into ```main``` as we are now able to use our reusable script from ```scikit-package``` while pip installing ```gooey``` in this specific repository so tests in the CI can pass.