### PR TITLE
feat: add talks and slides schemas and exemplars

### DIFF
--- a/news/talks-slides-schemas.rst
+++ b/news/talks-slides-schemas.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* ``talks`` and ``slides`` schemas and exemplars, describing reusable talks assembled
+  from decks of slides, together with the ``SLIDE_TYPES`` allowed list.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/exemplars.json
+++ b/src/regolith/exemplars.json
@@ -2177,6 +2177,37 @@
             "year": 2020
         }
     ],
+    "slides": {
+        "_id": "example-introduction",
+        "name": "introduction",
+        "tags": ["introduction", "overview"],
+        "slides": [
+            {
+                "type": "text",
+                "title": "What is local structure?",
+                "intro": "Three ideas underpin the rest of the talk.",
+                "bullets": ["crystals are described by an average structure", "real materials deviate from that average", "those deviations control the properties"],
+                "outro": "We will return to each of these.",
+                "shrink": false
+            },
+            {
+                "type": "imageleft-2col",
+                "title": "The nanostructure problem",
+                "image": "example_nanoparticle",
+                "caption": "A nanoparticle with a disordered surface.",
+                "fig_width": 0.9,
+                "fig_rotation": 0,
+                "imagecol_width": 0.5,
+                "bullets": ["the surface is not the same as the core"],
+                "shrink": false,
+                "paper": {
+                    "doi": "10.1107/S002188981000988X",
+                    "avatars": ["aexample"],
+                    "render": true
+                }
+            }
+        ]
+    },
     "students": {
         "_id": "Human A. Person",
         "aka": ["H. A. Person"],
@@ -2272,6 +2303,37 @@
             ]
         }
     ],
+    "talks": {
+        "_id": "2406ab_example_talk",
+        "active": true,
+        "talk_description": "An overview of the group's work on nanostructure, for a general audience.",
+        "learning_objectives": ["what a pair distribution function is", "why local structure matters for nanomaterials"],
+        "authorlist": ["A. B. Example", "C. D. Sample"],
+        "addresses": ["Department of Physics, Example University, New York, NY 10027, USA", "Department of Chemistry, Sample University, Boston, MA 02115, USA"],
+        "presenter": "aexample",
+        "presentationid": "2406ab_example_meeting",
+        "year": 2024,
+        "notes": ["the audience asked about sample preparation"],
+        "topics": [
+            {
+                "topic": "example-introduction",
+                "slide_list": "[:]"
+            },
+            {
+                "supertopic": "Local structure of materials",
+                "topics": [
+                    {
+                        "topic": "example-introduction",
+                        "slide_list": "[0]"
+                    },
+                    {
+                        "topic": "example-methods",
+                        "slide_list": "[1:3]"
+                    }
+                ]
+            }
+        ]
+    },
     "todos": [
         {"_id": "ascopatz"},
         {

--- a/src/regolith/exemplars.json
+++ b/src/regolith/exemplars.json
@@ -2177,37 +2177,74 @@
             "year": 2020
         }
     ],
