### PR TITLE
test: select the Agg matplotlib backend in tests/conftest.py

### DIFF
--- a/news/tests-mpl-agg-backend.rst
+++ b/news/tests-mpl-agg-backend.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Tests no longer load an interactive matplotlib backend, so the suite passes
+  locally without setting ``MPLBACKEND=Agg`` by hand.
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
 
+import matplotlib
 import pytest
 from pymongo import MongoClient
 from pymongo import errors as mongo_errors
@@ -15,6 +16,12 @@ from xonsh.api.os import rmtree
 
 from regolith.fsclient import dump_yaml
 from regolith.schemas import EXEMPLARS
+
+# Select a non-interactive backend before any helper imports pyplot, so that the
+# interactive backends are never loaded during the tests.  The Tk backend reads
+# uuid.uuid4().hex when it is imported, which fails in the tests that patch
+# uuid.uuid4 globally, and no test needs a display.
+matplotlib.use("Agg")
 
 OUTPUT_FAKE_DB = False  # always turn it to false after you used it
 # Currently the first two must be named test solely to match the helper map test output text


### PR DESCRIPTION
Call matplotlib.use("Agg") in tests/conftest.py so that no interactive backend is loaded while the tests run.

tests/test_helpers.py::test_helper_python patches uuid.uuid4 globally with mocker.patch. Inside that window the helpers import matplotlib.pyplot, which on a machine that has Tk resolves to the Tk backend, and _backend_tk reads uuid.uuid4().hex at module level. That raised AttributeError: 'str' object has no attribute 'hex' in the hm0, hm1, hm85 and hm86 cases. CI never saw it because CI has no Tk and so already fell back to Agg, and locally it needed MPLBACKEND=Agg in the environment to work around.

No test needs a display, so pinning the backend in conftest fixes the four failures at their source.