### PR TITLE
feat: add l_talks and l_slides listers

### DIFF
--- a/news/talk-slide-listers.rst
+++ b/news/talk-slide-listers.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* ``l_talks`` lister, which shows each talk beside the presentations it was given at,
+  filtered by id, description, presenter or year.
+* ``l_slides`` lister, which shows each deck of slides and how many slides it holds,
+  filtered by id, tag or the title of a slide it contains.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -21,6 +21,8 @@ from regolith.helpers import l_membershelper as l_members
 from regolith.helpers import l_milestoneshelper as l_milestone
 from regolith.helpers import l_progressreporthelper as l_progress
 from regolith.helpers import l_projectahelper as l_projecta
+from regolith.helpers import l_slideshelper as l_slides
+from regolith.helpers import l_talkshelper as l_talks
 from regolith.helpers import l_todohelper as l_todo
 from regolith.helpers import makeappointmentshelper as makeappointments
 from regolith.helpers import reimbstatushelper as reimbstatus
@@ -66,6 +68,8 @@ LISTER_HELPERS = {
     "l_progress": (l_progress.ProgressReportHelper, l_progress.subparser),
     "l_projecta": (l_projecta.ProjectaListerHelper, l_projecta.subparser),
     "l_reimbstatus": (reimbstatus.ReimbstatusHelper, reimbstatus.subparser),
+    "l_slides": (l_slides.SlidesListerHelper, l_slides.subparser),
+    "l_talks": (l_talks.TalksListerHelper, l_talks.subparser),
     "l_todo": (l_todo.TodoListerHelper, l_todo.subparser),
     "v_meetings": (v_meetings.MeetingsValidatorHelper, v_meetings.subparser),
     "attestations": (attestations.AttestationsHelper, attestations.subparser),

--- a/src/regolith/helpers/l_slideshelper.py
+++ b/src/regolith/helpers/l_slideshelper.py
@@ -1,0 +1,113 @@
+"""Lister for decks of slides.
+
+A deck holds slides on a single topic, and talks assemble decks into
+sections.  The id of a deck is the name a talk refers to it by, and the
+number of slides it holds is what a slide_list indexes into.
+"""
+
+from gooey import GooeyParser
+
+from regolith.fsclient import _id_key
+from regolith.helpers.basehelper import SoutHelperBase
+from regolith.tools import all_docs_from_collection, strip_str
+
+TARGET_COLL = "slides"
+HELPER_TARGET = "l_slides"
+
+
+def subparser(subpi):
+    int_kwargs = {}
+    if isinstance(subpi, GooeyParser):
+        int_kwargs["widget"] = "IntegerField"
+
+    subpi.add_argument(
+        "-d",
+        "--deck-id",
+        help="Filter decks to those whose id contains this fragment.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-t",
+        "--tag",
+        help="Filter decks to those carrying this tag.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-i",
+        "--title",
+        help="Filter decks to those holding a slide whose title contains this fragment.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show the title and type of every slide, with the index a slide_list would use.",
+    )
+    return subpi
+
+
+class SlidesListerHelper(SoutHelperBase):
+    """Helper for listing the decks of slides that talks are built
+    from."""
+
+    # btype must be the same as helper target in helper.py
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        gtx = self.gtx
+        rc = self.rc
+        rc.coll = f"{TARGET_COLL}"
+        colls = [
+            sorted(all_docs_from_collection(rc.client, collname), key=_id_key) for collname in self.needed_colls
+        ]
+        for db, coll in zip(self.needed_colls, colls):
+            gtx[db] = coll
+        gtx["all_docs_from_collection"] = all_docs_from_collection
+        gtx["float"] = float
+        gtx["str"] = str
+        gtx["zip"] = zip
+
+    @staticmethod
+    def _tags(deck):
+        """Return the tags of a deck as a list, however they are
+        written."""
+        tags = deck.get("tags") or []
+        return [tags] if isinstance(tags, str) else tags
+
+    def sout(self):
+        rc = self.rc
+        decks = self.gtx["slides"]
+
+        if rc.deck_id:
+            decks = [deck for deck in decks if rc.deck_id.casefold() in deck.get("_id", "").casefold()]
+        if rc.tag:
+            decks = [
+                deck for deck in decks if any(rc.tag.casefold() in tag.casefold() for tag in self._tags(deck))
+            ]
+        if rc.title:
+            decks = [
+                deck
+                for deck in decks
+                if any(
+                    rc.title.casefold() in (slide.get("title") or "").casefold()
+                    for slide in (deck.get("slides") or [])
+                )
+            ]
+
+        if not decks:
+            print("No decks of slides were found. Please loosen the filters and try again.")
+            return
+
+        for deck in decks:
+            slides = deck.get("slides") or []
+            name = deck.get("name")
+            heading = f"{deck.get('_id')} - ({len(slides)} slides)"
+            print(f"{heading} - {name}" if name else heading)
+            if rc.verbose:
+                for index, slide in enumerate(slides):
+                    print(f"    [{index}] {slide.get('type')}: {slide.get('title')}")
+        return

--- a/src/regolith/helpers/l_talkshelper.py
+++ b/src/regolith/helpers/l_talkshelper.py
@@ -1,0 +1,160 @@
+"""Lister for talks.
+
+A talk is the reusable content, assembled from decks in the slides
+collection, and a presentation is one occasion on which it was given.
+The presentations a talk has been given at are shown beside it, so that
+the id needed to build one can be found.
+"""
+
+from gooey import GooeyParser
+
+from regolith.fsclient import _id_key
+from regolith.helpers.basehelper import SoutHelperBase
+from regolith.tools import all_docs_from_collection, get_person_contact, strip_str
+
+TARGET_COLL = "talks"
+HELPER_TARGET = "l_talks"
+
+
+def subparser(subpi):
+    int_kwargs = {}
+    if isinstance(subpi, GooeyParser):
+        int_kwargs["widget"] = "IntegerField"
+        int_kwargs["gooey_options"] = {"min": 1900, "max": 2100}
+
+    subpi.add_argument(
+        "-t",
+        "--talk-id",
+        help="Filter talks to those whose id contains this fragment.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-d",
+        "--description",
+        help="Filter talks to those whose description contains this fragment.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-p",
+        "--presenter",
+        help="Filter talks to those given by this person, by id or name.",
+        type=strip_str,
+    )
+    subpi.add_argument(
+        "-y",
+        "--year",
+        help="Filter talks to those written in this year.",
+        **int_kwargs,
+    )
+    subpi.add_argument(
+        "--all",
+        action="store_true",
+        help="Show talks that are no longer active, which are left out by default.",
+    )
+    subpi.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show the description and the topics of each talk.",
+    )
+    return subpi
+
+
+class TalksListerHelper(SoutHelperBase):
+    """Helper for listing talks and the presentations they were given
+    at."""
+
+    # btype must be the same as helper target in helper.py
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}", "presentations", "people", "contacts"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        gtx = self.gtx
+        rc = self.rc
+        rc.coll = f"{TARGET_COLL}"
+        colls = [
+            sorted(all_docs_from_collection(rc.client, collname), key=_id_key) for collname in self.needed_colls
+        ]
+        for db, coll in zip(self.needed_colls, colls):
+            gtx[db] = coll
+        gtx["all_docs_from_collection"] = all_docs_from_collection
+        gtx["float"] = float
+        gtx["str"] = str
+        gtx["zip"] = zip
+
+    def _presentations_by_talk(self):
+        """Return the ids of the presentations that name each talk.
+
+        A talk may have been given more than once, so every presentation
+        that names it is kept rather than only the last one found.
+        """
+        presentations = {}
+        for presentation in self.gtx["presentations"]:
+            talk_id = presentation.get("talk_id")
+            if talk_id:
+                presentations.setdefault(talk_id, []).append(presentation.get("_id"))
+        return presentations
+
+    def _presenter_name(self, talk):
+        """Return the name of the person who gives a talk."""
+        presenter = talk.get("presenter")
+        if not presenter:
+            return ""
+        person = get_person_contact(presenter, self.gtx["people"], self.gtx["contacts"])
+        if person is None:
+            return presenter
+        return person.get("name") or presenter
+
+    def _count_slides(self, talk):
+        """Return the number of sections and decks a talk is built
+        from."""
+        sections = talk.get("topics") or []
+        decks = 0
+        for section in sections:
+            decks += len(section.get("topics") or []) if "supertopic" in section else 1
+        return len(sections), decks
+
+    def sout(self):
+        rc = self.rc
+        talks = self.gtx["talks"]
+        presentations = self._presentations_by_talk()
+
+        if not getattr(rc, "all", False):
+            talks = [talk for talk in talks if talk.get("active", True)]
+        if rc.talk_id:
+            talks = [talk for talk in talks if rc.talk_id.casefold() in talk.get("_id", "").casefold()]
+        if rc.description:
+            talks = [
+                talk
+                for talk in talks
+                if rc.description.casefold() in (talk.get("talk_description") or "").casefold()
+            ]
+        if rc.presenter:
+            talks = [
+                talk
+                for talk in talks
+                if rc.presenter.casefold() in (talk.get("presenter") or "").casefold()
+                or rc.presenter.casefold() in self._presenter_name(talk).casefold()
+            ]
+        if rc.year:
+            talks = [talk for talk in talks if talk.get("year") == int(rc.year)]
+
+        if not talks:
+            print("No talks were found. Please loosen the filters and try again.")
+            return
+
+        for talk in talks:
+            given_at = presentations.get(talk.get("_id"))
+            given_at = ", ".join(given_at) if given_at else "no presentation"
+            print(f"{talk.get('_id')} - ({given_at})")
+            if rc.verbose:
+                presenter = self._presenter_name(talk)
+                if presenter:
+                    print(f"    presenter: {presenter}")
+                if talk.get("talk_description"):
+                    print(f"    description: {talk.get('talk_description')}")
+                sections, decks = self._count_slides(talk)
+                print(f"    {sections} sections built from {decks} decks")
+        return

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1223,6 +1223,57 @@ helper_map = [
     #   "--presentation-url", "http://drive.google.com/SEV356DV",
     #   "--no-cal", "--expense-db private-test"], # Expect a new presentation and new expense in db 'private-test'
     #    "2006na_testd has been added in presentations\n2006na_testd has been added in expenses in database private-test\n"),
+    # Test the talks lister, which shows each talk beside the presentations it was given at
+    (
+        # A filter on a fragment of the talk id, expect the talk and its presentation
+        ["helper", "l_talks", "--talk-id", "graphite"],
+        "30-graphite-rock - (18sb_nslsii)\n",
+    ),
+    (
+        # A filter on the presenter, expect the talk they give
+        ["helper", "l_talks", "--presenter", "sbillinge"],
+        "30-graphite-rock - (18sb_nslsii)\n",
+    ),
+    (
+        # A filter matching no talk, expect a message saying to loosen the filters
+        ["helper", "l_talks", "--talk-id", "nosuchtalk"],
+        "No talks were found. Please loosen the filters and try again.\n",
+    ),
+    (
+        # The verbose form, expect the presenter, the description and how the talk is built
+        ["helper", "l_talks", "--verbose"],
+        "30-graphite-rock - (18sb_nslsii)\n"
+        "    presenter: Simon J. L. Billinge\n"
+        "    description: An overview of the group's work on nanostructure, for a general audience.\n"
+        "    2 sections built from 3 decks\n",
+    ),
+    # Test the slides lister, which shows each deck and how many slides it holds
+    (
+        # A filter on a tag, expect only the deck carrying it
+        ["helper", "l_slides", "--tag", "introduction"],
+        "example-introduction - (2 slides) - introduction\n",
+    ),
+    (
+        # A filter on the title of a slide inside a deck, expect the deck holding it
+        ["helper", "l_slides", "--title", "nanostructure"],
+        "example-introduction - (2 slides) - introduction\n",
+    ),
+    (
+        # A filter matching no deck, expect a message saying to loosen the filters
+        ["helper", "l_slides", "--deck-id", "nosuchdeck"],
+        "No decks of slides were found. Please loosen the filters and try again.\n",
+    ),
+    (
+        # The verbose form, expect every slide with the index a slide_list would use
+        ["helper", "l_slides", "--verbose"],
+        "example-introduction - (2 slides) - introduction\n"
+        "    [0] text: What is local structure?\n"
+        "    [1] imageleft-2col: The nanostructure problem\n"
+        "example-methods - (3 slides) - methods\n"
+        "    [0] image: Measuring a pair distribution function\n"
+        "    [1] imageright-2col: From diffraction pattern to PDF\n"
+        "    [2] text: What the PDF tells us\n",
+    ),
 ]
 
 db_srcs = [


### PR DESCRIPTION
Add two lister helpers in helpers/l_talkshelper.py and helpers/l_slideshelper.py and register them in LISTER_HELPERS, replacing the standalone scripts that were kept alongside the talks database.

l_talks shows each talk beside the presentations it was given at, which is where the id needed to build one comes from, and l_slides shows each deck with the number of slides it holds, which is what a slide_list indexes into. Both take filters, since a plain dump of every talk or deck is hard to search: talks filter on a fragment of the id, of the description, on the presenter or on the year, and decks on a fragment of the id, on a tag or on the title of a slide they hold. Their verbose forms show how a talk is built and every slide of a deck with the index a slide_list would use.

Neither writes a file. The scripts wrote talks-list.txt and slide-list.txt to make the output searchable, which the filters now do instead.

Two things the scripts got wrong are not carried over. talklister mapped a talk to a single presentation, so a talk given more than once lost all but one of them, and every presentation is now listed. It also wrote its file with '\n'.join() applied to a string built from the first two entries alone, which spread those entries one character per line, while the output it printed was correct.

Talks that are no longer active are left out unless --all is given.