### PR TITLE
refactor: drop the xonsh and rever dependencies

### DIFF
--- a/news/remove-xonsh-rever.rst
+++ b/news/remove-xonsh-rever.rst
@@ -1,0 +1,34 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``regolith.database`` is a normal Python module.  It was ``database.xsh`` and
+  needed the xonsh import hook, which put it beyond the reach of black, flake8,
+  isort and docformatter because it was not valid Python.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* The xonsh dependency.  ``xonsh.api.subprocess`` and ``xonsh.api.os`` are
+  replaced by the standard library ``subprocess`` and ``shutil``, and
+  ``xonsh.main.setup`` no longer runs on ``import regolith``, which cuts the
+  import from about 147 ms to about 47 ms and ``regolith --version`` from about
+  1370 ms to about 980 ms.
+* The rever dependency, which was unused: there is no ``rever.xsh`` and no
+  release workflow invokes it.
+
+**Fixed:**
+
+* ``deploy.py`` and ``storage.py`` can now catch a failing git command.  They
+  handle ``subprocess.CalledProcessError``, but ``xonsh.api.subprocess`` does
+  not define it, so those handlers raised ``AttributeError`` at the moment a
+  git command actually failed.
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 regolith = ["templates/*",
             "static/*.*",
             "static/img/*.*",
-            "*.xsh",
             "*.json"
             ]
 

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -5,8 +5,6 @@ docutils
 jinja2
 cerberus
 flatten-dict
-xonsh
-rever
 openpyxl
 pypdf
 nameparser

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,8 +4,6 @@ docutils
 jinja2
 cerberus
 flatten-dict
-xonsh
-rever
 openpyxl
 pypdf
 nameparser

--- a/src/regolith/__init__.py
+++ b/src/regolith/__init__.py
@@ -15,20 +15,8 @@
 ##############################################################################
 """Python package for research group content management system."""
 
-from xonsh.main import setup
-
 # package version
 from regolith.version import __version__  # noqa
 
 # silence the pyflakes syntax checker
 assert __version__ or True
-
-setup()
-del setup
-
-# Initialize the Xonsh environment
-# # execer = Execer(config=None)
-# # XSH.load(execer=execer)
-# # xonsh.imphooks.install_import_hooks(execer=execer)
-#
-# del xonsh

--- a/src/regolith/builders/basebuilder.py
+++ b/src/regolith/builders/basebuilder.py
@@ -1,11 +1,11 @@
 """Builder Base Classes."""
 
 import os
+import subprocess
 from glob import glob
 from itertools import groupby
 
 from jinja2 import Environment, FileSystemLoader
-from xonsh.api import subprocess
 
 try:
     from bibtexparser.bibdatabase import BibDatabase

--- a/src/regolith/database.py
+++ b/src/regolith/database.py
@@ -1,45 +1,86 @@
 """Helps manage mongodb setup and connections."""
+
+import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 from warnings import warn
 
-from xonsh.api import subprocess
-from xonsh.api.os import indir
-
 try:
     import hglib
-except:
+except ImportError:
     hglib = None
 
 from regolith.chained_db import ChainDB
-from regolith.tools import dbdirname
 from regolith.client_manager import ClientManager
+from regolith.tools import dbdirname
+
+
+def _run_git(args, cwd, check=False):
+    """Run a git command in a directory.
+
+    Parameters
+    ----------
+    args : list of str
+        The git arguments, without the leading ``git``.
+    cwd : str or pathlib.Path
+        The directory to run the command in.
+    check : bool, optional
+        The switch to raise ``subprocess.CalledProcessError`` when the
+        command returns a non-zero code.  The default is False.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The completed git process.
+    """
+    return subprocess.run(["git"] + list(args), cwd=str(cwd), check=check)
+
+
+def _run_first_git_success(arg_lists, cwd):
+    """Run git commands in order until one of them succeeds.
+
+    Parameters
+    ----------
+    arg_lists : list of list of str
+        The candidate argument lists, each tried in turn until one
+        returns zero.
+    cwd : str or pathlib.Path
+        The directory to run the commands in.
+
+    Returns
+    -------
+    bool
+        Whether one of the commands succeeded.
+    """
+    for args in arg_lists:
+        if _run_git(args, cwd).returncode == 0:
+            return True
+    return False
 
 
 def load_git_database(db, client, rc):
