### PR TITLE
fix: compose database paths with pathlib in tools.py and fsclient.py

### DIFF
--- a/news/fix-windows-filepaths.rst
+++ b/news/fix-windows-filepaths.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Database directory and file paths in ``tools.dbdirname``, ``tools.dbpathname``,
+  ``fsclient.py``, ``mongoclient.py`` and ``database.xsh`` are now composed with
+  ``pathlib.Path`` instead of ``os.path`` string joins.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``OSError: [Errno 22] Invalid argument`` when dumping collections on Windows under
+  python 3.14.  A posix-style ``url`` or ``path`` in ``regolithrc.json`` was joined as a
+  string, producing a filename such as ``..\../rg-db-private/db\people.yml`` that mixes
+  ``/`` and ``\`` separators.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/database.xsh
+++ b/src/regolith/database.xsh
@@ -1,6 +1,6 @@
 """Helps manage mongodb setup and connections."""
-import os
 from contextlib import contextmanager
+from pathlib import Path
 from warnings import warn
 
 from xonsh.api import subprocess
@@ -20,14 +20,14 @@ def load_git_database(db, client, rc):
     """Loads a git database"""
     dbdir = dbdirname(db, rc)
     # get or update the database
-    if os.path.isdir(dbdir):
-        with indir(dbdir):
+    if dbdir.is_dir():
+        with indir(str(dbdir)):
             (![git pull upstream master]
              or ![git pull origin master]
              or ![git pull])
     else:
-        git clone @(db['url']) @(dbdir)
-    with indir(dbdir):
+        git clone @(db['url']) @(str(dbdir))
+    with indir(str(dbdir)):
         if getattr(rc, 'branch', None):
             branch = rc.branch
             git checkout @(branch) or git checkout -b @(branch) master
@@ -42,12 +42,12 @@ def load_hg_database(db, client, rc):
         raise ImportError('hglib')
     dbdir = dbdirname(db, rc)
     # get or update the database
-    if os.path.isdir(dbdir):
-        client = hglib.open(dbdir)
+    if dbdir.is_dir():
+        client = hglib.open(str(dbdir))
         client.pull(update=True, force=True)
     else:
         # Strip off three characters for hg+
-        client = hglib.clone(db['url'][3:], dbdir)
+        client = hglib.clone(db['url'][3:], str(dbdir))
     # import all of the data
     client.load_database(db)
 
@@ -55,7 +55,7 @@ def load_hg_database(db, client, rc):
 def load_local_database(db, client, rc):
     """Loads a local database"""
     # make sure that we expand user stuff
-    db['url'] = os.path.expanduser(db['url'])
+    db['url'] = str(Path(db['url']).expanduser())
     # import all of the data
     client.load_database(db)
 
@@ -75,7 +75,7 @@ def load_database(db, client, rc):
         load_git_database(db, client, rc)
     elif url.startswith('hg+'):
         load_hg_database(db, client, rc)
