### PR TITLE
fix: dump only modified collections so reads leave the database alone

### DIFF
--- a/news/no-dump-on-read.rst
+++ b/news/no-dump-on-read.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``FileSystemClient.dump_database`` and ``ClientManager.dump_database`` take a
+  ``force`` keyword that writes every loaded collection, as the pre-existing
+  behavior did.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Commands that only read the database no longer rewrite every collection file
+  on the way out.  The filesystem client now tracks which collections were
+  modified and dumps only those, so listers and builders leave the database
+  untouched and git-backed databases are no longer auto-committed and pushed
+  after a read.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/broker.py
+++ b/src/regolith/broker.py
@@ -57,8 +57,10 @@ class Broker:
         if "files" not in document:
             document["files"] = {}
         document["files"][name] = output_path
+        # The document is edited in place rather than through the client, so
+        # the client has no record of the change and has to be forced to write.
         for db in self.rc.databases:
-            dump_database(db, self.db_client, self.rc)
+            dump_database(db, self.db_client, self.rc, force=True)
         push(self.store.store, self.store.path)
 
     @classmethod

--- a/src/regolith/client_manager.py
+++ b/src/regolith/client_manager.py
@@ -78,13 +78,29 @@ class ClientManager:
             if isinstance(client, MongoClient):
                 client.export_database(db)
 
-    def dump_database(self, db):
+    def dump_database(self, db, force=False):
+        """Dump a database with each client that backs it.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``name`` and ``backend``.
+        force : bool, optional
+            The switch to write every loaded collection rather than only
+            the modified ones.  The default is False.
+
+        Returns
+        -------
+        list of str
+            The paths, relative to the database directory, of the files
+            that were written.
+        """
         to_add = []
         # Iterate through the clients just in case databases on different backends have same name
         for client in self.clients:
             if isinstance(client, CLIENTS[db["backend"]]):
                 if db["name"] in client.keys():
-                    temp_add = client.dump_database(db)
+                    temp_add = client.dump_database(db, force=force)
                     if temp_add:
                         to_add.extend(temp_add)
         return to_add

--- a/src/regolith/database.xsh
+++ b/src/regolith/database.xsh
@@ -82,11 +82,14 @@ def load_database(db, client, rc):
                          '{}'.format(db))
 
 
-def dump_git_database(db, client, rc):
+def dump_git_database(db, client, rc, force=False):
     """Dumps a git database"""
     dbdir = dbdirname(db, rc)
-    # dump all of the data
-    to_add = client.dump_database(db)
+    # dump the data that changed
+    to_add = client.dump_database(db, force=force)
+    if not to_add:
+        # nothing was modified, so there is nothing to commit or push
+        return
     # update the repo
     cmd = ['git', 'add', '']
     for file in to_add:
@@ -108,11 +111,14 @@ def dump_git_database(db, client, rc):
         return
 
 
-def dump_hg_database(db, client, rc):
+def dump_hg_database(db, client, rc, force=False):
     """Dumps an hg database"""
     dbdir = dbdirname(db, rc)