-    """Loads a git database"""
+    """Loads a git database."""
     dbdir = dbdirname(db, rc)
     # get or update the database
     if dbdir.is_dir():
-        with indir(str(dbdir)):
-            (![git pull upstream master]
-             or ![git pull origin master]
-             or ![git pull])
+        _run_first_git_success(
+            [["pull", "upstream", "master"], ["pull", "origin", "master"], ["pull"]],
+            dbdir,
+        )
     else:
-        git clone @(db['url']) @(str(dbdir))
-    with indir(str(dbdir)):
-        if getattr(rc, 'branch', None):
-            branch = rc.branch
-            git checkout @(branch) or git checkout -b @(branch) master
+        subprocess.run(["git", "clone", db["url"], str(dbdir)])
+    if getattr(rc, "branch", None):
+        branch = rc.branch
+        _run_first_git_success([["checkout", branch], ["checkout", "-b", branch, "master"]], dbdir)
 
     # import all of the data
     client.load_database(db)
 
 
 def load_hg_database(db, client, rc):
-    """Loads an hg database"""
+    """Loads an hg database."""
     if hglib is None:
-        raise ImportError('hglib')
+        raise ImportError("hglib")
     dbdir = dbdirname(db, rc)
     # get or update the database
     if dbdir.is_dir():
@@ -47,15 +88,15 @@ def load_hg_database(db, client, rc):
         client.pull(update=True, force=True)
     else:
         # Strip off three characters for hg+
-        client = hglib.clone(db['url'][3:], str(dbdir))
+        client = hglib.clone(db["url"][3:], str(dbdir))
     # import all of the data
     client.load_database(db)
 
 
 def load_local_database(db, client, rc):
-    """Loads a local database"""
+    """Loads a local database."""
     # make sure that we expand user stuff
-    db['url'] = str(Path(db['url']).expanduser())
+    db["url"] = str(Path(db["url"]).expanduser())
     # import all of the data
     client.load_database(db)
 
@@ -66,24 +107,23 @@ def load_mongo_database(db, client):
 
 
 def load_database(db, client, rc):
-    """Loads a database"""
-    if db['backend'] in ('mongo', 'mongodb'):
+    """Loads a database."""
+    if db["backend"] in ("mongo", "mongodb"):
         load_mongo_database(db, client)
         return
-    url = db['url']
-    if url.startswith('git') or url.endswith('.git'):
+    url = db["url"]
+    if url.startswith("git") or url.endswith(".git"):
         load_git_database(db, client, rc)
-    elif url.startswith('hg+'):
+    elif url.startswith("hg+"):
         load_hg_database(db, client, rc)
     elif Path(url).expanduser().exists():
         load_local_database(db, client, rc)
     else:
-        raise ValueError('Do not know how to load this kind of database: '
-                         '{}'.format(db))
+        raise ValueError("Do not know how to load this kind of database: " "{}".format(db))
 
 
 def dump_git_database(db, client, rc, force=False):
-    """Dumps a git database"""
+    """Dumps a git database."""
     dbdir = dbdirname(db, rc)
     # dump the data that changed
     to_add = client.dump_database(db, force=force)
@@ -91,28 +131,26 @@ def dump_git_database(db, client, rc, force=False):
         # nothing was modified, so there is nothing to commit or push
         return
     # update the repo
-    cmd = ['git', 'add', '']
     for file in to_add:
-        cmd[2] = file
-        subprocess.check_call(cmd, cwd=dbdir)
-    cmd = ['git', 'commit', '-m', 'regolith auto-commit']
+        subprocess.check_call(["git", "add", file], cwd=dbdir)
+    cmd = ["git", "commit", "-m", "regolith auto-commit"]
     try:
         subprocess.check_call(cmd, cwd=dbdir)
     except subprocess.CalledProcessError:
-        warn('Could not git commit to ' + str(dbdir), RuntimeWarning)
+        warn("Could not git commit to " + str(dbdir), RuntimeWarning)
         return
-    cmd = ['git', 'push']
-    if hasattr(rc, 'remote') and hasattr(rc, 'branch'):
+    cmd = ["git", "push"]
+    if hasattr(rc, "remote") and hasattr(rc, "branch"):
         cmd += [rc.remote, rc.branch]
     try:
         subprocess.check_call(cmd, cwd=dbdir)
     except subprocess.CalledProcessError:
