### PR TITLE
feat: add format_affiliation to render an affiliation as one line

### DIFF
--- a/news/format-affiliation.rst
+++ b/news/format-affiliation.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* ``format_affiliation`` in ``tools.py``, which renders the affiliation returned by
+  ``get_person_affiliation`` as one line of text in a full, short or institution style.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -1512,6 +1512,64 @@ def missing_fields(affiliation):
     return [key for key, value in affiliation.items() if value == MISSING_INFO]
 
 
+AFFILIATION_STYLES = ("full", "short", "institution")
+
+
+def _is_present(value):
+    """Return true if an affiliation field holds usable text."""
+    return bool(value) and value != MISSING_INFO
+
+
+def format_affiliation(affiliation, style="full"):
+    """Return a person's affiliation as a single line of text.
+
+    The fields are joined by ", ".  Three styles are available.  The full style gives the department,
+    the institution and its address, as wanted on a manuscript.  The
+    short style gives the department and the institution, and the
+    institution style gives the institution alone, as wanted on a
+    presentation slide.  Fields that are empty, and fields that hold the
+    MISSING_INFO placeholder because get_person_affiliation was called
+    with strict=False, are left out rather than being written into the
+    line, so pass the affiliation through missing_fields first if an
+    incomplete line would be a problem.
+
+    Parameters
+    ----------
+    affiliation: dict
+        The affiliation returned by get_person_affiliation
+    style: str
+        The style of the line to build, one of "full", "short" or "institution".  Default
+        is "full"
+
+    Returns
+    -------
+    line: str
+        The affiliation fields for the style, in order, joined by ", ".  The state and the
+        zip are joined to each other by a space.  It is empty if the style has no field
+        that holds usable text
+
+    Raises
+    ------
+    ValueError
+        If the style is not one of the recognized styles
+    """
+    if style not in AFFILIATION_STYLES:
+        raise ValueError(
+            f"'{style}' is not a recognized affiliation style. Please pass one of "
+            f"{', '.join(AFFILIATION_STYLES)}."
+        )
+    parts = []
+    if style in ("full", "short"):
+        parts.append(affiliation.get("department"))
+    parts.append(affiliation.get("institution"))
+    if style == "full":
+        state_zip = " ".join(
+            field for field in (affiliation.get("state"), affiliation.get("zip")) if _is_present(field)
+        )
+        parts.extend([affiliation.get("street"), affiliation.get("city"), state_zip, affiliation.get("country")])
+    return ", ".join(part for part in parts if _is_present(part))
+
+
 def merge_collections_intersect(a, b, target_id):
     """Merge two collections such that just the intersection is
     returned.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,6 +20,7 @@ from regolith.tools import (
     filter_presentations,
     filter_publications,
     filter_software,
+    format_affiliation,
     fragment_retrieval,
     fuzzy_retrieval,
     get_appointments,
@@ -3807,3 +3808,87 @@ def test_get_person_affiliation_does_not_mutate():
     expected_institutions = copy.deepcopy(AFFILIATION_INSTITUTIONS)
     get_person_affiliation("afriend", AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS)
     assert AFFILIATION_INSTITUTIONS == expected_institutions
+
+
+CAMBRIDGE_AFFILIATION = {
+    "name": "Bernice Friend",
+    "department": "Cavendish Laboratory",
+    "institution": "University of Cambridge",
+    "street": "",
+    "city": "Cambridge",
+    "state": "",
+    "zip": "",
+    "country": "UK",
+    "institution_id": "cambridge",
+    "department_id": "physics",
+}
+
+
+@pytest.mark.parametrize(
+    "affiliation, style, expected_line",
+    [
+        # Test that each style selects the right fields of a fully resolved affiliation
+        (
+            # C1: A complete affiliation with the default style, expect department, institution
+            # and full address
+            COLUMBIA_PHYSICS_AFFILIATION,
+            "full",
+            "Department of Physics, Columbia University, 500 W 120th St, New York, NY 10027, USA",
+        ),
+        (
+            # C2: A complete affiliation with the short style, expect department and institution only
+            COLUMBIA_PHYSICS_AFFILIATION,
+            "short",
+            "Department of Physics, Columbia University",
+        ),
+        (
+            # C3: A complete affiliation with the institution style, expect the institution alone
+            COLUMBIA_PHYSICS_AFFILIATION,
+            "institution",
+            "Columbia University",
+        ),
+        (
+            # C4: An institution that records no street, state or zip, expect those fields left out
+            # with no doubled or trailing commas
+            CAMBRIDGE_AFFILIATION,
+            "full",
+            "Cavendish Laboratory, University of Cambridge, Cambridge, UK",
+        ),
+        (
+            # C5: A state with no zip, expect the state alone rather than a trailing space
+            {**COLUMBIA_PHYSICS_AFFILIATION, "zip": ""},
+            "full",
+            "Department of Physics, Columbia University, 500 W 120th St, New York, NY, USA",
+        ),
+        (
+            # C6: Fields left as placeholders by strict=False, expect them left out
+            {**COLUMBIA_PHYSICS_AFFILIATION, "department": MISSING_INFO, "country": MISSING_INFO},
+            "full",
+            "Columbia University, 500 W 120th St, New York, NY 10027",
+        ),
+        (
+            # C7: A style whose every field is a placeholder, expect an empty line
+            {**COLUMBIA_PHYSICS_AFFILIATION, "institution": MISSING_INFO},
+            "institution",
+            "",
+        ),
+    ],
+)
+def test_format_affiliation(affiliation, style, expected_line):
+    actual = format_affiliation(affiliation, style=style)
+    assert actual == expected_line
+
+
+def test_format_affiliation_bad_style():
+    # Test that an unrecognized style is rejected and the valid styles are named
+    with pytest.raises(ValueError) as excinfo:
+        format_affiliation(COLUMBIA_PHYSICS_AFFILIATION, style="address")
+    assert "'address' is not a recognized affiliation style" in str(excinfo.value)
+    assert "full, short, institution" in str(excinfo.value)
+
+
+def test_format_affiliation_does_not_mutate():
+    # Test that building a line leaves the affiliation unchanged
+    expected_affiliation = copy.deepcopy(COLUMBIA_PHYSICS_AFFILIATION)
+    format_affiliation(COLUMBIA_PHYSICS_AFFILIATION)
+    assert COLUMBIA_PHYSICS_AFFILIATION == expected_affiliation


### PR DESCRIPTION
Add format_affiliation to tools.py, which turns the flat dict returned by get_person_affiliation into a single comma separated line, and the AFFILIATION_STYLES constant naming the styles it accepts.

Three styles are provided. The full style gives the department, the institution and its address, as wanted on a manuscript. The short style gives the department and the institution, and the institution style gives the institution alone, as wanted on a presentation slide.

Fields that are empty, and fields holding the MISSING_INFO placeholder left by get_person_affiliation(strict=False), are dropped rather than written into the line, so an institution that records no street, state or zip does not produce doubled or trailing commas. An unrecognized style raises a ValueError naming the styles that are accepted.

The formatter takes the affiliation dict rather than a person and the collections, so that formatting stays testable without a database. It was deferred from the get_person_affiliation PR (#1282).