### PR TITLE
test: compare the a_proprev output again, with a fixed date

### DIFF
--- a/news/a-proprev-fixture-date.rst
+++ b/news/a-proprev-fixture-date.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* ``--date`` option to the ``a_proprev`` helper, so tests can fix the date that the
+  document id is built from.  It follows the convention already used by
+  ``a_proposal``, ``a_grppub_readlist``, ``u_milestone`` and ``l_progressreport``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The expected ``a_proprev`` output is compared again.  It sat in
+  ``tests/outputs/helper/proposalReviews.yml``, where the test never looked, so it
+  went stale and the helper had no output coverage.  Moved to
+  ``tests/outputs/a_proprev/proposalReviews.yaml``, the name the test builds from the
+  helper name and the extension the helper writes, and refreshed to the current output.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/a_proprevhelper.py
+++ b/src/regolith/helpers/a_proprevhelper.py
@@ -4,6 +4,7 @@ import datetime as dt
 import sys
 
 import nameparser
+from dateutil import parser as date_parser
 from gooey import GooeyParser
 
 from regolith.dates import month_to_str_int
@@ -35,6 +36,7 @@ def subparser(subpi):
         "-s", "--status", choices=ALLOWED_STATI, help="Report status", default="accepted", type=strip_str
     )
     subpi.add_argument("-t", "--title", help="the title of the proposal", type=strip_str)
+    subpi.add_argument("--date", help="The date that will be used for testing.", type=strip_str, **date_kwargs)
     return subpi
 
 
@@ -61,8 +63,12 @@ class PropRevAdderHelper(DbHelperBase):
     def db_updater(self):
         rc = self.rc
         name = nameparser.HumanName(rc.name)
-        month = dt.datetime.today().month
-        year = dt.datetime.today().year
+        if rc.date:
+            now = date_parser.parse(rc.date).date()
+        else:
+            now = dt.date.today()
+        month = now.month
+        year = now.year
         key = "{}{}_{}_{}".format(
             str(year)[-2:], month_to_str_int(month), name.last.casefold(), name.first.casefold().strip(".")
         )

--- a/tests/outputs/a_proprev/proposalReviews.yaml
+++ b/tests/outputs/a_proprev/proposalReviews.yaml
@@ -19,8 +19,8 @@
     - I can put extra things here, such as special instructions from the
     - program officer
   goals:
-    - The goals of the proposal are to put together a team to find a curefor Malaria,
-      and then to find it
+    - The goals of the proposal are to put together a team to find a cure for 
+      Malaria, and then to find it
   importance:
     - save lives
     - lift people from poverty
@@ -54,16 +54,14 @@
     - when they find it they will determine a cure
   does_what: Find a cure for Poverty
   due_date: '2020-04-10'
-  freewrite:
-    - I can put extra things here, such as special instructions from the
-    - program officer
+  freewrite: I can put extra things here, such as special instructions from the
   goals:
-    - The goals of the proposal are to put together a team to find a curefor Poverty,
-      and then to find it
+    - The goals of the proposal are to put together a team to find a cure for 
+      Poverty, and then to find it
   importance:
     - save lives
     - lift people from poverty
-  institutions: upenn
+  institutions: []
   month: May
   names:
     - A Genius
@@ -80,7 +78,7 @@
     - Society will benefit by poor people being made unpoor if they want to be
   requester: Tessemer Guebre
   reviewer: sbillinge
-  status: invited,accepted,declined,downloaded,inprogress,submitted
+  status: submitted
   summary: dynamite proposal
   title: A stunning new way to cure Poverty
   year: 2019
@@ -88,9 +86,36 @@
   adequacy_of_resources:
     - The resources available to the PI seem adequate
   agency: nsf
-  competency_of_team: []
-  doe_appropriateness_of_approach: []
-  doe_reasonableness_of_budget: []
+  competency_of_team:
+    - For renewal applications, what is the past performance and potential of 
+      the research team? How well qualified is the research team to carry out 
+      the proposed research? Is the lead institution proposing to perform a 
+      greater portion of the scientific and technical work than any other team 
+      member? Are the research environment and facilities adequate for 
+      performing the research? Does the proposed work take advantage of unique 
+      facilities and capabilities?
+  doe_appropriateness_data_management_plan:
+    - To what extent does the Data Management and Sharing Plan (DMSP) enable 
+      data generated in the course of the research project to be publicly shared
+      and preserved in a timely and fair manner that enables validation and 
+      replication of results? How well do the selected digital repositories 
+      enable appropriate sharing of scientific data? Does the DMSP adequately 
+      justify any limitations of data sharing?  Are there any weaknesses in the 
+      DMSP that should be addressed prior to the start of the project?
+  doe_appropriateness_of_approach:
+    - How logical and feasible are the research approaches? Does the proposed 
+      research employ innovative concepts or methods? Are the conceptual 
+      framework, methods, and analyses well justified, adequately developed, and
+      likely to lead to scientifically valid conclusions? Does the applicant 
+      recognize significant potential problems and consider alternative 
+      strategies? Is the proposed research aligned with the published priorities
+      identified or incorporated by reference in Section III of this NOFO? Does 
+      the proposed plan to recruit and retain students and early-stage 
+      investigators provide sufficient mentorship?
+  doe_other: []
+  doe_reasonableness_of_budget:
+    - Are the proposed budget and staffing levels adequate to carry out the 
+      proposed research? Is the budget reasonable and appropriate for the scope?
   doe_relevance_to_program_mission: []
   does_how: []
   does_what: ''
@@ -99,7 +124,7 @@
   goals: []
   importance: []
   institutions: []
-  month: tbd
+  month: 4
   names: A. Einstein
   nsf_broader_impacts: []
   nsf_create_original_transformative: []

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1104,6 +1104,8 @@ helper_map = [
             "downloaded",
             "--title",
             "A flat world theory",
+            "--date",
+            "2020-04-08",
         ],
         "A. Einstein proposal has been added/updated in proposal reviews\n",
     ),


### PR DESCRIPTION
The expected output for a_proprev sat in
tests/outputs/helper/proposalReviews.yml, but test_helper_python builds expecteddir from the helper name, so it looked for tests/outputs/a_proprev and found nothing. The extension was wrong too, since the helper writes proposalReviews.yaml. The fixture was therefore never compared and had gone stale, leaving a_proprev with no coverage of what it writes.

Move it to tests/outputs/a_proprev/proposalReviews.yaml and refresh it from the current output. The document id is built from today's date, so add the usual --date test hook to a_proprevhelper.py and pass it from the test case, otherwise the revived fixture would go stale again every month.


Claude-Session: https://claude.ai/code/session_014wDbJKU4zfKqSu8WUtJCMm