### PR TITLE
fix: say when the talks or slides collection is empty rather than bla…

### DIFF
--- a/news/listers-empty-collection-message.rst
+++ b/news/listers-empty-collection-message.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``l_talks`` and ``l_slides`` now say when the collection is empty, rather than telling
+  the reader to loosen filters they may not have set.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/l_slideshelper.py
+++ b/src/regolith/helpers/l_slideshelper.py
@@ -82,6 +82,13 @@ class SlidesListerHelper(SoutHelperBase):
         rc = self.rc
         decks = self.gtx["slides"]
 
+        if not decks:
+            print(
+                "The slides collection is empty, so there is nothing to list. Please run from a "
+                "directory whose regolithrc.json lists the database that holds slides.yml."
+            )
+            return
+
         if rc.deck_id:
             decks = [deck for deck in decks if rc.deck_id.casefold() in deck.get("_id", "").casefold()]
         if rc.tag:

--- a/src/regolith/helpers/l_talkshelper.py
+++ b/src/regolith/helpers/l_talkshelper.py
@@ -121,6 +121,13 @@ class TalksListerHelper(SoutHelperBase):
         talks = self.gtx["talks"]
         presentations = self._presentations_by_talk()
 
+        if not talks:
+            print(
+                "The talks collection is empty, so there is nothing to list. Please run from a "
+                "directory whose regolithrc.json lists the database that holds talks.yml."
+            )
+            return
+
         if not getattr(rc, "all", False):
             talks = [talk for talk in talks if talk.get("active", True)]
         if rc.talk_id:


### PR DESCRIPTION
…ming filters

An empty collection and a set of filters that excluded everything both printed the same message, telling the reader to loosen filters they may not have set. The two cases now read differently, and the empty collection points at the reason it is empty, which is that the run was made from a directory whose regolithrc.json does not list the database holding talks.yml or slides.yml.

Only the regolithrc.json beside the talks database lists that database, so listing talks from the local directory of another database found nothing and said so misleadingly.