### PR TITLE
feat: extract multiple repos for given owner/orgs by running api command

### DIFF
--- a/news/gh-extractor-command.rst
+++ b/news/gh-extractor-command.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add command line utility to Github Repos metadata extractor to build `releaselist`
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/commands.py
+++ b/src/regolith/commands.py
@@ -7,7 +7,7 @@ import sys
 from copy import copy
 from pprint import pprint
 
-import yaml
+from ruamel.yaml import YAML
 
 from regolith import storage
 from regolith.builder import BUILDERS, builder
@@ -275,8 +275,12 @@ def ghextractor(rc):
     )
     yaml_dict = to_software_yaml(data)
     output = getattr(rc, "output", "software.yml")
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.allow_unicode = True
     with open(output, "w", encoding="utf-8") as f:
-        yaml.safe_dump(yaml_dict, f, sort_keys=False)
+        yaml.dump(yaml_dict, f)
     print(f"Wrote {output}")
 
 

--- a/src/regolith/commands.py
+++ b/src/regolith/commands.py
@@ -7,10 +7,13 @@ import sys
 from copy import copy
 from pprint import pprint
 
+import yaml
+
 from regolith import storage
 from regolith.builder import BUILDERS, builder
 from regolith.deploy import deploy as dploy
 from regolith.emailer import emailer
+from regolith.GHextractor import extract_github, to_software_yaml
 from regolith.helper import FAST_UPDATER_WHITELIST, HELPERS, UPDATER_HELPERS, helpr
 from regolith.runcontrol import RunControl
 from regolith.tools import string_types
@@ -258,12 +261,32 @@ def validate(rc):
         # sys.exit(f"Validation failed on some records")
 
 
+def ghextractor(rc):
+    """Extract GitHub repository metadata and write software YAML."""
+    owner = rc.owner
+    repo = getattr(rc, "repo", None)
+    all_repos = getattr(rc, "all", False)
+    token = getattr(rc, "token", None) or os.getenv("GITHUB_TOKEN")
+    data = extract_github(
+        owner,
+        repo=repo,
+        all_repos=all_repos,
+        token=token,
+    )
+    yaml_dict = to_software_yaml(data)
+    output = getattr(rc, "output", "software.yml")
+    with open(output, "w", encoding="utf-8") as f:
+        yaml.safe_dump(yaml_dict, f, sort_keys=False)
+    print(f"Wrote {output}")
+
+
 DISCONNECTED_COMMANDS = {
     "rc": lambda rc: print(rc._pformat()),
     "deploy": deploy,
     "store": storage.main,
     "json-to-yaml": json_to_yaml,
     "yaml-to-json": yaml_to_json,
+    "gh-extractor": ghextractor,
 }
 
 CONNECTED_COMMANDS = {

--- a/src/regolith/main.py
+++ b/src/regolith/main.py
@@ -254,6 +254,16 @@ def create_parser():
         default=None,
     )
 
+    # GitHub extractor subparser
+    ghe = subp.add_parser(
+        "gh-extractor",
+        help="Extract GitHub repository metadata and write software YAML",
+    )
+    ghe.add_argument("owner", help="GitHub owner or organization")
+    ghe.add_argument("--repo", help="Single repository name")
+    ghe.add_argument("--all", action="store_true", help="Extract all active repositories")
+    ghe.add_argument("--token", help="GitHub token (or set GITHUB_TOKEN)")
+
     # Validator
     val = subp.add_parser("validate", help="Validates db")
     val.add_argument(


### PR DESCRIPTION
@sbillinge Ready for review, note that for `releases` field I did not test as for my own repo I do not have any release. We might test this and if there is any formatting issue in `software.yml` generated, I could make edits on that. The other fields I have tested locally and it should be right. 

To use this, we first have the Github personal access token export on local. Then use the command `regolith gh-extractor <owner> --all` to extract all repos or `regolith gh-extractor <owner> <package-name>` for individual package. Then it would generate the `software.yml` for the packages. After that we use the original `regolith build releaselist` command to build the releaselist report. 