### PR TITLE
fix: list mongo collections with the pymongo 4 API

### DIFF
--- a/news/fix-pymongo4-collection-names.rst
+++ b/news/fix-pymongo4-collection-names.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``MongoClient.collection_names`` and ``MongoClient.dump_database`` now list
+  collections with ``list_collection_names``.  They called
+  ``Database.collection_names``, which pymongo removed in 4.0, so listing the
+  collections of a mongo database and backing one up to the filesystem both
+  raised ``AttributeError``.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -454,7 +454,7 @@ class MongoClient:
         dbpath = Path(dbpathname(db, self.rc))
         dbpath.mkdir(parents=True, exist_ok=True)
         to_add = []
-        colls = self.client[db["name"]].collection_names(include_system_collections=False)
+        colls = self.client[db["name"]].list_collection_names()
         for collection in colls:
             f = str(dbpath / (collection + ".json"))
             cmd = [
@@ -486,8 +486,23 @@ class MongoClient:
         return self.client[key]
 
     def collection_names(self, dbname, include_system_collections=True):
-        """Returns the collection names for the database name."""
-        return self.client[dbname].collection_names()
+        """Return the names of the collections in a database.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database to list.
+        include_system_collections : bool, optional
+            The switch kept for signature parity with the filesystem
+            client.  Mongo keeps its system collections in a namespace
+            that is not listed, so it is ignored.
+
+        Returns
+        -------
+        list of str
+            The names of the collections in the database.
+        """
+        return self.client[dbname].list_collection_names()
 
     def all_documents(self, collname, copy=True):
         """Returns an iterable over all documents in a collection."""

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -1,0 +1,46 @@
+"""Tests for the mongo backed client that do not need a live mongod."""
+
+from pathlib import Path
+
+from regolith.mongoclient import MongoClient
+
+
+class FakePymongoDatabase:
+    """A stand-in for a pymongo Database that offers only the collection
+    listing call that pymongo 4 still provides."""
+
+    def __init__(self, collection_names):
+        self._collection_names = collection_names
+
+    def list_collection_names(self):
+        return list(self._collection_names)
+
+    def __getattr__(self, name):
+        # pymongo 4 removed Database.collection_names, so reaching for any
+        # other attribute is the regression these tests guard against.
+        raise AttributeError(f"pymongo 4 Database has no attribute {name!r}")
+
+
+def _client_with(collection_names):
+    """Build a MongoClient whose pymongo client is the fake database."""
+    client = MongoClient.__new__(MongoClient)
+    client.client = {"test": FakePymongoDatabase(collection_names)}
+    client.rc = None
+    return client
+
+
+def test_collection_names_uses_the_pymongo_4_api():
+    # Test listing the collections of a database, which must go through
+    # list_collection_names because pymongo 4 removed collection_names
+    client = _client_with(["people", "todos"])
+    assert client.collection_names("test") == ["people", "todos"]
+
+
+def test_dump_database_lists_collections_with_the_pymongo_4_api(mocker, tmp_path):
+    # Test that dumping a mongo database lists its collections through the
+    # pymongo 4 API, so that a mongo to filesystem backup does not fail
+    mocker.patch("regolith.mongoclient.subprocess.check_call")
+    client = _client_with(["people"])
+    db = {"name": "test", "url": str(tmp_path), "path": "db", "local": True}
+    to_add = client.dump_database(db)
+    assert to_add == [str(Path("db") / "people.json")]


### PR DESCRIPTION
mongoclient.py: MongoClient.collection_names and MongoClient.dump_database called Database.collection_names, which pymongo removed in 4.0, so both raised AttributeError on any current pymongo.  Listing a database in the html builders' index templates and backing a mongo database up to the filesystem were the two affected paths.

Both now call list_collection_names.  The include_system_collections argument is kept on collection_names for parity with FileSystemClient, which also ignores it, and is documented as ignored rather than passed on: mongo keeps system collections in a namespace that is not listed.

tests/test_mongoclient.py: new module.  The fake pymongo database raises AttributeError for every attribute but list_collection_names, so the tests fail against the old calls.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64