-    elif os.path.exists(os.path.expanduser(url)):
+    elif Path(url).expanduser().exists():
         load_local_database(db, client, rc)
     else:
         raise ValueError('Do not know how to load this kind of database: '
@@ -96,7 +96,7 @@ def dump_git_database(db, client, rc):
     try:
         subprocess.check_call(cmd, cwd=dbdir)
     except subprocess.CalledProcessError:
-        warn('Could not git commit to ' + dbdir, RuntimeWarning)
+        warn('Could not git commit to ' + str(dbdir), RuntimeWarning)
         return
     cmd = ['git', 'push']
     if hasattr(rc, 'remote') and hasattr(rc, 'branch'):
@@ -104,7 +104,7 @@ def dump_git_database(db, client, rc):
     try:
         subprocess.check_call(cmd, cwd=dbdir)
     except subprocess.CalledProcessError:
-        warn('Could not git push from ' + dbdir, RuntimeWarning)
+        warn('Could not git push from ' + str(dbdir), RuntimeWarning)
         return
 
 
@@ -141,7 +141,7 @@ def dump_database(db, client, rc):
         dump_git_database(db, client, rc)
     elif url.startswith('hg+'):
         dump_hg_database(db, client, rc)
-    elif os.path.exists(url):
+    elif Path(url).expanduser().exists():
         dump_local_database(db, client, rc)
     else:
         raise ValueError('Do not know how to dump this kind of database')

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -3,12 +3,11 @@
 import datetime
 import json
 import logging
-import os
 import signal
 import sys
 from collections import defaultdict
 from copy import deepcopy
-from glob import iglob
+from pathlib import Path
 
 import ruamel.yaml
 from ruamel.yaml import YAML
@@ -58,7 +57,7 @@ def _id_key(doc):
 def load_json(filename):
     """Loads a JSON file and returns a dict of its documents."""
     docs = {}
-    with open(filename, encoding="utf-8") as fh:
+    with Path(filename).open(encoding="utf-8") as fh:
         lines = fh.readlines()
     for line in lines:
         doc = json.loads(line)
@@ -76,7 +75,7 @@ def dump_json(filename, docs, date_handler=None):
     docs = sorted(docs.values(), key=_id_key)
     lines = [json.dumps(doc, sort_keys=True, default=date_handler) for doc in docs]
     s = "\n".join(lines)
-    with open(filename, "w", encoding="utf-8") as fh:
+    with Path(filename).open("w", encoding="utf-8") as fh:
         fh.write(s)
 
 
@@ -86,7 +85,7 @@ def load_yaml(filename, return_inst=False, loader=None):
         inst = YAML()
     else:
         inst = loader
-    with open(filename, encoding="utf-8") as fh:
+    with Path(filename).open(encoding="utf-8") as fh:
         docs = inst.load(fh)
         docs = _rec_re_type(docs)
     for _id, doc in docs.items():
@@ -106,7 +105,7 @@ def dump_yaml(filename, docs, inst=None):
         sorted_dict[k] = ruamel.yaml.comments.CommentedMap()
         for kk in sorted(doc.keys()):
             sorted_dict[k][kk] = doc[kk]
-    with open(filename, "w", encoding="utf-8") as fh:
+    with Path(filename).open("w", encoding="utf-8") as fh:
         with DelayedKeyboardInterrupt():
             inst.dump(sorted_dict, stream=fh)
 
@@ -150,15 +149,14 @@ class FileSystemClient:
         dbs = self.dbs
         for f in [
             file
-            for file in iglob(os.path.join(dbpath, "*.json"))
-            if file not in db["blacklist"]
+            for file in sorted(Path(dbpath).glob("*.json"))
+            if str(file) not in db["blacklist"]
             and len(db["whitelist"]) == 0
-            or os.path.basename(file).split(".")[0] in db["whitelist"]
+            or file.name.split(".")[0] in db["whitelist"]
         ]:
-            collfilename = os.path.split(f)[-1]
-            base, ext = os.path.splitext(collfilename)
+            base = f.stem
             self._collfiletypes[base] = "json"
-            print("loading " + f + "...", file=sys.stderr)
+            print("loading " + str(f) + "...", file=sys.stderr)
             dbs[db["name"]][base] = load_json(f)
 
     def load_yaml(self, db, dbpath):
@@ -166,19 +164,18 @@ class FileSystemClient:
         dbs = self.dbs
         for f in [
             file
-            for file in iglob(os.path.join(dbpath, "*.y*ml"))
-            if file not in db["blacklist"]
+            for file in sorted(Path(dbpath).glob("*.y*ml"))
+            if str(file) not in db["blacklist"]
             and len(db["whitelist"]) == 0
-            or os.path.basename(file).split(".")[0] in db["whitelist"]
+            or file.name.split(".")[0] in db["whitelist"]
         ]:
-            collfilename = os.path.split(f)[-1]
-            base, ext = os.path.splitext(collfilename)
+            base, ext = f.stem, f.suffix
             self._collexts[base] = ext
             self._collfiletypes[base] = "yaml"
             # print("loading " + f + "...", file=sys.stderr)
             coll, inst = load_yaml(f, return_inst=True)
             dbs[db["name"]][base] = coll
-            self._yamlinsts[dbpath, base] = inst
+            self._yamlinsts[Path(dbpath), base] = inst
 
     def load_database(self, db):
         """Loads a database."""
@@ -188,23 +185,21 @@ class FileSystemClient:
 
     def dump_json(self, docs, collname, dbpath):
         """Dumps json docs and returns filename."""
-        f = os.path.join(dbpath, collname + ".json")
+        f = Path(dbpath) / (collname + ".json")
         dump_json(f, docs)
-        filename = os.path.split(f)[-1]
-        return filename
+        return f.name
 
     def dump_yaml(self, docs, collname, dbpath):
         """Dumps json docs and returns filename."""
-        f = os.path.join(dbpath, collname + self._collexts.get(collname, ".yaml"))
-        inst = self._yamlinsts.get((dbpath, collname), None)
+        f = Path(dbpath) / (collname + self._collexts.get(collname, ".yaml"))
+        inst = self._yamlinsts.get((Path(dbpath), collname), None)
         dump_yaml(f, docs, inst=inst)
-        filename = os.path.split(f)[-1]
-        return filename
+        return f.name
 
     def dump_database(self, db):
         """Dumps a database back to the filesystem."""
         dbpath = dbpathname(db, self.rc)
-        os.makedirs(dbpath, exist_ok=True)
+        Path(dbpath).mkdir(parents=True, exist_ok=True)
         to_add = []
         for collname, collection in self.dbs[db["name"]].items():
             # print("dumping " + collname + "...", file=sys.stderr)
@@ -215,7 +210,7 @@ class FileSystemClient:
                 filename = self.dump_yaml(collection, collname, dbpath)
             else:
                 raise ValueError("did not recognize file type for regolith")
-            to_add.append(os.path.join(db["path"], filename))
+            to_add.append(str(Path(db["path"]) / filename))
         return to_add
 
     def close(self):

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -135,7 +135,7 @@ def export_json(collection: str, dbpath: str, dbname: str, host: str = None, uri
         cmd += ["--host", host, "--db", dbname]
     if uri is not None:
         cmd += ["--uri", uri]
-    cmd += ["--out", str(os.path.join(dbpath, collection + ".json"))]
+    cmd += ["--out", str(Path(dbpath) / (collection + ".json"))]
     try:
         subprocess.check_call(cmd, stderr=subprocess.STDOUT)
     except FileNotFoundError:
@@ -433,7 +433,7 @@ class MongoClient:
         if uri == "localhost":
             uri = None
             host = "localhost"
-        dbpath = os.path.abspath(dbpathname(db, self.rc))
+        dbpath = Path(dbpathname(db, self.rc)).resolve()
         dbname = db["name"]
         for collection in self.dbs[dbname].keys():
             export_json(collection, dbpath, dbname, host=host, uri=uri)
@@ -441,12 +441,12 @@ class MongoClient:
 
     def dump_database(self, db):
         """Dumps a database dict via mongoexport."""
-        dbpath = dbpathname(db, self.rc)
-        os.makedirs(dbpath, exist_ok=True)
+        dbpath = Path(dbpathname(db, self.rc))
+        dbpath.mkdir(parents=True, exist_ok=True)
         to_add = []
         colls = self.client[db["name"]].collection_names(include_system_collections=False)
         for collection in colls:
-            f = os.path.join(dbpath, collection + ".json")
+            f = str(dbpath / (collection + ".json"))
             cmd = [
                 "mongoexport",
                 "--db",
@@ -461,7 +461,7 @@ class MongoClient:
             except subprocess.CalledProcessError as exc:
                 print("Status : FAIL", exc.returncode, exc.output)
                 raise exc
-            to_add.append(os.path.join(db["path"], collection + ".json"))
+            to_add.append(str(Path(db["path"]) / (collection + ".json")))
         return to_add
 
     def close(self):

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -61,19 +61,48 @@ MISSING_INFO = "MISSING"
 
 
 def dbdirname(db, rc):
-    """Gets the database dir name."""
+    """Get the directory that holds a database as a pathlib.Path.
+
+    Parameters
+    ----------
+    db : dict
+        The database description.  A remote database is cached under
+        the build directory, a local one lives at its own ``url``.
+    rc : RunControl
+        The run control instance supplying ``builddir``.
+
+    Returns
+    -------
+    pathlib.Path
+        The directory of the database.  Building it with pathlib keeps
+        the separators native, so a posix-style ``url`` read from the
+        rc file does not leave mixed separators on Windows.
+    """
     if db.get("local", False) is False:
-        dbsdir = os.path.join(rc.builddir, "_dbs")
-        dbdir = os.path.join(dbsdir, db["name"])
+        dbdir = pathlib.Path(rc.builddir) / "_dbs" / db["name"]
     else:
-        dbdir = db["url"]
+        dbdir = pathlib.Path(db["url"])
     return dbdir
 
 
 def dbpathname(db, rc):
-    """Gets the database path name."""
-    dbdir = dbdirname(db, rc)
-    dbpath = os.path.join(dbdir, db["path"])
+    """Get the directory that holds the collection files as a
+    pathlib.Path.
+
+    Parameters
+    ----------
+    db : dict
+        The database description, supplying ``path`` relative to the
+        database directory.
+    rc : RunControl
+        The run control instance supplying ``builddir``.
+
+    Returns
+    -------
+    pathlib.Path
+        The directory of the collection files.
+    """
+    dbpath = dbdirname(db, rc) / db["path"]
     return dbpath
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,7 @@
 import copy
 import datetime as dt
+import os
+from pathlib import PurePath
 
 import habanero
 import pytest
@@ -15,6 +17,8 @@ from regolith.tools import (
     compound_list,
     create_repo,
     date_to_rfc822,
+    dbdirname,
+    dbpathname,
     dereference_institution,
     filter_employment_for_advisees,
     filter_presentations,
@@ -3977,3 +3981,45 @@ def test_get_person_affiliation_skips_not_in_cv(name_or_id, expected_department,
     actual = get_person_affiliation(name_or_id, AFFILIATION_PEOPLE, AFFILIATION_CONTACTS, AFFILIATION_INSTITUTIONS)
     assert actual["department"] == expected_department
     assert actual["institution"] == expected_institution
+
+
+@pytest.mark.parametrize(
+    "db, expected_parts",
+    [
+        # Test that database directories are composed with pathlib so that posix-style
+        # entries in the rc file do not leave mixed separators on Windows
+        # C1: A remote database, expect it cached under the build directory
+        ({"name": "test-db", "path": "db", "url": "https://example.com/db.git"}, ("_build", "_dbs", "test-db")),
+        # C2: A local database whose url is posix-style, expect the url used as given
+        (
+            {"name": "test-db", "path": "db", "url": "../../rg-db-private", "local": True},
+            ("..", "..", "rg-db-private"),
+        ),
+    ],
+)
+def test_dbdirname(db, expected_parts):
+    rc = copy.copy(DEFAULT_RC)
+    actual = dbdirname(db, rc)
+    assert isinstance(actual, PurePath)
+    assert actual.parts == expected_parts
+
+
+@pytest.mark.parametrize(
+    "db",
+    [
+        # Test that the collection directory of a local database is composed with the
+        # native separator only.  A str-joined path mixes "/" and "\\" on Windows, which
+        # python 3.14 refuses to open with "OSError: [Errno 22] Invalid argument"
+        # C1: A posix-style url carrying the parent hops, expect the parent hops kept
+        {"name": "test-db", "path": "db", "url": "../../rg-db-private", "local": True},
+        # C2: A posix-style multi-component path carrying the parent hops, expect the
+        # same directory, since it is the join of url and path that has to stay native
+        {"name": "test-db", "path": "../rg-db-private/db", "url": "..", "local": True},
+    ],
+)
+def test_dbpathname_has_no_foreign_separators(db):
+    rc = copy.copy(DEFAULT_RC)
+    actual = dbpathname(db, rc)
+    assert actual.parts == ("..", "..", "rg-db-private", "db")
+    foreign_sep = "/" if os.sep == "\\" else "\\"
+    assert foreign_sep not in str(actual)


### PR DESCRIPTION
Dumping a collection on Windows under python 3.14 raised "OSError: [Errno 22] Invalid argument" when the database url or path in regolithrc.json was written posix-style. dbdirname and dbpathname joined those entries as strings, so a url of ".." and a path of "../rg-db-private/db" produced "..\../rg-db-private/db\people.yml", which mixes "/" and "\" separators.

Build the paths with pathlib.Path instead, in tools.py where url and path are joined and throughout fsclient.py, mongoclient.py and database.xsh where they are globbed, opened and passed on. dbdirname and dbpathname now return a Path, and collection files load in sorted order rather than in filesystem order.


Claude-Session: https://claude.ai/code/session_014wDbJKU4zfKqSu8WUtJCMm