### PR TITLE
feat: add get_person_affiliation tool for canonical name and affiliation

### DIFF
--- a/news/person-affiliation.rst
+++ b/news/person-affiliation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``get_person_affiliation`` tool returning a person's canonical name and affiliation as a flat dict, with ``missing_fields`` and the ``MISSING_INFO`` placeholder for unresolved information
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -56,6 +56,9 @@ PRESENTATION_TYPES = alloweds.get("PRESENTATION_TYPES")
 PRESENTATION_STATI = alloweds.get("PRESENTATION_STATI")
 OPTIONAL_KEYS_INSTITUTIONS = alloweds.get("OPTIONAL_KEYS_INSTITUTIONS")
 
+# The placeholder written into an affiliation field that could not be resolved
+MISSING_INFO = "MISSING"
+
 
 def dbdirname(db, rc):
     """Gets the database dir name."""
@@ -1327,6 +1330,186 @@ def get_person_contact(name, people_coll, contacts_coll):
         return contacts_person
     else:
         return None
+
+
+def _latest_employment(employment, now=None):
+    """Return the current employment entry, or the most recently ended
+    one."""
+    if now is None:
+        now = date.today()
+    current, ended, undated = [], [], []
+    for entry in employment:
+        dates = get_dates(entry)
+        begin_date, end_date = dates.get("begin_date"), dates.get("end_date")
+        if begin_date is None:
+            # An entry with no parseable begin date can only be used as a last resort
+            undated.append(entry)
+        elif is_current(entry, now=now):
+            current.append((entry, begin_date))
+        else:
+            ended.append((entry, end_date or date.min))
+    if current:
+        return max(current, key=lambda pair: pair[1])[0]
+    if ended:
+        return max(ended, key=lambda pair: pair[1])[0]
+    if undated:
+        return undated[0]
+    return None
+
+
+def _resolve_department(department, institution):
+    """Return the canonical department name and id for a department
+    reference."""
+    if not department:
+        return {"department": MISSING_INFO, "department_id": MISSING_INFO}
+    departments = []
+    if institution is not None:
+        for department_id, entry in (institution.get("departments") or {}).items():
+            # Copy so that the institution document is not modified by adding the key as an _id
+            entry = dict(entry)
+            entry["_id"] = department_id
+            departments.append(entry)
+    match = fuzzy_retrieval(departments, ["name", "aka", "_id"], department, case_sensitive=False)
+    if match is None:
+        # The reference is all we know, so keep it but flag that it resolved to no department
+        return {"department": department, "department_id": MISSING_INFO}
+    return {
+        "department": match.get("name") or MISSING_INFO,
+        "department_id": match.get("_id") or MISSING_INFO,
+    }
+
+
+def _resolve_address(institution):
+    """Return the address fields of an institution document."""
+    if institution is None:
+        return {key: MISSING_INFO for key in ("street", "city", "state", "zip", "country")}
+    address = {}
+    for key in ("city", "country"):
+        address[key] = str(institution[key]) if institution.get(key) else MISSING_INFO
+    for key in ("street", "state", "zip"):
+        address[key] = str(institution[key]) if institution.get(key) else ""
+    return address
+
+
+def get_person_affiliation(name_or_id, people_coll, contacts_coll, institutions_coll, strict=True, now=None):
+    """Return a dict with a person's canonical name and affiliation.
+
+    The person is looked for in the people collection and, if not found
+    there, in the contacts collection.  Their affiliation is taken from
+    the current entry of their employment list, or from the most recently
+    ended entry if none is current.  Short-form people in contacts carry
+    their affiliation directly in their institution and department
+    fields.  The institution and department references are resolved
+    against the institutions collection, and may each be given as an
+    _id, a canonical name or an aka.
+
+    Parameters
+    ----------
+    name_or_id: str
+        The name, aka or id of the person to look for.  The match is not case sensitive
+    people_coll: collection (list of dicts)
+        The people collection
+    contacts_coll: collection (list of dicts)
+        The contacts collection
+    institutions_coll: collection (list of dicts)
+        The institutions collection
+    strict: bool
+        The switch controlling what happens when a field cannot be resolved.  When true a
+        ValueError naming every unresolved field is raised.  When false the unresolved
+        fields are filled with the MISSING_INFO placeholder.  Default is True
+    now: datetime.date object
+        The date to treat as today when deciding which employment entry is current.  If it
+        is None the current date is used.  Default is None
+
+    Returns
+    -------
+    affiliation: dict
+        The canonical name under "name", the affiliation under "department" and
+        "institution", the institution address under "street", "city", "state", "zip" and
+        "country", and the resolved database keys under "institution_id" and
+        "department_id".  Fields that could not be resolved hold MISSING_INFO.  The street,
+        state and zip fields are optional in the institutions schema, so for a resolved
+        institution that simply does not record them they hold an empty string rather than
+        MISSING_INFO
+
+    Raises
+    ------
+    ValueError
+        If the person is not found in either collection, whatever the value of strict, or
+        if strict is true and any affiliation field could not be resolved
+    """
+    person = get_person_contact(name_or_id, people_coll, contacts_coll)
+    if person is None:
+        raise ValueError(
+            f"Person '{name_or_id}' was not found in the people or contacts collections. "
+            f"Please add an entry for them, or add '{name_or_id}' to the aka list of their "
+            "existing entry."
+        )
+    employment = person.get("employment") or []
+    employment_entry = _latest_employment(employment, now=now)
+    if employment_entry is not None:
+        organization = employment_entry.get("organization") or employment_entry.get("institution")
+        department = employment_entry.get("department")
+    else:
+        organization = person.get("institution") or person.get("organization")
+        department = person.get("department")
+    institution = None
+    if organization:
+        institution = fuzzy_retrieval(
+            list(institutions_coll),
+            ["name", "aka", "_id"],
+            organization,
+            case_sensitive=False,
+        )
+    if institution is not None:
+        institution_name = institution.get("name") or MISSING_INFO
+        institution_id = institution.get("_id") or MISSING_INFO
+    elif organization:
+        # The organization is not in the institutions collection, so its name is all we know
+        institution_name, institution_id = organization, MISSING_INFO
+    else:
+        institution_name, institution_id = MISSING_INFO, MISSING_INFO
+    department_info = _resolve_department(department, institution)
+    address = _resolve_address(institution)
+    affiliation = {
+        "name": person.get("name") or MISSING_INFO,
+        "department": department_info["department"],
+        "institution": institution_name,
+        "street": address["street"],
+        "city": address["city"],
+        "state": address["state"],
+        "zip": address["zip"],
+        "country": address["country"],
+        "institution_id": institution_id,
+        "department_id": department_info["department_id"],
+    }
+    if strict:
+        unresolved = missing_fields(affiliation)
+        if unresolved:
+            raise ValueError(
+                f"The following affiliation information for '{affiliation['name']}' could not be "
+                f"resolved: {', '.join(unresolved)}. Please add the missing information to the "
+                "people, contacts or institutions collections, or call get_person_affiliation with "
+                "strict=False to receive placeholders instead."
+            )
+    return affiliation
+
+
+def missing_fields(affiliation):
+    """Return the list of affiliation fields that could not be resolved.
+
+    Parameters
+    ----------
+    affiliation: dict
+        The affiliation returned by get_person_affiliation
+
+    Returns
+    -------
+    fields: list of str
+        The keys whose value is the MISSING_INFO placeholder, in the order they appear in
+        the affiliation.  An empty list means every field was resolved
+    """
+    return [key for key, value in affiliation.items() if value == MISSING_INFO]
 
 
 def merge_collections_intersect(a, b, target_id):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,6 +7,7 @@ import requests_mock
 
 from regolith.runcontrol import DEFAULT_RC
 from regolith.tools import (
+    MISSING_INFO,
     awards_grants_honors,
     collect_appts,
     collection_str,
@@ -24,6 +25,7 @@ from regolith.tools import (
     get_appointments,
     get_formatted_crossref_reference,
     get_id_from_name,
+    get_person_affiliation,
     get_person_contact,
     get_tags,
     get_target_repo_info,
@@ -39,6 +41,7 @@ from regolith.tools import (
     merge_collections_all,
     merge_collections_intersect,
     merge_collections_superior,
+    missing_fields,
     month_and_year,
     number_suffix,
     remove_duplicate_docs,
@@ -3495,3 +3498,312 @@ def test_strip_string(tstr):
     expected = tstr[1]
     actual = strip_str(tstr[0])
     assert expected == actual
+
+
+AFFILIATION_INSTITUTIONS = [
+    {
+        "_id": "columbiau",
+        "aka": ["Columbia University", "Columbia"],
+        "name": "Columbia University",
+        "street": "500 W 120th St",
+        "city": "New York",
+        "state": "NY",
+        "zip": "10027",
+        "country": "USA",
+        "departments": {
+            "physics": {"name": "Department of Physics", "aka": ["Dept. of Physics", "Physics"]},
+            "apam": {"name": "Department of Applied Physics and Applied Mathematics", "aka": ["APAM"]},
+        },
+    },
+    {
+        # An overseas institution, which records no state or zip
+        "_id": "cambridge",
+        "aka": ["Cambridge"],
+        "name": "University of Cambridge",
+        "city": "Cambridge",
+        "country": "UK",
+        "departments": {"physics": {"name": "Cavendish Laboratory", "aka": ["Cavendish"]}},
+    },
+]
+
+AFFILIATION_PEOPLE = [
+    {
+        # A person whose current employment is the second entry in the list
+        "_id": "aeinstein",
+        "name": "Albert Einstein",
+        "aka": ["A. Einstein", "Einstein"],
+        "employment": [
+            {
+                "begin_date": "2010-01-01",
+                "end_date": "2014-12-31",
+                "organization": "cambridge",
+                "department": "physics",
+                "position": "post-doctoral scholar",
+            },
+            {
+                "begin_date": "2015-01-01",
+                "organization": "Columbia University",
+                "department": "APAM",
+                "position": "professor",
+            },
+        ],
+    },
+    {
+        # A person with no current employment, whose latest entry ended most recently
+        "_id": "mcurie",
+        "name": "Marie Curie",
+        "aka": ["M. Curie"],
+        "employment": [
+            {
+                "begin_year": 2001,
+                "end_year": 2004,
+                "organization": "cambridge",
+                "department": "Cavendish",
+                "position": "research scientist",
+            },
+            {
+                "begin_year": 2005,
+                "end_year": 2009,
+                "organization": "columbiau",
+                "department": "Dept. of Physics",
+                "position": "professor",
+            },
+        ],
+    },
+    {
+        # A person employed by an organization that is not in the institutions collection
+        "_id": "pdirac",
+        "name": "Paul Dirac",
+        "employment": [
+            {"begin_year": 2015, "organization": "Miskatonic University", "position": "professor"},
+        ],
+    },
+    {
+        # A person whose employment records no department
+        "_id": "rfeynman",
+        "name": "Richard Feynman",
+        "employment": [{"begin_year": 2015, "organization": "columbiau", "position": "professor"}],
+    },
+    {
+        # A person with no employment at all
+        "_id": "nemo",
+        "name": "Captain Nemo",
+    },
+]
+
+AFFILIATION_CONTACTS = [
+    {
+        "_id": "afriend",
+        "name": "Anthony B Friend",
+        "aka": ["A. B. Friend", "Tony Friend"],
+        "institution": "columbiau",
+        "department": "physics",
+    },
+    {
+        # A short-form person at the overseas institution, referred to by aka
+        "_id": "bfriend",
+        "name": "Bernice Friend",
+        "institution": "Cambridge",
+        "department": "Cavendish Laboratory",
+    },
+]
+
+COLUMBIA_PHYSICS_AFFILIATION = {
+    "name": "Anthony B Friend",
+    "department": "Department of Physics",
+    "institution": "Columbia University",
+    "street": "500 W 120th St",
+    "city": "New York",
+    "state": "NY",
+    "zip": "10027",
+    "country": "USA",
+    "institution_id": "columbiau",
+    "department_id": "physics",
+}
+
+
+@pytest.mark.parametrize(
+    "name_or_id, expected_affiliation",
+    [
+        # Test that a person is found and their affiliation resolved from either collection
+        # C1: A person in people whose second employment entry is current, expect the current one
+        (
+            "aeinstein",
+            {
+                "name": "Albert Einstein",
+                "department": "Department of Applied Physics and Applied Mathematics",
+                "institution": "Columbia University",
+                "street": "500 W 120th St",
+                "city": "New York",
+                "state": "NY",
+                "zip": "10027",
+                "country": "USA",
+                "institution_id": "columbiau",
+                "department_id": "apam",
+            },
+        ),
+        # C2: A person found only in contacts, expect their institution and department fields used
+        ("afriend", COLUMBIA_PHYSICS_AFFILIATION),
+        # C3: A person looked up by name, aka and mixed case, expect the same person each time
+        # 1. Canonical name
+        ("Anthony B Friend", COLUMBIA_PHYSICS_AFFILIATION),
+        # 2. An aka
+        ("Tony Friend", COLUMBIA_PHYSICS_AFFILIATION),
+        # 3. An id in the wrong case
+        ("AFriend", COLUMBIA_PHYSICS_AFFILIATION),
+        # C4: A person with no current employment, expect the entry that ended most recently
+        (
+            "mcurie",
+            {
+                "name": "Marie Curie",
+                "department": "Department of Physics",
+                "institution": "Columbia University",
+                "street": "500 W 120th St",
+                "city": "New York",
+                "state": "NY",
+                "zip": "10027",
+                "country": "USA",
+                "institution_id": "columbiau",
+                "department_id": "physics",
+            },
+        ),
+        # C5: An institution that records no state or zip, expect empty strings for those
+        (
+            "bfriend",
+            {
+                "name": "Bernice Friend",
+                "department": "Cavendish Laboratory",
+                "institution": "University of Cambridge",
+                "street": "",
+                "city": "Cambridge",
+                "state": "",
+                "zip": "",
+                "country": "UK",
+                "institution_id": "cambridge",
+                "department_id": "physics",
+            },
+        ),
+    ],
+)
+def test_get_person_affiliation(name_or_id, expected_affiliation):
+    actual = get_person_affiliation(name_or_id, AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS)
+    assert actual == expected_affiliation
+
+
+@pytest.mark.parametrize(
+    "name_or_id, expected_affiliation, expected_missing",
+    [
+        # Test that unresolvable fields become placeholders when strict is false
+        # C1: An organization absent from institutions, expect its name kept but no id or address
+        (
+            "pdirac",
+            {
+                "name": "Paul Dirac",
+                "department": MISSING_INFO,
+                "institution": "Miskatonic University",
+                "street": MISSING_INFO,
+                "city": MISSING_INFO,
+                "state": MISSING_INFO,
+                "zip": MISSING_INFO,
+                "country": MISSING_INFO,
+                "institution_id": MISSING_INFO,
+                "department_id": MISSING_INFO,
+            },
+            ["department", "street", "city", "state", "zip", "country", "institution_id", "department_id"],
+        ),
+        # C2: Employment recording no department, expect only the department fields missing
+        (
+            "rfeynman",
+            {
+                "name": "Richard Feynman",
+                "department": MISSING_INFO,
+                "institution": "Columbia University",
+                "street": "500 W 120th St",
+                "city": "New York",
+                "state": "NY",
+                "zip": "10027",
+                "country": "USA",
+                "institution_id": "columbiau",
+                "department_id": MISSING_INFO,
+            },
+            ["department", "department_id"],
+        ),
+        # C3: A person with no employment at all, expect every affiliation field missing
+        (
+            "nemo",
+            {
+                "name": "Captain Nemo",
+                "department": MISSING_INFO,
+                "institution": MISSING_INFO,
+                "street": MISSING_INFO,
+                "city": MISSING_INFO,
+                "state": MISSING_INFO,
+                "zip": MISSING_INFO,
+                "country": MISSING_INFO,
+                "institution_id": MISSING_INFO,
+                "department_id": MISSING_INFO,
+            },
+            [
+                "department",
+                "institution",
+                "street",
+                "city",
+                "state",
+                "zip",
+                "country",
+                "institution_id",
+                "department_id",
+            ],
+        ),
+    ],
+)
+def test_get_person_affiliation_not_strict(name_or_id, expected_affiliation, expected_missing):
+    actual = get_person_affiliation(
+        name_or_id, AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS, strict=False
+    )
+    assert actual == expected_affiliation
+    assert missing_fields(actual) == expected_missing
+
+
+@pytest.mark.parametrize(
+    "name_or_id, strict, expected_error",
+    [
+        # Test that missing information raises rather than building a partial affiliation
+        # C1: An unresolvable field with strict true, expect every unresolved field named
+        ("rfeynman", True, "could not be resolved: department, department_id"),
+        # C2: An organization absent from institutions with strict true, expect the address named
+        ("pdirac", True, "could not be resolved: department, street, city"),
+        # C3: A person absent from both collections, expect a raise whatever the value of strict
+        # 1. With strict true
+        ("Nobody McGhost", True, "was not found in the people or contacts collections"),
+        # 2. With strict false, because a wrong name cannot be papered over with a placeholder
+        ("Nobody McGhost", False, "was not found in the people or contacts collections"),
+    ],
+)
+def test_get_person_affiliation_raises(name_or_id, strict, expected_error):
+    with pytest.raises(ValueError) as excinfo:
+        get_person_affiliation(
+            name_or_id, AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS, strict=strict
+        )
+    assert expected_error in str(excinfo.value)
+
+
+def test_get_person_affiliation_now():
+    # Test that the now argument decides which employment entry counts as current
+    expected_department = "Cavendish Laboratory"
+    actual = get_person_affiliation(
+        "aeinstein",
+        AFFILIATION_PEOPLE,
+        AFFILIATION_CONTACTS,
+        AFFILIATION_INSTITUTIONS,
+        now=dt.date(2012, 6, 1),
+    )
+    assert actual["department"] == expected_department
+    assert actual["institution"] == "University of Cambridge"
+
+
+def test_get_person_affiliation_does_not_mutate():
+    # Test that resolving a department leaves the institutions collection unchanged
+    expected_institutions = copy.deepcopy(AFFILIATION_INSTITUTIONS)
+    get_person_affiliation("afriend", AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS)
+    assert AFFILIATION_INSTITUTIONS == expected_institutions


### PR DESCRIPTION
Add get_person_affiliation to tools.py, which returns a flat dict holding a person's canonical name, department, institution and institution address, for use in presentations and manuscripts.

The person is looked up in the people collection and falls back to contacts. Their affiliation is taken from the current entry of their employment list, or from the most recently ended entry if none is current. Institution and department references are resolved against the institutions collection whether they are given as an _id, a canonical name or an aka.

By default any field that cannot be resolved raises a ValueError naming every unresolved field, so that documents are not built with incorrect affiliation information. Passing strict=False fills those fields with the MISSING_INFO placeholder instead, which the new missing_fields helper reports. The street, state and zip fields are optional in the institutions schema, so for a resolved institution that does not record them they hold an empty string rather than the placeholder.