### PR TITLE
fix: credit the authors of the presentation, and skip editorships

### DIFF
--- a/news/presentation-authors-from-presentation.rst
+++ b/news/presentation-authors-from-presentation.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The presentation builder credits the authors of the presentation, falling back to the
+  authorlist of the talk, rather than reading the talk alone.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``get_person_affiliation`` no longer takes an employment entry marked ``not_in_cv``,
+  such as an editorship held alongside a post, as a person's affiliation.
+* The institute line of a talk no longer runs ``\small`` into the text of a single
+  affiliation, which made an undefined control sequence.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/presentationbuilder.py
+++ b/src/regolith/builders/presentationbuilder.py
@@ -231,17 +231,23 @@ class PresentationBuilder(LatexBuilderBase):
         }
 
     def _get_authors(self, presentation, talk):
-        """Return the authors of a talk and the affiliations they share.
+        """Return the authors of a presentation and the affiliations
+        they share.
 
-        Authors keep the order the talk lists them in.  Affiliations are
-        numbered in the order they first appear, and an affiliation
-        shared by several authors is listed once, so that two authors in
-        the same department of the same institution carry the same
-        number while two departments of one institution stay apart.  The
-        author giving the presentation is marked so that the template
-        can pick them out.
+        The authors are the ones the presentation credits, falling back
+        to the authorlist of the talk for a presentation that names
+        none, since the same talk given on two occasions may credit
+        different people.  Authors keep the order they are listed in.
+        Affiliations are numbered in the order they first appear, and an
+        affiliation shared by several authors is listed once, so that
+        two authors in the same department of the same institution carry
+        the same number while two departments of one institution stay
+        apart.  The author giving the presentation is marked so that the
+        template can pick them out.
         """
-        authorlist = talk.get("authorlist") or []
+        # The presentation is the occasion, so the authors credited on it come first. A
+        # talk carries an authorlist only when its presentations do not say who to credit
+        authorlist = presentation.get("authors") or talk.get("authorlist") or []
         if isinstance(authorlist, str):
             authorlist = [authorlist]
         addresses = talk.get("addresses") or []

--- a/src/regolith/templates/talk.tex
+++ b/src/regolith/templates/talk.tex
@@ -12,7 +12,7 @@
 {%- if not loop.last %}, {% endif -%}
 {%- endfor -%}
 }
-\institute{\small
+\institute{\small{}
 {%- for affiliation in general['affiliations'] -%}
 {%- if general['affiliations']|length > 1 -%}\textsuperscript{ {{- loop.index -}} }{%- endif -%}
 {{- affiliation -}}

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -1337,6 +1337,10 @@ def _latest_employment(employment, now=None):
     one."""
     if now is None:
         now = date.today()
+    # An entry kept out of the cv, such as an editorship held alongside a post, is not the
+    # affiliation the person would put on a paper, so it is only used if it is all there is
+    substantive = [entry for entry in employment if not entry.get("not_in_cv")]
+    employment = substantive or employment
     current, ended, undated = [], [], []
     for entry in employment:
         dates = get_dates(entry)

--- a/tests/outputs/presentation/18sb_nslsii.tex
+++ b/tests/outputs/presentation/18sb_nslsii.tex
@@ -4,8 +4,8 @@
 \setbeamertemplate{caption}{\centering\raggedright\scriptsize\insertcaption\par}
 \title{ ClusterMining: extracting core structures of metallic nanoparticles from the atomic pair distribution function }
 \subtitle{  }
-\author{\underline{Simon J. L. Billinge}\textsuperscript{1}, Anthony B Friend\textsuperscript{2}, C. D. Sample\textsuperscript{3}}
-\institute{\small\textsuperscript{1}The University of South Carolina \\ \textsuperscript{2}Department of Physics, Columbia University \\ \textsuperscript{3}Department of Chemistry, Sample University, Boston, MA 02115, USA}
+\author{Anthony Scopatz}
+\institute{\small{}The University of South Carolina}
 \date{\today}
 \begin{document}
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3591,6 +3591,41 @@ AFFILIATION_PEOPLE = [
         "_id": "nemo",
         "name": "Captain Nemo",
     },
+    {
+        # A person holding an editorship, kept out of their cv, alongside their post. The
+        # editorship began later, so it would win on date alone
+        "_id": "reditor",
+        "name": "Rosalind Editor",
+        "employment": [
+            {
+                "begin_year": 2008,
+                "organization": "columbiau",
+                "department": "physics",
+                "position": "professor",
+            },
+            {
+                "begin_year": 2011,
+                "organization": "cambridge",
+                "department": "physics",
+                "position": "editor",
+                "not_in_cv": True,
+            },
+        ],
+    },
+    {
+        # A person whose only employment is kept out of their cv
+        "_id": "oeditor",
+        "name": "Only Editor",
+        "employment": [
+            {
+                "begin_year": 2011,
+                "organization": "cambridge",
+                "department": "physics",
+                "position": "editor",
+                "not_in_cv": True,
+            },
+        ],
+    },
 ]
 
 AFFILIATION_CONTACTS = [
@@ -3925,3 +3960,20 @@ def test_string_to_slice_applies_to_a_list():
     assert items[string_to_slice("[1:3]")] == ["b", "c"]
     assert items[string_to_slice("[:]")] == items
     assert items[string_to_slice("[0:5:2]")] == ["a", "c", "e"]
+
+
+@pytest.mark.parametrize(
+    "name_or_id, expected_department, expected_institution",
+    [
+        # Test that an employment entry kept out of the cv is not taken as the affiliation
+        # C1: A post held alongside an editorship that began later, expect the post, since an
+        # editorship is not what the person would put on a paper
+        ("reditor", "Department of Physics", "Columbia University"),
+        # C2: An editorship as the only employment, expect it used rather than nothing
+        ("oeditor", "Cavendish Laboratory", "University of Cambridge"),
+    ],
+)
+def test_get_person_affiliation_skips_not_in_cv(name_or_id, expected_department, expected_institution):
+    actual = get_person_affiliation(name_or_id, AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS)
+    assert actual["department"] == expected_department
+    assert actual["institution"] == expected_institution


### PR DESCRIPTION
Three things kept the title page of a talk from naming its authors correctly.

The builder read the authorlist of the talk, which in practice is empty, since the authors are recorded on the presentation. It now credits the authors of the presentation and falls back to the authorlist of the talk, which is the right way round: the presentation is the occasion, and the same talk given twice may credit different people. In a database of 53 talks and 56 presentations that name one, no talk carried an authorlist and every presentation carried authors, so before this the title page named the presenter alone.

get_person_affiliation took the most recently begun of the employment entries current on the date asked for, which for someone holding an editorship alongside their post was the editorship. Entries marked not_in_cv are now left out, since an entry kept out of a cv is not what the person would put on a paper. An entry marked that way is still used when it is the only one there is.

The institute line wrote \small directly against the text of a single affiliation, making the undefined control sequence \smallThe. It now writes an empty group after the declaration.