### PR TITLE
feat: add a presentation builder that renders talks as beamer documents

### DIFF
--- a/news/presentation-builder.rst
+++ b/news/presentation-builder.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* ``presentation`` builder, which renders a beamer document for each presentation that
+  names a talk, gathering the slides from the decks the talk lists under its topics.
+* ``question`` and ``answers`` fields on a slide, used by the cork slide types.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builder.py
+++ b/src/regolith/builder.py
@@ -13,6 +13,7 @@ from regolith.builders.htmlbuilder import HtmlBuilder
 from regolith.builders.internalhtmlbuilder import InternalHtmlBuilder
 from regolith.builders.manuscriptreviewbuilder import ManRevBuilder
 from regolith.builders.postdocadbuilder import PostdocadBuilder
+from regolith.builders.presentationbuilder import PresentationBuilder
 from regolith.builders.preslistbuilder import PresListBuilder
 from regolith.builders.proposalreviewbuilder import PropRevBuilder
 from regolith.builders.publistbuilder import PubListBuilder
@@ -34,6 +35,7 @@ BUILDERS = {
     "html": HtmlBuilder,
     "internalhtml": InternalHtmlBuilder,
     "postdocad": PostdocadBuilder,
+    "presentation": PresentationBuilder,
     "preslist": PresListBuilder,
     "publist": PubListBuilder,
     "releaselist": ReleaseListBuilder,

--- a/src/regolith/builders/presentationbuilder.py
+++ b/src/regolith/builders/presentationbuilder.py
@@ -1,0 +1,181 @@
+"""Builder for presentations.
+
+A talk in the talks collection is assembled from decks of slides in the
+slides collection.  A presentation in the presentations collection is
+one occasion on which a talk was given, and points at its talk with
+talk_id. This builder renders a beamer document for every presentation
+that names a talk.
+"""
+
+import ast
+
+from regolith.builders.basebuilder import LatexBuilderBase
+from regolith.tools import all_docs_from_collection, get_person_contact
+
+
+def string_to_slice(slice_str):
+    """Return the slice described by a string such as "[2:5]".
+
+    Parameters
+    ----------
+    slice_str: str
+        The slice written in python syntax, with or without the enclosing
+        brackets.  An omitted start, stop or step is taken as None
+
+    Returns
+    -------
+    selection: slice
+        The slice the string describes
+    """
+    parts = slice_str.strip("[]").split(":")
+    start = int(parts[0]) if parts[0] else None
+    stop = int(parts[1]) if parts[1] else None
+    step = int(parts[2]) if len(parts) > 2 and parts[2] else None
+    return slice(start, stop, step)
+
+
+def select_slides(deck, slide_list, topic):
+    """Return the slides a topic selects from a deck.
+
+    Parameters
+    ----------
+    deck: dict
+        The document from the slides collection
+    slide_list: str
+        The selection written in python indexing syntax, either a slice such
+        as "[:]" or "[2:5]", or a list of indices such as "[1,4,7]"
+    topic: str
+        The id of the deck, used in the error message
+
+    Returns
+    -------
+    slides: list of dicts
+        The selected slides, in the order they are selected
+
+    Raises
+    ------
+    ValueError
+        If the selection cannot be read, or selects a slide the deck does not
+        have
+    """
+    slides = deck.get("slides") or []
+    try:
+        if ":" in slide_list:
+            return slides[string_to_slice(slide_list)]
+        return [slides[index] for index in ast.literal_eval(slide_list)]
+    except (IndexError, SyntaxError, TypeError, ValueError):
+        raise ValueError(
+            f"The slide_list '{slide_list}' of topic '{topic}' could not be applied to that deck, "
+            f"which has {len(slides)} slides. Please write the slide_list as a slice, such as "
+            '"[:]" or "[2:5]", or as a list of indices, such as "[1,4,7]", that the deck has.'
+        )
+
+
+class PresentationBuilder(LatexBuilderBase):
+    """Build a beamer document for each presentation that names a talk.
+
+    The slides are gathered from the decks the talk lists under its
+    topics, and written to one tex file per presentation.
+
+    Methods
+    -------
+    construct_global_ctx()
+        Constructs the global context.
+    latex()
+        Render latex template.
+    """
+
+    btype = "presentation"
+    needed_colls = ["presentations", "talks", "slides", "people", "contacts"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        gtx = self.gtx
+        rc = self.rc
+        # Listed, not left as the generator all_docs_from_collection returns, because each
+        # collection is scanned once per topic and a generator yields nothing the second time
+        for coll in self.needed_colls:
+            gtx[coll] = list(all_docs_from_collection(rc.client, coll))
+
+    def _get_deck(self, topic):
+        """Return the deck of slides with the given id."""
+        for deck in self.gtx["slides"]:
+            if deck.get("_id") == topic:
+                return deck
+        raise ValueError(
+            f"The topic '{topic}' was not found in the slides collection. Please add a deck with "
+            f"that id, or correct the topic in the talk that asks for it."
+        )
+
+    def _gather_topics(self, talk):
+        """Return the sections of a talk, each holding its selected
+        slides.
+
+        A section is either a topic taken straight from one deck, or a
+        supertopic gathering slides from several decks under one
+        heading.
+        """
+        topics = []
+        for entry in talk.get("topics") or []:
+            if "supertopic" in entry:
+                slides = []
+                for subtopic in entry.get("topics") or []:
+                    topic = subtopic.get("topic")
+                    deck = self._get_deck(topic)
+                    slides.extend(select_slides(deck, subtopic.get("slide_list"), topic))
+                topics.append({"name": entry.get("supertopic"), "slides": slides})
+            else:
+                topic = entry.get("topic")
+                deck = self._get_deck(topic)
+                # A new dict, so that the deck in the slides collection is left alone
+                topics.append(
+                    {
+                        "name": deck.get("name"),
+                        "slides": select_slides(deck, entry.get("slide_list"), topic),
+                    }
+                )
+        return topics
+
+    def _get_talk(self, presentation):
+        """Return the talk a presentation names."""
+        talk_id = presentation.get("talk_id")
+        for talk in self.gtx["talks"]:
+            if talk.get("_id") == talk_id:
+                return talk
+        raise ValueError(
+            f"The talk '{talk_id}', named by presentation '{presentation.get('_id')}', was not "
+            f"found in the talks collection. Please add a talk with that id, or correct the "
+            f"talk_id of the presentation."
+        )
+
+    def _get_presenter_name(self, presentation, talk):
+        """Return the name of the person giving the presentation."""
+        presenter = presentation.get("presenter") or talk.get("presenter")
+        if not presenter:
+            return ""
+        person = get_person_contact(presenter, self.gtx["people"], self.gtx["contacts"])
+        if person is None:
+            # The presenter is not in the collections, so their name is all we know
+            return presenter
+        return person.get("name") or presenter
+
+    def latex(self):
+        """Render latex template."""
+        for presentation in self.gtx["presentations"]:
+            if not presentation.get("talk_id"):
+                continue
+            talk = self._get_talk(presentation)
+            general = {
+                "title": presentation.get("title") or "",
+                "subtitle": presentation.get("subtitle") or "",
+                "presenter": self._get_presenter_name(presentation, talk),
+            }
+            presentation_id = presentation.get("_id")
+            self.render(
+                "talk.tex",
+                f"{presentation_id}.tex",
+                general=general,
+                topics=self._gather_topics(talk),
+            )
+            self.pdf(presentation_id)

--- a/src/regolith/builders/presentationbuilder.py
+++ b/src/regolith/builders/presentationbuilder.py
@@ -10,28 +10,15 @@ that names a talk.
 import ast
 
 from regolith.builders.basebuilder import LatexBuilderBase
-from regolith.tools import all_docs_from_collection, get_person_contact
-
-
-def string_to_slice(slice_str):
-    """Return the slice described by a string such as "[2:5]".
-
-    Parameters
-    ----------
-    slice_str: str
-        The slice written in python syntax, with or without the enclosing
-        brackets.  An omitted start, stop or step is taken as None
-
-    Returns
-    -------
-    selection: slice
-        The slice the string describes
-    """
-    parts = slice_str.strip("[]").split(":")
-    start = int(parts[0]) if parts[0] else None
-    stop = int(parts[1]) if parts[1] else None
-    step = int(parts[2]) if len(parts) > 2 and parts[2] else None
-    return slice(start, stop, step)
+from regolith.dates import get_dates
+from regolith.tools import (
+    all_docs_from_collection,
+    format_affiliation,
+    fuzzy_retrieval,
+    get_person_affiliation,
+    get_person_contact,
+    string_to_slice,
+)
 
 
 def select_slides(deck, slide_list, topic):
@@ -71,6 +58,50 @@ def select_slides(deck, slide_list, topic):
         )
 
 
+def number_affiliations(entries, presenter_name=""):
+    """Return authors numbered by the affiliation they share.
+
+    Parameters
+    ----------
+    entries: list of dicts
+        The authors in the order they are to appear, each holding their "name" and their
+        "affiliation" as a single line of text.  An empty affiliation is one that could
+        not be found
+    presenter_name: str
+        The name of the author giving the presentation.  Default is an empty string,
+        which marks nobody
+
+    Returns
+    -------
+    authors: list of dicts
+        The authors in the order given, each holding their "name", the "number" of their
+        affiliation and whether they are the presenter under "is_presenter".  The number
+        is None for an author with no affiliation, and for every author when there is
+        nothing to tell apart
+    affiliations: list of str
+        The affiliations in the order they first appear, each listed once.  Two authors
+        whose affiliation reads the same share a number, so two departments of one
+        institution stay apart while one department shared by two authors is listed once
+    """
+    authors, affiliations = [], []
+    for entry in entries:
+        affiliation = entry.get("affiliation") or ""
+        if affiliation and affiliation not in affiliations:
+            affiliations.append(affiliation)
+        authors.append(
+            {
+                "name": entry.get("name") or "",
+                "number": affiliations.index(affiliation) + 1 if affiliation else None,
+                "is_presenter": bool(presenter_name) and entry.get("name") == presenter_name,
+            }
+        )
+    # A single affiliation needs no numbering, since every author shares it
+    if len(affiliations) < 2:
+        for author in authors:
+            author["number"] = None
+    return authors, affiliations
+
+
 class PresentationBuilder(LatexBuilderBase):
     """Build a beamer document for each presentation that names a talk.
 
@@ -86,7 +117,7 @@ class PresentationBuilder(LatexBuilderBase):
     """
 
     btype = "presentation"
-    needed_colls = ["presentations", "talks", "slides", "people", "contacts"]
+    needed_colls = ["presentations", "talks", "slides", "people", "contacts", "institutions"]
 
     def construct_global_ctx(self):
         """Constructs the global context."""
@@ -160,16 +191,85 @@ class PresentationBuilder(LatexBuilderBase):
             return presenter
         return person.get("name") or presenter
 
+    def _resolve_address(self, address):
+        """Return an entry of the addresses of a talk as text.
+
+        The entry is either an id in the institutions collection or an
+        address already written out.
+        """
+        institution = fuzzy_retrieval(
+            self.gtx["institutions"], ["name", "aka", "_id"], address, case_sensitive=False
+        )
+        if institution is None:
+            return address
+        return institution.get("name") or address
+
+    def _get_author(self, author, address, on):
+        """Return the name and affiliation of one author of a talk.
+
+        The author is looked for in the people and contacts collections,
+        which give their canonical name and the affiliation they held on
+        the date of the presentation.  For an author who is not in
+        either collection the name is taken as written and the
+        affiliation from the addresses of the talk.
+        """
+        try:
+            affiliation = get_person_affiliation(
+                author,
+                self.gtx["people"],
+                self.gtx["contacts"],
+                self.gtx["institutions"],
+                strict=False,
+                now=on,
+            )
+        except ValueError:
+            # Not a person we hold, so the talk itself has to say who they are
+            return {"name": author, "affiliation": self._resolve_address(address) if address else ""}
+        return {
+            "name": affiliation["name"],
+            "affiliation": format_affiliation(affiliation, style="short"),
+        }
+
+    def _get_authors(self, presentation, talk):
+        """Return the authors of a talk and the affiliations they share.
+
+        Authors keep the order the talk lists them in.  Affiliations are
+        numbered in the order they first appear, and an affiliation
+        shared by several authors is listed once, so that two authors in
+        the same department of the same institution carry the same
+        number while two departments of one institution stay apart.  The
+        author giving the presentation is marked so that the template
+        can pick them out.
+        """
+        authorlist = talk.get("authorlist") or []
+        if isinstance(authorlist, str):
+            authorlist = [authorlist]
+        addresses = talk.get("addresses") or []
+        if isinstance(addresses, str):
+            addresses = [addresses]
+        dates = get_dates(presentation) if presentation.get("begin_date") or presentation.get("begin_year") else {}
+        on = dates.get("begin_date") or dates.get("date")
+        presenter_name = self._get_presenter_name(presentation, talk)
+
+        entries = [
+            self._get_author(author, addresses[index] if index < len(addresses) else "", on)
+            for index, author in enumerate(authorlist)
+        ]
+        return number_affiliations(entries, presenter_name)
+
     def latex(self):
         """Render latex template."""
         for presentation in self.gtx["presentations"]:
             if not presentation.get("talk_id"):
                 continue
             talk = self._get_talk(presentation)
+            authors, affiliations = self._get_authors(presentation, talk)
             general = {
                 "title": presentation.get("title") or "",
                 "subtitle": presentation.get("subtitle") or "",
                 "presenter": self._get_presenter_name(presentation, talk),
+                "authors": authors,
+                "affiliations": affiliations,
             }
             presentation_id = presentation.get("_id")
             self.render(

--- a/src/regolith/exemplars.json
+++ b/src/regolith/exemplars.json
@@ -2365,7 +2365,7 @@
                     },
                     {
                         "topic": "example-methods",
-                        "slide_list": "[1:3]"
+                        "slide_list": "[0:2]"
                     }
                 ]
             }