-    "slides": {
-        "_id": "example-introduction",
-        "name": "introduction",
-        "tags": ["introduction", "overview"],
-        "slides": [
-            {
-                "type": "text",
-                "title": "What is local structure?",
-                "intro": "Three ideas underpin the rest of the talk.",
-                "bullets": ["crystals are described by an average structure", "real materials deviate from that average", "those deviations control the properties"],
-                "outro": "We will return to each of these.",
-                "shrink": false
-            },
-            {
-                "type": "imageleft-2col",
-                "title": "The nanostructure problem",
-                "image": "example_nanoparticle",
-                "caption": "A nanoparticle with a disordered surface.",
-                "fig_width": 0.9,
-                "fig_rotation": 0,
-                "imagecol_width": 0.5,
-                "bullets": ["the surface is not the same as the core"],
-                "shrink": false,
-                "paper": {
-                    "doi": "10.1107/S002188981000988X",
-                    "avatars": ["aexample"],
-                    "render": true
+    "slides": [
+        {
+            "_id": "example-introduction",
+            "name": "introduction",
+            "tags": ["introduction", "overview"],
+            "slides": [
+                {
+                    "type": "text",
+                    "title": "What is local structure?",
+                    "intro": "Three ideas underpin the rest of the talk.",
+                    "bullets": ["crystals are described by an average structure", "real materials deviate from that average", "those deviations control the properties"],
+                    "outro": "We will return to each of these.",
+                    "shrink": false
+                },
+                {
+                    "type": "imageleft-2col",
+                    "title": "The nanostructure problem",
+                    "image": "example_nanoparticle",
+                    "caption": "A nanoparticle with a disordered surface.",
+                    "fig_width": 0.9,
+                    "fig_rotation": 0,
+                    "imagecol_width": 0.5,
+                    "bullets": ["the surface is not the same as the core"],
+                    "shrink": false,
+                    "paper": {
+                        "doi": "10.1107/S002188981000988X",
+                        "avatars": ["sbillinge"],
+                        "render": true
+                    }
                 }
-            }
-        ]
-    },
+            ]
+        },
+        {
+            "_id": "example-methods",
+            "name": "methods",
+            "tags": ["methods"],
+            "slides": [
+                {
+                    "type": "image",
+                    "title": "Measuring a pair distribution function",
+                    "image": "example_diffractometer",
+                    "caption": "The diffractometer used to collect the data.",
+                    "fig_width": 0.8,
+                    "fig_rotation": 0,
+                    "shrink": false
+                },
+                {
+                    "type": "imageright-2col",
+                    "title": "From diffraction pattern to PDF",
+                    "image": "example_transform",
+                    "caption": "The Fourier transform of the total scattering structure function.",
+                    "fig_width": 0.9,
+                    "fig_rotation": 0,
+                    "imagecol_width": 0.4,
+                    "intro": "The transform is done in three steps.",
+                    "bullets": ["correct and normalize the measured intensity", "Fourier transform to real space", "fit a structure model to the result"],
+                    "shrink": true
+                },
+                {
+                    "type": "text",
+                    "title": "What the PDF tells us",
+                    "bullets": ["the near neighbour distances", "how ordered the structure is over longer distances"],
+                    "outro": "Both are hidden in the average structure.",
+                    "shrink": false
+                }
+            ]
+        }
+    ],
     "students": {
         "_id": "Human A. Person",
         "aka": ["H. A. Person"],
@@ -2304,14 +2341,14 @@
         }
     ],
     "talks": {
-        "_id": "30-example-talk",
+        "_id": "30-graphite-rock",
         "active": true,
         "talk_description": "An overview of the group's work on nanostructure, for a general audience.",
         "learning_objectives": ["what a pair distribution function is", "why local structure matters for nanomaterials"],
         "authorlist": ["sbillinge", "afriend", "C. D. Sample"],
         "addresses": ["columbiau", "usouthcarolina", "Department of Chemistry, Sample University, Boston, MA 02115, USA"],
         "presenter": "sbillinge",
-        "presentationid": "18sb_this_and_that",
+        "presentationid": "18sb_nslsii",
         "year": 2024,
         "notes": ["the audience asked about sample preparation"],
         "topics": [

--- a/src/regolith/exemplars.json
+++ b/src/regolith/exemplars.json
@@ -2304,14 +2304,14 @@
         }
     ],
     "talks": {
-        "_id": "2406ab_example_talk",
+        "_id": "30-example-talk",
         "active": true,
         "talk_description": "An overview of the group's work on nanostructure, for a general audience.",
         "learning_objectives": ["what a pair distribution function is", "why local structure matters for nanomaterials"],
-        "authorlist": ["A. B. Example", "C. D. Sample"],
-        "addresses": ["Department of Physics, Example University, New York, NY 10027, USA", "Department of Chemistry, Sample University, Boston, MA 02115, USA"],
-        "presenter": "aexample",
-        "presentationid": "2406ab_example_meeting",
+        "authorlist": ["sbillinge", "afriend", "C. D. Sample"],
+        "addresses": ["columbiau", "usouthcarolina", "Department of Chemistry, Sample University, Boston, MA 02115, USA"],
+        "presenter": "sbillinge",
+        "presentationid": "18sb_this_and_that",
         "year": 2024,
         "notes": ["the audience asked about sample preparation"],
         "topics": [

--- a/src/regolith/schemas.json
+++ b/src/regolith/schemas.json
@@ -3183,7 +3183,7 @@
             "description": "This collection describes talks, which are assembled from decks in the slides collection. A talk is the reusable content, and a presentation in the presentations collection is one occasion on which it was given."
         },
         "_id": {
-            "description": "The unique id for the talk.",
+            "description": "The unique id for the talk. By convention this is the length of the talk in minutes, followed by a short name, with the words separated by dashes, such as 30-example-talk.",
             "required": true,
             "type": "string"
         },
@@ -3193,12 +3193,12 @@
             "type": "boolean"
         },
         "addresses": {
-            "description": "The affiliations of the authors, in the same order as authorlist.",
+            "description": "The affiliations of the authors, in the same order as authorlist. An entry is either an id in the institutions collection, which is dereferenced when the talk is built, or an address written out in full.",
             "required": false,
             "anyof_type": ["string", "list"]
         },
         "authorlist": {
-            "description": "The ids or names of the authors of the talk.",
+            "description": "The authors of the talk. An entry is either an id in the people or contacts collections, which is dereferenced when the talk is built, or a name written out in full.",
             "required": false,
             "anyof_type": ["string", "list"]
         },