-    # dump all of the data
-    to_add = client.dump_database(db)
+    # dump the data that changed
+    to_add = client.dump_database(db, force=force)
+    if not to_add:
+        # nothing was modified, so there is nothing to commit or push
+        return
     # update the repo
     hgclient = hglib.open(dbdir)
     if len(hgclient.status(include=to_add, modified=True,
@@ -123,26 +129,30 @@ def dump_hg_database(db, client, rc):
     hgclient.push()
 
 
-def dump_local_database(db, client, rc):
+def dump_local_database(db, client, rc, force=False):
     """Dumps a local database"""
-    dbdir = dbdirname(db, rc)
-    # dump all of the data
-    client.dump_database(db)
+    # dump the data that changed
+    client.dump_database(db, force=force)
     return
 
 
-def dump_database(db, client, rc):
-    """Dumps a database"""
+def dump_database(db, client, rc, force=False):
+    """Dumps a database
+
+    Only the collections that were modified since they were loaded are
+    written, unless ``force`` is set, so a command that reads without
+    writing leaves the database files untouched.
+    """
     # do not dump mongo db
     if db['backend'] in ('mongo', 'mongodb'):
         return
     url = db['url']
     if url.startswith('git') or url.endswith('.git'):
-        dump_git_database(db, client, rc)
+        dump_git_database(db, client, rc, force=force)
     elif url.startswith('hg+'):
-        dump_hg_database(db, client, rc)
+        dump_hg_database(db, client, rc, force=force)
     elif Path(url).expanduser().exists():
-        dump_local_database(db, client, rc)
+        dump_local_database(db, client, rc, force=force)
     else:
         raise ValueError('Do not know how to dump this kind of database')
 

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -130,6 +130,7 @@ class FileSystemClient:
         self.closed = True
         self.dbs = None
         self.chained_db = None
+        self._dirty = set()
         self.open()
         self._collfiletypes = {}
         self._collexts = {}
@@ -142,7 +143,42 @@ class FileSystemClient:
         if self.closed:
             self.dbs = defaultdict(lambda: defaultdict(dict))
             self.chained_db = {}
+            self._dirty = set()
             self.closed = False
+
+    def mark_dirty(self, dbname, collname):
+        """Record that a collection has changes that are not yet on
+        disk.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection that was modified.
+        """
+        self._dirty.add((dbname, collname))
+
+    def is_dirty(self, dbname, collname=None):
+        """Return True if a collection, or any collection of a database,
+        has changes that are not yet on disk.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database to check.
+        collname : str, optional
+            The name of the collection to check.  The default checks
+            every collection of the database.
+
+        Returns
+        -------
+        bool
+            The dirty state of the requested collection or database.
+        """
+        if collname is not None:
+            return (dbname, collname) in self._dirty
+        return any(dirty_dbname == dbname for dirty_dbname, _ in self._dirty)
 
     def load_json(self, db, dbpath):
         """Loads the JSON part of a database."""
@@ -196,13 +232,38 @@ class FileSystemClient:
         dump_yaml(f, docs, inst=inst)
         return f.name
 
-    def dump_database(self, db):
-        """Dumps a database back to the filesystem."""
+    def dump_database(self, db, force=False):
+        """Dump the modified collections of a database back to the
+        filesystem.
+
+        A collection is written only if it was modified since it was
+        loaded, so a command that reads without writing leaves the
+        database files untouched.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``name`` and ``path``.
+        force : bool, optional
+            The switch to write every loaded collection rather than only
+            the modified ones.  The default is False.
+
+        Returns
+        -------
+        list of str
+            The paths, relative to the database directory, of the files
+            that were written.
+        """
+        dbname = db["name"]
+        collnames = [collname for collname in self.dbs[dbname] if force or self.is_dirty(dbname, collname)]
+        if not collnames:
+            return []
         dbpath = dbpathname(db, self.rc)
         Path(dbpath).mkdir(parents=True, exist_ok=True)
         to_add = []
-        for collname, collection in self.dbs[db["name"]].items():
+        for collname in collnames:
             # print("dumping " + collname + "...", file=sys.stderr)
+            collection = self.dbs[dbname][collname]
             filetype = self._collfiletypes.get(collname, "yaml")
             if filetype == "json":
                 filename = self.dump_json(collection, collname, dbpath)
@@ -211,6 +272,7 @@ class FileSystemClient:
             else:
                 raise ValueError("did not recognize file type for regolith")
             to_add.append(str(Path(db["path"]) / filename))
+            self._dirty.discard((dbname, collname))
         return to_add
 
     def close(self):
@@ -237,17 +299,20 @@ class FileSystemClient:
         """Inserts one document to a database/collection."""
         coll = self.dbs[dbname][collname]
         coll[doc["_id"]] = doc
+        self.mark_dirty(dbname, collname)
 
     def insert_many(self, dbname, collname, docs):
         """Inserts many documents into a database/collection."""
         coll = self.dbs[dbname][collname]
         for doc in docs:
             coll[doc["_id"]] = doc
+            self.mark_dirty(dbname, collname)
 
     def delete_one(self, dbname, collname, doc):
         """Removes a single document from a collection."""
         coll = self.dbs[dbname][collname]
         del coll[doc["_id"]]
+        self.mark_dirty(dbname, collname)
 
     def find_one(self, dbname, collname, filter):
         """Finds the first document matching filter."""
@@ -268,3 +333,4 @@ class FileSystemClient:
         newdoc = dict(filter if doc is None else doc)
         newdoc.update(update)
         coll[newdoc["_id"]] = newdoc
+        self.mark_dirty(dbname, collname)

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -439,8 +439,18 @@ class MongoClient:
             export_json(collection, dbpath, dbname, host=host, uri=uri)
         return
 
-    def dump_database(self, db):
-        """Dumps a database dict via mongoexport."""
+    def dump_database(self, db, force=False):
+        """Dumps a database dict via mongoexport.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``name`` and ``path``.
+        force : bool, optional
+            The switch kept for signature parity with the filesystem
+            client.  Mongo exports every collection either way, so it is
+            ignored.
+        """
         dbpath = Path(dbpathname(db, self.rc))
         dbpath.mkdir(parents=True, exist_ok=True)
         to_add = []

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -1,8 +1,12 @@
 import datetime
 import tempfile
+from copy import copy
 from pathlib import Path
 
-from regolith.fsclient import date_encoder, dump_json
+import pytest
+
+from regolith.fsclient import FileSystemClient, date_encoder, dump_json, dump_yaml
+from regolith.runcontrol import DEFAULT_RC
 
 
 def test_date_encoder():
@@ -43,3 +47,112 @@ def test_dump_json():
 #         json.dump(json_doc, f)
 #     actual = load_json(filename)
 #     assert actual == expected
+
+
+@pytest.fixture
+def fs_db(tmp_path):
+    """Build a two collection filesystem database and return its client
+    and db description."""
+    dbpath = tmp_path / "db"
+    dbpath.mkdir()
+    dump_yaml(dbpath / "people.yaml", {"scopatz": {"_id": "scopatz", "name": "Anthony Scopatz"}})
+    dump_yaml(dbpath / "abstracts.yaml", {"first": {"_id": "first", "text": "an abstract"}})
+    db = {
+        "name": "test",
+        "url": str(tmp_path),
+        "path": "db",
+        "local": True,
+        "backend": "filesystem",
+        "blacklist": [],
+        "whitelist": [],
+    }
+    rc = copy(DEFAULT_RC)
+    rc._update({"builddir": str(tmp_path / "_build")})
+    client = FileSystemClient(rc)
+    client.load_database(db)
+    yield client, db, dbpath
+
+
+def _mtimes(dbpath):
+    """Return a dict mapping each collection filename to its
+    modification time."""
+    return {f.name: f.stat().st_mtime_ns for f in sorted(dbpath.iterdir())}
+
+
+def test_dump_database_skips_unmodified_collections(fs_db):
+    # Test that a read-only session leaves every collection file untouched
+    client, db, dbpath = fs_db
+    before = _mtimes(dbpath)
+    # Reading is not a modification, so it must not mark anything dirty
+    list(client.all_documents("people"))
+    written = client.dump_database(db)
+    assert written == []
+    assert _mtimes(dbpath) == before
+
+
+def test_dump_database_writes_only_modified_collections(fs_db):
+    # Test that a write to one collection dumps that collection alone
+    client, db, dbpath = fs_db
+    before = _mtimes(dbpath)
+    client.insert_one("test", "people", {"_id": "sbillinge", "name": "Simon Billinge"})
+    written = client.dump_database(db)
+    assert written == [str(Path("db") / "people.yaml")]
+    after = _mtimes(dbpath)
+    assert after["people.yaml"] != before["people.yaml"]
+    assert after["abstracts.yaml"] == before["abstracts.yaml"]
+
+
+def test_dump_database_clears_dirty_state(fs_db):
+    # Test that a collection is written once per modification, so that a
+    # second dump with no further writes is a no-op
+    client, db, dbpath = fs_db
+    client.insert_one("test", "people", {"_id": "sbillinge", "name": "Simon Billinge"})
+    assert client.is_dirty("test", "people") is True
+    client.dump_database(db)
+    assert client.is_dirty("test", "people") is False
+    assert client.is_dirty("test") is False
+    before = _mtimes(dbpath)
+    assert client.dump_database(db) == []
+    assert _mtimes(dbpath) == before
+
+
+def test_dump_database_force_writes_every_collection(fs_db):
+    # Test that force writes the unmodified collections too, which is what
+    # an in-place edit outside the client needs
+    client, db, dbpath = fs_db
+    before = _mtimes(dbpath)
+    written = client.dump_database(db, force=True)
+    assert sorted(written) == [str(Path("db") / "abstracts.yaml"), str(Path("db") / "people.yaml")]
+    after = _mtimes(dbpath)
+    assert after["people.yaml"] != before["people.yaml"]
+    assert after["abstracts.yaml"] != before["abstracts.yaml"]
+
+
+@pytest.mark.parametrize(
+    "write",
+    [
+        # C1: inserting one document marks the collection dirty
+        lambda client: client.insert_one("test", "people", {"_id": "new", "name": "New Person"}),
+        # C2: inserting many documents marks the collection dirty
+        lambda client: client.insert_many("test", "people", [{"_id": "new", "name": "New Person"}]),
+        # C3: updating a document marks the collection dirty
+        lambda client: client.update_one("test", "people", {"_id": "scopatz"}, {"name": "A. Scopatz"}),
+        # C4: deleting a document marks the collection dirty
+        lambda client: client.delete_one("test", "people", {"_id": "scopatz"}),
+    ],
+)
+def test_writes_mark_the_collection_dirty(fs_db, write):
+    # Test that every mutating client method records the collection as dirty
+    client, db, dbpath = fs_db
+    assert client.is_dirty("test", "people") is False
+    write(client)
+    assert client.is_dirty("test", "people") is True
+    assert client.is_dirty("test", "abstracts") is False
+
+
+def test_insert_many_of_nothing_is_not_a_modification(fs_db):
+    # Test that inserting an empty list of documents leaves the collection clean
+    client, db, dbpath = fs_db
+    client.insert_many("test", "people", [])
+    assert client.is_dirty("test", "people") is False
+    assert client.dump_database(db) == []


### PR DESCRIPTION
fsclient.py, client_manager.py, database.xsh, broker.py: every connected command dumped every collection of every database when the connect() context manager exited, so a pure lister rewrote the whole database and, for a git-backed database, ran git add/commit/push after a read.

FileSystemClient now records a (dbname, collname) pair as dirty whenever insert_one, insert_many, update_one or delete_one touches it, and dump_database writes only the dirty collections, clearing them as it goes.  dump_git_database and dump_hg_database return before committing when nothing was written.  A force keyword restores the write-everything behavior and is used by Broker.add_file, which edits a document in place rather than through the client and so leaves no dirty record.

closes #1304


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64