--- a/src/regolith/schemas.json
+++ b/src/regolith/schemas.json
@@ -3021,6 +3021,16 @@
                         "required": false,
                         "anyof_type": ["string", "list"]
                     },
+                    "question": {
+                        "description": "The question posed to the audience, for slides of the cork and cork_2col types.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    "answers": {
+                        "description": "The answers offered to the audience, revealed one at a time, for slides of the cork and cork_2col types.",
+                        "required": false,
+                        "anyof_type": ["string", "list"]
+                    },
                     "solution": {
                         "description": "The answer to the question posed on the slide, for slides used in teaching.",
                         "required": false,

--- a/src/regolith/templates/animation.tex
+++ b/src/regolith/templates/animation.tex
@@ -1,0 +1,2 @@
+\centering
+\makebox[\textwidth][c]{\animategraphics[loop,width={{ s['fig_width'] }}\dimexpr\textwidth+2cm\relax,angle={{ s['fig_rotation'] }}]{10}{ {{ s['image'] }}-}{0}{ {{ s['n-frames'] }} }}

--- a/src/regolith/templates/cork.tex
+++ b/src/regolith/templates/cork.tex
@@ -1,0 +1,9 @@
+{{ s['question'] }}
+{% if s['answers'] %}
+\begin{enumerate}
+{% for a in s['answers'] %}
+  \pause\item {{ a }}
+{% endfor %}
+\end{enumerate}
+  \pause
+{% endif %}

--- a/src/regolith/templates/cork_2col.tex
+++ b/src/regolith/templates/cork_2col.tex
@@ -1,0 +1,19 @@
+{{ s['question'] }}
+{% if s['answers'] %}
+\begin{columns}
+\column{ {{ s['imagecol_width'] }}\textwidth}
+\begin{figure}
+\begin{center}
+\includegraphics[width={{ s['fig_width'] }}\columnwidth]{ {{ s['image'] }} }
+\caption{ {{ s['caption'] }} }
+\end{center}
+\end{figure}
+\column{ {{ 1-s['imagecol_width'] }}\textwidth}
+\begin{enumerate}
+{% for a in s['answers'] %}
+  \pause\item {{ a }}
+{% endfor %}
+\end{enumerate}
+  \pause
+\end{columns}
+{% endif %}

--- a/src/regolith/templates/image.tex
+++ b/src/regolith/templates/image.tex
@@ -1,0 +1,8 @@
+\begin{figure}
+\begin{center}
+\makebox[\textwidth][c]{\includegraphics[width={{ s['fig_width'] }}\dimexpr\textwidth+2cm\relax, angle={{ s['fig_rotation'] }} ]{ {{ s['image'] }} }}
+{% if s['caption'] %}
+\caption{ {{ s['caption'] }} }
+{% endif %}
+\end{center}
+\end{figure}

--- a/src/regolith/templates/imageleft-2col.tex
+++ b/src/regolith/templates/imageleft-2col.tex
@@ -1,0 +1,25 @@
+\begin{columns}
+\column{ {{ s['imagecol_width'] }}\textwidth}
+\begin{figure}
+\begin{center}
+\makebox[\columnwidth][c]{\includegraphics[width={{ s['fig_width'] }}\dimexpr\columnwidth+2cm\relax, angle={{ s['fig_rotation'] }} ]{ {{ s['image'] }} }}
+{% if s['caption'] %}
+\caption{ {{ s['caption'] }} }
+{% endif %}
+\end{center}
+\end{figure}
+\column{ {{ 1-s['imagecol_width'] }}\textwidth}
+{% if s['intro'] %}
+{{ s['intro'] }}
+{% endif %}
+{% if s['bullets'] %}
+\begin{itemize}
+{% for a in s['bullets'] %}
+  \item {{ a }}
+{% endfor %}
+\end{itemize}
+{% endif %}
+{% if s['outro'] %}
+{{ s['outro'] }}
+{% endif %}
+\end{columns}

--- a/src/regolith/templates/imageright-2col.tex
+++ b/src/regolith/templates/imageright-2col.tex
@@ -1,0 +1,25 @@
+\begin{columns}
+\column{ {{ 1-s['imagecol_width'] }}\textwidth}
+{% if s['intro'] %}
+{{ s['intro'] }}
+{% endif %}
+{% if s['bullets'] %}
+\begin{itemize}
+{% for a in s['bullets'] %}
+  \item {{ a }}
+{% endfor %}
+\end{itemize}
+{% endif %}
+{% if s['outro'] %}
+{{ s['outro'] }}
+{% endif %}
+\column{ {{ s['imagecol_width'] }}\textwidth}
+\begin{figure}
+\begin{center}
+\makebox[\columnwidth][c]{\includegraphics[width={{ s['fig_width'] }}\dimexpr\columnwidth+2cm\relax, angle={{ s['fig_rotation'] }} ]{ {{ s['image'] }} }}
+{% if s['caption'] %}
+\caption{ {{ s['caption'] }} }
+{% endif %}
+\end{center}
+\end{figure}
+\end{columns}

--- a/src/regolith/templates/talk.tex
+++ b/src/regolith/templates/talk.tex
@@ -1,0 +1,47 @@
+\documentclass{beamer}
+\usepackage{graphicx}
+\setlength{\parskip}{0 pt}
+\setbeamertemplate{caption}{\centering\raggedright\scriptsize\insertcaption\par}
+\title{ {{ general['title'] }} }
+\subtitle{ {{ general['subtitle'] }} }
+\author{ {{ general['presenter'] }} }
+\date{\today}
+\begin{document}
+
+\begin{frame}
+\titlepage
+\end{frame}
+{% for topic in topics %}
+\section{ {{ topic['name'] }} }
+{% for s in topic['slides'] %}
+{% if s["shrink"] %}
+\begin{frame}[shrink=10]
+{% else %}
+\begin{frame}
+{% endif %}
+\frametitle{ {{ s['title'] }} }
+{% if s["type"] == "imageleft-2col" %}
+{% include 'imageleft-2col.tex' %}
+{% endif %}
+{% if s["type"] == "imageright-2col" %}
+{% include 'imageright-2col.tex' %}
+{% endif %}
+{% if s["type"] == "image" %}
+{% include 'image.tex' %}
+{% endif %}
+{% if s["type"] == "animation" %}
+{% include 'animation.tex' %}
+{% endif %}
+{% if s["type"] == "text" %}
+{% include 'text.tex' %}
+{% endif %}
+{% if s["type"] == "cork" %}
+{% include 'cork.tex' %}
+{% endif %}
+{% if s["type"] == "cork_2col" %}
+{% include 'cork_2col.tex' %}
+{% endif %}
+\end{frame}
+{% endfor %}
+{% endfor %}
+\end{document}

--- a/src/regolith/templates/talk.tex
+++ b/src/regolith/templates/talk.tex
@@ -4,7 +4,24 @@
 \setbeamertemplate{caption}{\centering\raggedright\scriptsize\insertcaption\par}
 \title{ {{ general['title'] }} }
 \subtitle{ {{ general['subtitle'] }} }
+{% if general['authors'] -%}
+\author{
+{%- for a in general['authors'] -%}
+{%- if a['is_presenter'] -%}\underline{ {{- a['name'] -}} }{%- else -%}{{ a['name'] }}{%- endif -%}
+{%- if a['number'] -%}\textsuperscript{ {{- a['number'] -}} }{%- endif -%}
+{%- if not loop.last %}, {% endif -%}
+{%- endfor -%}
+}
+\institute{\small
+{%- for affiliation in general['affiliations'] -%}
+{%- if general['affiliations']|length > 1 -%}\textsuperscript{ {{- loop.index -}} }{%- endif -%}
+{{- affiliation -}}
+{%- if not loop.last %} \\ {% endif -%}
+{%- endfor -%}
+}
+{%- else -%}
 \author{ {{ general['presenter'] }} }
+{%- endif %}
 \date{\today}
 \begin{document}
 

--- a/src/regolith/templates/text.tex
+++ b/src/regolith/templates/text.tex
@@ -1,0 +1,13 @@
+{% if s['intro'] %}
+{{ s['intro'] }}
+{% endif %}
+{% if s['bullets'] %}
+\begin{itemize}
+{% for a in s['bullets'] %}
+  \item {{ a }}
+{% endfor %}
+\end{itemize}
+{% endif %}
+{% if s['outro'] %}
+{{ s['outro'] }}
+{% endif %}

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -2703,3 +2703,24 @@ def strip_str(s):
     if isinstance(s, str):
         return s.strip()
     return s
+
+
+def string_to_slice(slice_str):
+    """Return the slice described by a string such as "[2:5]".
+
+    Parameters
+    ----------
+    slice_str: str
+        The slice written in python syntax, with or without the enclosing brackets.  An
+        omitted start, stop or step is taken as None, so "[:]" is every item
+
+    Returns
+    -------
+    selection: slice
+        The slice the string describes
+    """
+    parts = slice_str.strip("[]").split(":")
+    start = int(parts[0]) if parts[0] else None
+    stop = int(parts[1]) if parts[1] else None
+    step = int(parts[2]) if len(parts) > 2 and parts[2] else None
+    return slice(start, stop, step)

--- a/tests/outputs/presentation/18sb_nslsii.tex
+++ b/tests/outputs/presentation/18sb_nslsii.tex
@@ -1,0 +1,181 @@
+\documentclass{beamer}
+\usepackage{graphicx}
+\setlength{\parskip}{0 pt}
+\setbeamertemplate{caption}{\centering\raggedright\scriptsize\insertcaption\par}
+\title{ ClusterMining: extracting core structures of metallic nanoparticles from the atomic pair distribution function }
+\subtitle{  }
+\author{ Simon J. L. Billinge }
+\date{\today}
+\begin{document}
+
+\begin{frame}
+\titlepage
+\end{frame}
+
+\section{ introduction }
+
+
+\begin{frame}
+
+\frametitle{ What is local structure? }
+
+
+
+
+
+
+Three ideas underpin the rest of the talk.
+
+
+\begin{itemize}
+
+  \item crystals are described by an average structure
+
+  \item real materials deviate from that average
+
+  \item those deviations control the properties
+
+\end{itemize}
+
+
+We will return to each of these.
+
+
+
+
+\end{frame}
+
+
+\begin{frame}
+
+\frametitle{ The nanostructure problem }
+
+\begin{columns}
+\column{ 0.5\textwidth}
+\begin{figure}
+\begin{center}
+\makebox[\columnwidth][c]{\includegraphics[width=0.9\dimexpr\columnwidth+2cm\relax, angle=0 ]{ example_nanoparticle }}
+
+\caption{ A nanoparticle with a disordered surface. }
+
+\end{center}
+\end{figure}
+\column{ 0.5\textwidth}
+
+
+\begin{itemize}
+
+  \item the surface is not the same as the core
+
+\end{itemize}
+
+
+\end{columns}
+
+
+
+
+
+
+
+\end{frame}
+
+
+\section{ Local structure of materials }
+
+
+\begin{frame}
+
+\frametitle{ What is local structure? }
+
+
+
+
+
+
+Three ideas underpin the rest of the talk.
+
+
+\begin{itemize}
+
+  \item crystals are described by an average structure
+
+  \item real materials deviate from that average
+
+  \item those deviations control the properties
+
+\end{itemize}
+
+
+We will return to each of these.
+
+
+
+
+\end{frame}
+
+
+\begin{frame}
+
+\frametitle{ Measuring a pair distribution function }
+
+
+
+\begin{figure}
+\begin{center}
+\makebox[\textwidth][c]{\includegraphics[width=0.8\dimexpr\textwidth+2cm\relax, angle=0 ]{ example_diffractometer }}
+
+\caption{ The diffractometer used to collect the data. }
+
+\end{center}
+\end{figure}
+
+
+
+
+
+\end{frame}
+
+
+\begin{frame}[shrink=10]
+
+\frametitle{ From diffraction pattern to PDF }
+
+
+\begin{columns}
+\column{ 0.6\textwidth}
+
+The transform is done in three steps.
+
+
+\begin{itemize}
+
+  \item correct and normalize the measured intensity
+
+  \item Fourier transform to real space
+
+  \item fit a structure model to the result
+
+\end{itemize}
+
+
+\column{ 0.4\textwidth}
+\begin{figure}
+\begin{center}
+\makebox[\columnwidth][c]{\includegraphics[width=0.9\dimexpr\columnwidth+2cm\relax, angle=0 ]{ example_transform }}
+
+\caption{ The Fourier transform of the total scattering structure function. }
+
+\end{center}
+\end{figure}
+\end{columns}
+
+
+
+
+
+
+\end{frame}
+
+
+\end{document}

--- a/tests/outputs/presentation/18sb_nslsii.tex
+++ b/tests/outputs/presentation/18sb_nslsii.tex
@@ -4,7 +4,8 @@
 \setbeamertemplate{caption}{\centering\raggedright\scriptsize\insertcaption\par}
 \title{ ClusterMining: extracting core structures of metallic nanoparticles from the atomic pair distribution function }
 \subtitle{  }
-\author{ Simon J. L. Billinge }
+\author{\underline{Simon J. L. Billinge}\textsuperscript{1}, Anthony B Friend\textsuperscript{2}, C. D. Sample\textsuperscript{3}}
+\institute{\small\textsuperscript{1}The University of South Carolina \\ \textsuperscript{2}Department of Physics, Columbia University \\ \textsuperscript{3}Department of Chemistry, Sample University, Boston, MA 02115, USA}
 \date{\today}
 \begin{document}
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -10,6 +10,7 @@ import openpyxl
 import pytest
 
 from regolith.broker import load_db
+from regolith.builders.presentationbuilder import number_affiliations
 from regolith.main import main
 
 builder_map = [
@@ -341,3 +342,102 @@ def test_builder_python(bm, db_src, make_db, make_mongodb, monkeypatch):
         # Skip because of a date time in
         if file != "rss.xml":
             assert expected == actual
+
+
+@pytest.mark.parametrize(
+    "entries, presenter_name, expected_authors, expected_affiliations",
+    [
+        (
+            # C1: Authors at three different places, expect them numbered in the order they
+            # first appear
+            [
+                {"name": "A. One", "affiliation": "Department of Physics, Columbia University"},
+                {"name": "B. Two", "affiliation": "The University of South Carolina"},
+                {"name": "C. Three", "affiliation": "Department of Chemistry, Sample University"},
+            ],
+            "B. Two",
+            [
+                {"name": "A. One", "number": 1, "is_presenter": False},
+                {"name": "B. Two", "number": 2, "is_presenter": True},
+                {"name": "C. Three", "number": 3, "is_presenter": False},
+            ],
+            [
+                "Department of Physics, Columbia University",
+                "The University of South Carolina",
+                "Department of Chemistry, Sample University",
+            ],
+        ),
+        (
+            # C2: Two authors in the same department of the same institution, expect them to
+            # share a number and that affiliation to be listed once
+            [
+                {"name": "A. One", "affiliation": "APAM, Columbia University"},
+                {"name": "B. Two", "affiliation": "APAM, Columbia University"},
+                {"name": "C. Three", "affiliation": "The University of South Carolina"},
+            ],
+            "",
+            [
+                {"name": "A. One", "number": 1, "is_presenter": False},
+                {"name": "B. Two", "number": 1, "is_presenter": False},
+                {"name": "C. Three", "number": 2, "is_presenter": False},
+            ],
+            ["APAM, Columbia University", "The University of South Carolina"],
+        ),
+        (
+            # C3: Two authors in different departments of one institution, expect distinct
+            # numbers because the affiliations do not read the same
+            [
+                {"name": "A. One", "affiliation": "APAM, Columbia University"},
+                {"name": "B. Two", "affiliation": "Department of Physics, Columbia University"},
+            ],
+            "A. One",
+            [
+                {"name": "A. One", "number": 1, "is_presenter": True},
+                {"name": "B. Two", "number": 2, "is_presenter": False},
+            ],
+            ["APAM, Columbia University", "Department of Physics, Columbia University"],
+        ),
+        (
+            # C4: Every author at one place, expect no numbering since there is nothing to
+            # tell apart
+            [
+                {"name": "A. One", "affiliation": "APAM, Columbia University"},
+                {"name": "B. Two", "affiliation": "APAM, Columbia University"},
+            ],
+            "B. Two",
+            [
+                {"name": "A. One", "number": None, "is_presenter": False},
+                {"name": "B. Two", "number": None, "is_presenter": True},
+            ],
+            ["APAM, Columbia University"],
+        ),
+        (
+            # C5: An author whose affiliation could not be found, expect them to carry no
+            # number while the others keep theirs
+            [
+                {"name": "A. One", "affiliation": "APAM, Columbia University"},
+                {"name": "B. Two", "affiliation": ""},
+                {"name": "C. Three", "affiliation": "The University of South Carolina"},
+            ],
+            "",
+            [
+                {"name": "A. One", "number": 1, "is_presenter": False},
+                {"name": "B. Two", "number": None, "is_presenter": False},
+                {"name": "C. Three", "number": 2, "is_presenter": False},
+            ],
+            ["APAM, Columbia University", "The University of South Carolina"],
+        ),
+        (
+            # C6: No authors at all, expect nothing to number
+            [],
+            "A. One",
+            [],
+            [],
+        ),
+    ],
+)
+def test_number_affiliations(entries, presenter_name, expected_authors, expected_affiliations):
+    # Test that authors keep their order and that a shared affiliation is listed once
+    actual_authors, actual_affiliations = number_affiliations(entries, presenter_name)
+    assert actual_authors == expected_authors
+    assert actual_affiliations == expected_affiliations

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -22,6 +22,7 @@ builder_map = [
     "formalletter",
     #    "html",
     "internalhtml",
+    "presentation",
     "preslist",
     "publist",
     "recent-collabs",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -47,6 +47,7 @@ from regolith.tools import (
     number_suffix,
     remove_duplicate_docs,
     search_collection,
+    string_to_slice,
     strip_str,
     update_schemas,
     validate_meeting,
@@ -3892,3 +3893,35 @@ def test_format_affiliation_does_not_mutate():
     expected_affiliation = copy.deepcopy(COLUMBIA_PHYSICS_AFFILIATION)
     format_affiliation(COLUMBIA_PHYSICS_AFFILIATION)
     assert COLUMBIA_PHYSICS_AFFILIATION == expected_affiliation
+
+
+@pytest.mark.parametrize(
+    "slice_str, expected_selection",
+    [
+        # Test that a slice written as a string selects the same items python indexing would
+        # C1: A start and a stop, expect the items between them
+        ("[1:3]", slice(1, 3, None)),
+        # C2: Neither a start nor a stop, expect every item
+        ("[:]", slice(None, None, None)),
+        # C3: A start only, expect everything from it onwards
+        ("[2:]", slice(2, None, None)),
+        # C4: A stop only, expect everything up to it
+        ("[:4]", slice(None, 4, None)),
+        # C5: A step as well, expect it carried through
+        ("[0:6:2]", slice(0, 6, 2)),
+        # C6: A negative start, expect it kept as written so it counts from the end
+        ("[-2:]", slice(-2, None, None)),
+        # C7: No enclosing brackets, expect them not to be needed
+        ("1:3", slice(1, 3, None)),
+    ],
+)
+def test_string_to_slice(slice_str, expected_selection):
+    assert string_to_slice(slice_str) == expected_selection
+
+
+def test_string_to_slice_applies_to_a_list():
+    # Test that the returned slice selects the items it names
+    items = ["a", "b", "c", "d", "e"]
+    assert items[string_to_slice("[1:3]")] == ["b", "c"]
+    assert items[string_to_slice("[:]")] == items
+    assert items[string_to_slice("[0:5:2]")] == ["a", "c", "e"]


### PR DESCRIPTION
Add PresentationBuilder in builders/presentationbuilder.py, register it in the BUILDERS map as presentation, and add the templates it renders. It replaces the standalone script that was kept alongside the talks database.

For every presentation that names a talk with talk_id, the builder gathers the slides the talk asks for and writes one beamer tex file to the build directory. A section of a talk is either a topic taken straight from a deck, named after the deck, or a supertopic gathering slides from several decks under one heading. A slide_list is read as a slice, such as "[:]" or "[2:5]", or as a list of indices, such as "[1,4,7]". The presenter is looked up in people and falls back to contacts, so the author line holds their canonical name.

Three things are done differently from the script it replaces. The topics are gathered into new dicts rather than by updating the deck in place, which the script did and which left the slides collection modified. A slide_list that cannot be applied to its deck, and a topic or talk_id that names something missing, now raise errors that say what to do rather than IndexError or KeyError. The collections are listed rather than left as the generator that all_docs_from_collection returns, because each is scanned once per topic and a generator yields nothing the second time.

The templates are the generic form of the ones kept with the talks database, with the group specific preamble, colours and graphics path left out, since a templates directory beside regolithrc.json already takes precedence over the packaged one. The cork templates need question and answers on a slide, which the slides schema did not yet have, so those two fields are added.

The output directory is rc.builddir, which regolithrc.json can already override, so no path is written into the source.

The exemplars now select the first two slides of the example-methods deck rather than the last two, so that the builder test covers the image template as well as the text, imageleft-2col and imageright-2col ones.