-        warn('Could not git push from ' + str(dbdir), RuntimeWarning)
+        warn("Could not git push from " + str(dbdir), RuntimeWarning)
         return
 
 
 def dump_hg_database(db, client, rc, force=False):
-    """Dumps an hg database"""
+    """Dumps an hg database."""
     dbdir = dbdirname(db, rc)
     # dump the data that changed
     to_add = client.dump_database(db, force=force)
@@ -121,44 +159,42 @@ def dump_hg_database(db, client, rc, force=False):
         return
     # update the repo
     hgclient = hglib.open(dbdir)
-    if len(hgclient.status(include=to_add, modified=True,
-                           unknown=True, added=True)) == 0:
+    if len(hgclient.status(include=to_add, modified=True, unknown=True, added=True)) == 0:
         return
-    hgclient.commit(message='regolith auto-commit', include=to_add,
-                    addremove=True)
+    hgclient.commit(message="regolith auto-commit", include=to_add, addremove=True)
     hgclient.push()
 
 
 def dump_local_database(db, client, rc, force=False):
-    """Dumps a local database"""
+    """Dumps a local database."""
     # dump the data that changed
     client.dump_database(db, force=force)
     return
 
 
 def dump_database(db, client, rc, force=False):
-    """Dumps a database
+    """Dumps a database.
 
     Only the collections that were modified since they were loaded are
     written, unless ``force`` is set, so a command that reads without
     writing leaves the database files untouched.
     """
     # do not dump mongo db
-    if db['backend'] in ('mongo', 'mongodb'):
+    if db["backend"] in ("mongo", "mongodb"):
         return
-    url = db['url']
-    if url.startswith('git') or url.endswith('.git'):
+    url = db["url"]
+    if url.startswith("git") or url.endswith(".git"):
         dump_git_database(db, client, rc, force=force)
-    elif url.startswith('hg+'):
+    elif url.startswith("hg+"):
         dump_hg_database(db, client, rc, force=force)
     elif Path(url).expanduser().exists():
         dump_local_database(db, client, rc, force=force)
     else:
-        raise ValueError('Do not know how to dump this kind of database')
+        raise ValueError("Do not know how to dump this kind of database")
 
 
 def open_dbs(rc, dbs=None):
-    """Open the databases
+    """Open the databases.
 
     Parameters
     ----------
@@ -179,11 +215,11 @@ def open_dbs(rc, dbs=None):
     chained_db = {}
     for db in rc.databases:
         # if we only want to access some dbs and this db is not in that some
-        db['whitelist'] = dbs
-        if 'blacklist' not in db:
-            db['blacklist'] = ['.travis.yml', '.travis.yaml']
+        db["whitelist"] = dbs
+        if "blacklist" not in db:
+            db["blacklist"] = [".travis.yml", ".travis.yaml"]
         load_database(db, client, rc)
-        for base, coll in client.dbs[db['name']].items():
+        for base, coll in client.dbs[db["name"]].items():
             if base not in chained_db:
                 chained_db[base] = {}
             for k, v in coll.items():
@@ -194,10 +230,11 @@ def open_dbs(rc, dbs=None):
     client.chained_db = chained_db
     return client
 
+
 @contextmanager
 def connect(rc, dbs=None):
-    """Context manager for ensuring that database is properly setup and torn
-    down"""
+    """Context manager for ensuring that database is properly setup and
+    torn down."""
     client = open_dbs(rc, dbs=dbs)
     yield client
     for db in rc.databases:

--- a/src/regolith/deploy.py
+++ b/src/regolith/deploy.py
@@ -1,11 +1,10 @@
 """Helps deploy what we have built."""
 
 import os
+import subprocess
 import time
 from distutils.dir_util import copy_tree
 from warnings import warn
-
-from xonsh.api import subprocess
 
 try:
     import hglib

--- a/src/regolith/helpers/basehelper.py
+++ b/src/regolith/helpers/basehelper.py
@@ -1,11 +1,11 @@
 """Builder Base Classes."""
 
 import os
+import subprocess
 from glob import glob
 from itertools import groupby
 
 from jinja2 import Environment, FileSystemLoader
-from xonsh.api import subprocess
 
 from regolith.sorters import category_val, date_key, doc_date_key, level_val
 from regolith.tools import LATEX_OPTS, date_to_rfc822, gets, latex_safe, latex_safe_url, month_and_year, rfc822now

--- a/src/regolith/storage.py
+++ b/src/regolith/storage.py
@@ -2,10 +2,9 @@
 
 import os
 import shutil
+import subprocess
 from contextlib import contextmanager
 from warnings import warn
-
-from xonsh.api import subprocess
 
 try:
     import hglib

--- a/tests/bootstrap_builders.py
+++ b/tests/bootstrap_builders.py
@@ -1,11 +1,10 @@
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 from copy import deepcopy
-
-from xonsh.api import subprocess
 
 from regolith.broker import load_db
 from regolith.fsclient import dump_yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 import json
 import os
+import shutil
+import stat
+import subprocess
 import tempfile
 from copy import deepcopy
 from pathlib import Path
@@ -11,8 +14,6 @@ import matplotlib
 import pytest
 from pymongo import MongoClient
 from pymongo import errors as mongo_errors
-from xonsh.api import subprocess
-from xonsh.api.os import rmtree
 
 from regolith.fsclient import dump_yaml
 from regolith.schemas import EXEMPLARS
@@ -28,6 +29,30 @@ OUTPUT_FAKE_DB = False  # always turn it to false after you used it
 REGOLITH_MONGODB_NAME = "test"
 FS_DB_NAME = "test"
 ALTERNATE_REGOLITH_MONGODB_NAME = "mongo_test"
+
+# A missing mongo binary raises FileNotFoundError and a failing one raises
+# CalledProcessError.  Either way the mongo backed tests cannot run here, so
+# the fixtures treat both the same and yield False to skip them.
+MONGO_LAUNCH_ERRORS = (CalledProcessError, FileNotFoundError)
+
+
+def rmtree(dirname):
+    """Remove a directory, even when git has left read-only files in it.
+
+    Parameters
+    ----------
+    dirname : str or pathlib.Path
+        The directory to remove.
+    """
+
+    def clear_readonly(func, path, exc):
+        # Git writes read-only files into .git, which Windows refuses to
+        # unlink until the read-only bit is cleared.  See
+        # https://stackoverflow.com/questions/2656322 for more info.
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    shutil.rmtree(dirname, onexc=clear_readonly)
 
 
 # copied over from cookiecutter conftest.py
@@ -161,7 +186,7 @@ def make_mongodb():
         cmd = ["mongo", REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
         try:
             subprocess.check_call(cmd, cwd=repo)
-        except CalledProcessError:
+        except MONGO_LAUNCH_ERRORS:
             print(
                 "Mongodb likely has not been installed as a service. In order to run mongodb tests, make sure\n"
                 "to install the mongodb community edition with the following link: \n"
@@ -175,7 +200,7 @@ def make_mongodb():
         forked = True
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             "If using linux or mac, Mongod command failed to execute. "
             "If using windows, the status of mongo could \n not be retrieved. "
@@ -194,7 +219,7 @@ def make_mongodb():
     cmd = ["mongo", REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             f'Deleting the test database failed, insert "mongo {REGOLITH_MONGODB_NAME} --eval '
             f'"db.dropDatabase()"" into command line manually'
@@ -270,7 +295,7 @@ def make_mixed_db():
         cmd = ["mongo", REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
         try:
             subprocess.check_call(cmd, cwd=repo)
-        except CalledProcessError:
+        except MONGO_LAUNCH_ERRORS:
             print(
                 "Mongod likely has not been installed as a service. In order to run mongodb tests, make sure\n"
                 "to install the mongodb community edition with the following link: \n"
@@ -284,7 +309,7 @@ def make_mixed_db():
         forked = True
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             "If on linux/mac, Mongod command failed to execute. If on windows, the status of mongo could not be\n"
             "retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with\n"
@@ -307,7 +332,7 @@ def make_mixed_db():
     cmd = ["mongo", REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             f'Deleting the test database failed, insert "mongo {REGOLITH_MONGODB_NAME} --eval '
             f'"db.dropDatabase()"" into command line manually'
@@ -444,7 +469,7 @@ def make_migration_db(fs_to_mongo_true__mongo_to_fs_false):
         cmd = ["mongo", ALTERNATE_REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
         try:
             subprocess.check_call(cmd, cwd=repo)
-        except CalledProcessError:
+        except MONGO_LAUNCH_ERRORS:
             print(
                 "Mongod likely has not been installed as a service. In order to run mongodb tests, make sure\n"
                 "to install the mongodb community edition with the following link: \n"
@@ -458,7 +483,7 @@ def make_migration_db(fs_to_mongo_true__mongo_to_fs_false):
         forked = True
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             "If on linux/mac, Mongod command failed to execute. If on windows, the status of mongo could not be\n"
             "retrieved. In order to run mongodb tests, make sure to install the mongodb community edition with\n"
@@ -475,7 +500,7 @@ def make_migration_db(fs_to_mongo_true__mongo_to_fs_false):
     cmd = ["mongo", ALTERNATE_REGOLITH_MONGODB_NAME, "--eval", "db.dropDatabase()"]
     try:
         subprocess.check_call(cmd, cwd=repo)
-    except CalledProcessError:
+    except MONGO_LAUNCH_ERRORS:
         print(
             f'Deleting the test database failed, insert "mongo {ALTERNATE_REGOLITH_MONGODB_NAME} --eval '
             f'"db.dropDatabase()"" into command line manually'
@@ -491,7 +516,7 @@ def shut_down_fork(forked, repo):
         cmd = ["mongo", "admin", "--eval", "db.shutdownServer()"]
         try:
             subprocess.check_call(cmd, cwd=repo)
-        except CalledProcessError:
+        except MONGO_LAUNCH_ERRORS:
             print(
                 'Deleting the test database failed, insert "mongo admin --eval '
                 '"db.shutdownServer()"" into command line manually'

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,7 +1,5 @@
 import datetime as dt
 import os
-
-# from xonsh.lib import subprocess
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,10 +1,10 @@
 import os
+import subprocess
 import sys
 from io import StringIO
 from subprocess import CalledProcessError
 
 import pytest
-from xonsh.api import subprocess
 
 from regolith.main import main
 
@@ -59,9 +59,7 @@ def test_validate_bad_python(make_bad_db):
 def test_validate(make_db):
     repo = make_db
     os.chdir(repo)
-    out = subprocess.check_output(["regolith", "validate"])
-    if isinstance(out, bytes):
-        out = out.decode("utf-8")
+    out = subprocess.check_output(["regolith", "validate"], text=True)
     assert "NO ERRORS IN DBS" in out
 
 
@@ -70,7 +68,7 @@ def test_validate_bad(make_bad_db):
     repo = make_bad_db
     os.chdir(repo)
     try:
-        subprocess.check_output(["regolith", "validate"])
+        subprocess.check_output(["regolith", "validate"], text=True)
     except CalledProcessError as e:
         assert "Errors found in " in e.output
         assert "NO ERRORS IN DBS" not in e.output


### PR DESCRIPTION
database.xsh was the only .xsh file in the repo and the sole reason regolith depended on xonsh: importing it needed the hook that xonsh.main.setup installs, which ran on every `import regolith`.  Because the file was not valid Python, black, flake8, isort and docformatter could never read it, so the module holding open_dbs, load_database and connect sat outside the whole toolchain.  It is now database.py, with the xonsh subprocess syntax written as subprocess calls: the `![a] or ![b]` chains become _run_first_git_success, and `with indir(d)` becomes cwd=d.

deploy.py, storage.py, basebuilder.py, basehelper.py, conftest.py, test_validate.py, bootstrap_builders.py: use the standard library subprocess instead of xonsh.api.subprocess, and shutil instead of xonsh.api.os.rmtree.

This also fixes a latent bug: deploy.py and storage.py catch subprocess.CalledProcessError, which xonsh.api.subprocess does not define, so those handlers raised AttributeError exactly when a git command failed.

conftest.py: the mongo fixtures relied on xonsh returning non-zero for a missing binary where the standard library raises FileNotFoundError, so the guards now catch MONGO_LAUNCH_ERRORS.  test_validate.py: check_output is called with text=True, since xonsh decoded its output and the standard library does not.

rever goes too.  Nothing imports it, there is no rever.xsh and no workflow runs it; it was only holding xonsh in place.

Verified by running the suite with a stub package that raises ImportError for xonsh: 610 passed, 38 skipped.  `import regolith` drops from about 147 ms to 47 ms and `regolith --version` from about 1370 ms to 980 ms.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64