@@ -3218,7 +3218,7 @@
             "type": "string"
         },
         "presenter": {
-            "description": "The id or name of the person who gives the talk.",
+            "description": "The id or name of the person who gives the talk, who is normally one of the authorlist.",
             "required": false,
             "type": "string"
         },

--- a/src/regolith/schemas.json
+++ b/src/regolith/schemas.json
@@ -2934,6 +2934,129 @@
             "anyof_type": ["string", "integer"]
         }
     },
+    "slides": {
+        "_description": {
+            "description": "This collection contains decks of slides on a single topic, which are assembled into talks by the talks collection."
+        },
+        "_id": {
+            "description": "The unique id for the deck, which is the name the talks collection refers to it by.",
+            "required": true,
+            "type": "string"
+        },
+        "name": {
+            "description": "The human readable name of the deck.",
+            "required": false,
+            "type": "string"
+        },
+        "slides": {
+            "description": "The slides in the deck, in the order they are shown.",
+            "required": true,
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    "type": {
+                        "description": "The kind of slide, which selects the latex template used to lay it out.",
+                        "required": true,
+                        "type": "string",
+                        "eallowed": "SLIDE_TYPES"
+                    },
+                    "title": {
+                        "description": "The title placed at the top of the slide.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    "image": {
+                        "description": "The name of the image file to place on the slide, without its extension. It is resolved against the graphics path of the latex template.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    "caption": {
+                        "description": "The caption placed under the image.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    "fig_width": {
+                        "description": "The width of the image as a fraction of the column it is placed in.",
+                        "required": false,
+                        "anyof_type": ["float", "integer"]
+                    },
+                    "fig_rotation": {
+                        "description": "The rotation applied to the image, in degrees.",
+                        "required": false,
+                        "anyof_type": ["float", "integer"]
+                    },
+                    "imagecol_width": {
+                        "description": "The width of the image column as a fraction of the slide, for the two column slide types.",
+                        "required": false,
+                        "anyof_type": ["float", "integer"]
+                    },
+                    "intro": {
+                        "description": "The text placed above the bullets.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
+                    "bullets": {
+                        "description": "The bulleted points making up the body of the slide.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
+                    "outro": {
+                        "description": "The text placed below the bullets.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
+                    "shrink": {
+                        "description": "Whether the slide is shrunk to fit its content onto one frame.",
+                        "required": false,
+                        "type": "boolean"
+                    },
+                    "n-frames": {
+                        "description": "The number of frames in the animation, for slides of the animation type.",
+                        "required": false,
+                        "type": "integer"
+                    },
+                    "notes": {
+                        "description": "The speaker notes for the slide.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
+                    "solution": {
+                        "description": "The answer to the question posed on the slide, for slides used in teaching.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
+                    "paper": {
+                        "description": "The paper the content of the slide is taken from.",
+                        "required": false,
+                        "type": "dict",
+                        "schema": {
+                            "doi": {
+                                "description": "The doi of the paper.",
+                                "required": false,
+                                "type": "string"
+                            },
+                            "avatars": {
+                                "description": "The ids of the people whose avatars are shown beside the citation.",
+                                "required": false,
+                                "anyof_type": ["string", "list"]
+                            },
+                            "render": {
+                                "description": "Whether the citation is rendered on the slide.",
+                                "required": false,
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "tags": {
+            "description": "The tags used to find the deck.",
+            "required": false,
+            "anyof_type": ["string", "list"]
+        }
+    },
     "software": {
         "_description": {"description": "Information about software, such as active, grants, etc."},
         "_id": {
@@ -3053,6 +3176,114 @@
             "description": "The university identifier for the student",
             "required": false,
             "type": "string"
+        }
+    },
+    "talks": {
+        "_description": {
+            "description": "This collection describes talks, which are assembled from decks in the slides collection. A talk is the reusable content, and a presentation in the presentations collection is one occasion on which it was given."
+        },
+        "_id": {
+            "description": "The unique id for the talk.",
+            "required": true,
+            "type": "string"
+        },
+        "active": {
+            "description": "Whether the talk is one that may still be given.",
+            "required": false,
+            "type": "boolean"
+        },
+        "addresses": {
+            "description": "The affiliations of the authors, in the same order as authorlist.",
+            "required": false,
+            "anyof_type": ["string", "list"]
+        },
+        "authorlist": {
+            "description": "The ids or names of the authors of the talk.",
+            "required": false,
+            "anyof_type": ["string", "list"]
+        },
+        "learning_objectives": {
+            "description": "The things the audience should take away from the talk.",
+            "required": false,
+            "anyof_type": ["string", "list"]
+        },
+        "notes": {
+            "description": "The notes made about how the talk went.",
+            "required": false,
+            "anyof_type": ["string", "list"]
+        },
+        "presentationid": {
+            "description": "The id of the presentation in the presentations collection that this talk was built for.",
+            "required": false,
+            "type": "string"
+        },
+        "presenter": {
+            "description": "The id or name of the person who gives the talk.",
+            "required": false,
+            "type": "string"
+        },
+        "talk_description": {
+            "description": "The short description of what the talk covers.",
+            "required": false,
+            "type": "string"
+        },
+        "topics": {
+            "description": "The sections of the talk, in the order they are shown. An entry is either a topic taken straight from a deck, or a supertopic gathering slides from several decks under one section heading.",
+            "required": true,
+            "type": "list",
+            "schema": {
+                "type": "dict",
+                "anyof": [
+                    {
+                        "schema": {
+                            "topic": {
+                                "description": "The id of the deck in the slides collection to take slides from.",
+                                "required": true,
+                                "type": "string"
+                            },
+                            "slide_list": {
+                                "description": "The slides to take from the deck, written as python indexing syntax, either a slice such as \"[:]\" or \"[2:5]\" or a list of indices such as \"[1,4,7]\".",
+                                "required": true,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "schema": {
+                            "supertopic": {
+                                "description": "The heading shown for the gathered section.",
+                                "required": true,
+                                "type": "string"
+                            },
+                            "topics": {
+                                "description": "The decks gathered under the heading.",
+                                "required": true,
+                                "type": "list",
+                                "schema": {
+                                    "type": "dict",
+                                    "schema": {
+                                        "topic": {
+                                            "description": "The id of the deck in the slides collection to take slides from.",
+                                            "required": true,
+                                            "type": "string"
+                                        },
+                                        "slide_list": {
+                                            "description": "The slides to take from the deck, written as python indexing syntax, either a slice such as \"[:]\" or \"[2:5]\" or a list of indices such as \"[1,4,7]\".",
+                                            "required": true,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "year": {
+            "description": "The year the talk was written.",
+            "required": false,
+            "type": "integer"
         }
     },
     "todos": {

--- a/src/regolith/schemas.py
+++ b/src/regolith/schemas.py
@@ -38,6 +38,15 @@ alloweds = {
     ],
     "GRANT_STATI": ["pending", "declined", "accepted", "in-prep"],
     "GRANT_ROLES": ["pi", "copi", "co-pi"],
+    "SLIDE_TYPES": [
+        "text",
+        "image",
+        "imageleft-2col",
+        "imageright-2col",
+        "animation",
+        "cork",
+        "cork_2col",
+    ],
     "MILESTONE_TYPES": [
         "mergedpr",
         "meeting",


### PR DESCRIPTION
Add schemas and exemplars for the talks and slides collections to schemas.json and exemplars.json, and the SLIDE_TYPES allowed list to schemas.py.

A deck in slides holds an ordered list of slides on one topic. A talk in talks assembles decks into an ordered list of topics, where an entry is either a topic taken straight from a deck or a supertopic gathering slides from several decks under one section heading. A talk is the reusable content, and a presentation in the presentations collection is one occasion on which it was given, linked by the talk_id field that presentations already carries.

The field types follow the data in an existing talks database of 53 talks and 192 decks holding 883 slides. Several fields there are written as either a string or a list, and the figure widths as either a float or an integer, so those use anyof_type. The slide type uses eallowed rather than allowed so that an unrecognized type warns rather than failing validation.

The new entries are spliced into the two json files rather than written by a round trip, so that no existing collection is reformatted.