### PR TITLE
fix: render the data management plan and other comments in propreport…

### DIFF
--- a/news/render-doe-review-fields.rst
+++ b/news/render-doe-review-fields.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* ``doe_appropriateness_data_management_plan`` and ``doe_other`` to the exemplar DOE
+  proposal review, so the new sections of the report are covered by the tests.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The proposal review report now prints the reviewer's answers on the data management
+  and sharing plan and their other comments.  ``a_proprev`` has been prompting for both
+  since the DOE prompt update, but ``propreport.txt`` never rendered them, so the
+  answers were collected and silently dropped.  Reviews written before those fields
+  existed are read with a default, and the NSF report is unchanged.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/proposalreviewbuilder.py
+++ b/src/regolith/builders/proposalreviewbuilder.py
@@ -66,6 +66,8 @@ class PropRevBuilder(LatexBuilderBase):
                 does_what=rev["does_what"],
                 relevance=rev["doe_relevance_to_program_mission"],
                 budget=rev["doe_reasonableness_of_budget"],
+                data_management_plan=rev.get("doe_appropriateness_data_management_plan", []),
+                other=rev.get("doe_other", []),
                 does_how=rev["does_how"],
                 goals=rev["goals"],
                 importance=rev["importance"],

--- a/src/regolith/exemplars.json
+++ b/src/regolith/exemplars.json
@@ -1867,8 +1867,14 @@
             ],
             "agency": "doe",
             "competency_of_team": ["super competent!"],
+            "doe_appropriateness_data_management_plan": [
+                "The DMSP names a repository and is appropriate"
+            ],
             "doe_appropriateness_of_approach": [
                 "The proposed approach is highly innovative"
+            ],
+            "doe_other": [
+                "The team should say more about the mosquito nets"
             ],
             "doe_reasonableness_of_budget": ["They could do it with half the money"],
             "doe_relevance_to_program_mission": ["super relevant"],

--- a/src/regolith/templates/propreport.txt
+++ b/src/regolith/templates/propreport.txt
@@ -86,6 +86,20 @@ Relevance to Program Mission:
 {%- for thing in relevance %}
   - {{ thing -}}
 {% endfor %}
+{% if len(data_management_plan) > 0 %}
+
+Appropriateness of the Data Management and Sharing Plan:
+{%- for thing in data_management_plan %}
+  - {{ thing -}}
+{% endfor %}
+{% endif %}
+{% if len(other) > 0 %}
+
+Other comments:
+{%- for thing in other %}
+  - {{ thing -}}
+{% endfor %}
+{% endif %}
 {% endif %}
 
 {% if agency.lower() == "nsf"%}

--- a/tests/outputs/review-prop/1906doeExample_sbillinge.txt
+++ b/tests/outputs/review-prop/1906doeExample_sbillinge.txt
@@ -44,6 +44,16 @@ Relevance to Program Mission:
   - super relevant
 
 
+Appropriateness of the Data Management and Sharing Plan:
+  - The DMSP names a repository and is appropriate
+
+
+
+Other comments:
+  - The team should say more about the mosquito nets
+
+
+
 
 
 


### PR DESCRIPTION
….txt

a_proprev prompts the reviewer on the DOE data management and sharing plan and for any other comments, but propreport.txt had no section for either, so proposalreviewbuilder.py never passed them to the template and the answers were collected and silently dropped.

Pass both to the template from proposalreviewbuilder.py and add the two sections to propreport.txt, nested in the existing doe conditional so the NSF report is byte for byte unchanged. Reviews written before these fields existed do not carry the keys, so read them with a default. Add both fields to the exemplar DOE review to cover the new sections, and leave them off the NSF exemplar so the default is covered too.


Claude-Session: https://claude.ai/code/session_014wDbJKU4zfKqSu8WUtJCMm