### PR TITLE
test: add the new doe fields to the expected a_proprev output

### DIFF
--- a/news/a-proprev-fixture-doe-fields.rst
+++ b/news/a-proprev-fixture-doe-fields.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The expected ``a_proprev`` output now carries the two DOE fields that were added to
+  the exemplar proposal review.  The fixture is a snapshot of the whole
+  ``proposalReviews`` collection, so adding a field to any document in it changes the
+  file, and the two changes were written against a ``main`` that did not yet have the
+  other.
+
+**Security:**
+
+* <news item>

--- a/tests/outputs/a_proprev/proposalReviews.yaml
+++ b/tests/outputs/a_proprev/proposalReviews.yaml
@@ -4,8 +4,12 @@
   agency: doe
   competency_of_team:
     - super competent!
+  doe_appropriateness_data_management_plan:
+    - The DMSP names a repository and is appropriate
   doe_appropriateness_of_approach:
     - The proposed approach is highly innovative
+  doe_other:
+    - The team should say more about the mosquito nets
   doe_reasonableness_of_budget:
     - They could do it with half the money
   doe_relevance_to_program_mission:


### PR DESCRIPTION
The expected output in tests/outputs/a_proprev/proposalReviews.yaml is a snapshot of the whole proposalReviews collection, so it also records the exemplar reviews. Adding doe_appropriateness_data_management_plan and doe_other to the exemplar doe review changed that file, but the two changes were written against a main that did not yet have the other, so each passed on its own and main went red once both had merged.

Refresh the snapshot against the current exemplars.


Claude-Session: https://claude.ai/code/session_014wDbJKU4zfKqSu8WUtJCMm