### PR TITLE
feat: add get and find to the database clients

### DIFF
--- a/news/client-get-find.rst
+++ b/news/client-get-find.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* ``get(collname, _id)`` and ``find(collname, filter)`` on the database clients.
+  ``ClientManager`` asks each database for the documents it holds and chains only
+  those, so a mongo backend answers an id lookup from its index and a filtered
+  query on the server instead of returning the whole collection.  The filesystem
+  client gains the same two methods, and ``find_one`` now looks an id up rather
+  than scanning.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/client_manager.py
+++ b/src/regolith/client_manager.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from copy import deepcopy
 
-from regolith.fsclient import FileSystemClient
+from regolith.chained_db import ChainDB
+from regolith.fsclient import FileSystemClient, doc_matches
 from regolith.mongoclient import MongoClient
 
 CLIENTS = {
@@ -122,6 +123,122 @@ class ClientManager:
         if copy:
             return deepcopy(self.chained_db.get(collname, {})).values()
         return self.chained_db.get(collname, {}).values()
+
+    def _client_for(self, db):
+        """Return the client that backs a database, or None.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``backend``.
+
+        Returns
+        -------
+        FileSystemClient, MongoClient or None
+            The client for the database's backend.
+        """
+        for client in self.clients:
+            if isinstance(client, CLIENTS[db["backend"]]):
+                return client
+        return None
+
+    def _chain(self, docs):
+        """Merge the versions of one document held by several databases.
+
+        Parameters
+        ----------
+        docs : list of dict
+            The versions of the document, ordered as ``rc.databases`` is,
+            so that the merge resolves the way ``open_dbs`` does.
+
+        Returns
+        -------
+        dict, ChainDB or None
+            The single document when only one database holds it, a
+            ChainDB over all of them when several do, and None when the
+            list is empty.
+        """
+        if not docs:
+            return None
+        if len(docs) == 1:
+            return docs[0]
+        chained = ChainDB(docs[0])
+        for doc in docs[1:]:
+            chained.maps.append(doc)
+        return chained
+
+    def get(self, collname, _id, copy=True):
+        """Return one document of a collection by id, chained across the
+        databases that hold it.
+
+        Each database is asked for the single document rather than for
+        the whole collection, so a mongo backend answers from its index
+        on ``_id``.
+
+        Parameters
+        ----------
+        collname : str
+            The name of the collection to read.
+        _id : str
+            The id of the document.
+        copy : bool, optional
+            The switch to return a copy rather than the client's own
+            document.  Mutating an uncopied document changes state the
+            client does not know it has to write.  The default is True.
+
+        Returns
+        -------
+        dict, ChainDB or None
+            The merged document, or None when no database holds it.
+        """
+        docs = []
+        for db in self.rc.databases:
+            client = self._client_for(db)
+            if client is None:
+                continue
+            doc = client.get(db["name"], collname, _id)
+            if doc is not None:
+                docs.append(doc)
+        chained = self._chain(docs)
+        if chained is None:
+            return None
+        return deepcopy(chained) if copy else chained
+
+    def find(self, collname, filter=None, copy=True):
+        """Yield the documents of a collection that match a filter,
+        chained across the databases that hold them.
+
+        A document is matched on its merged value, which no single
+        database knows, so the versions are gathered per database and the
+        filter is applied to the merge.  Each database is read once.
+
+        Parameters
+        ----------
+        collname : str
+            The name of the collection to read.
+        filter : dict, optional
+            The keys and values a document must have.  The default
+            yields every document of the collection.
+        copy : bool, optional
+            The switch to yield copies rather than the clients' own
+            documents.  The default is True.
+
+        Yields
+        ------
+        dict or ChainDB
+            The matching merged documents.
+        """
+        versions = {}
+        for db in self.rc.databases:
+            client = self._client_for(db)
+            if client is None:
+                continue
+            for doc in client.find(db["name"], collname):
+                versions.setdefault(doc["_id"], []).append(doc)
+        for docs in versions.values():
+            merged = self._chain(docs)
+            if doc_matches(merged, filter):
+                yield deepcopy(merged) if copy else merged
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -54,6 +54,30 @@ def _id_key(doc):
     return doc["_id"]
 
 
+def doc_matches(doc, filter):
+    """Return True if a document has every key and value of a filter.
+
+    Parameters
+    ----------
+    doc : dict
+        The document to test.
+    filter : dict or None
+        The keys and values the document must have.  An empty or absent
+        filter matches every document.
+
+    Returns
+    -------
+    bool
+        Whether the document matches.
+    """
+    if not filter:
+        return True
+    for key, value in filter.items():
+        if key not in doc or doc[key] != value:
+            return False
+    return True
+
+
 def load_json(filename):
     """Loads a JSON file and returns a dict of its documents."""
     docs = {}
@@ -314,17 +338,54 @@ class FileSystemClient:
         del coll[doc["_id"]]
         self.mark_dirty(dbname, collname)
 
+    def get(self, dbname, collname, _id):
+        """Return one document of a collection by id.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        _id : str
+            The id of the document.
+
+        Returns
+        -------
+        dict or None
+            The document, or None when the database has no such document.
+        """
+        return self.dbs.get(dbname, {}).get(collname, {}).get(_id)
+
+    def find(self, dbname, collname, filter=None):
+        """Yield the documents of a collection that match a filter.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        filter : dict, optional
+            The keys and values a document must have.  The default
+            yields every document of the collection.
+
+        Yields
+        ------
+        dict
+            The matching documents.
+        """
+        for doc in self.dbs.get(dbname, {}).get(collname, {}).values():
+            if doc_matches(doc, filter):
+                yield doc
+
     def find_one(self, dbname, collname, filter):
         """Finds the first document matching filter."""
-        coll = self.dbs[dbname][collname]
-        for doc in coll.values():
-            matches = True
-            for key, value in filter.items():
-                if key not in doc or doc[key] != value:
-                    matches = False
-                    break
-            if matches:
-                return doc
+        # An id is unique, so look it up rather than scanning the collection
+        if filter and set(filter) == {"_id"}:
+            return self.get(dbname, collname, filter["_id"])
+        for doc in self.find(dbname, collname, filter):
+            return doc
 
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -556,6 +556,51 @@ class MongoClient:
         else:
             return coll.delete_one(doc)
 
+    def get(self, dbname, collname, _id):
+        """Return one document of a collection by id.
+
+        The lookup is served by the server's index on ``_id`` rather than
+        by reading the collection into memory.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        _id : str
+            The id of the document.
+
+        Returns
+        -------
+        dict or None
+            The document, or None when the database has no such document.
+        """
+        return self.client[dbname][collname].find_one({"_id": _id})
+
+    def find(self, dbname, collname, filter=None):
+        """Yield the documents of a collection that match a filter.
+
+        The filter is sent to the server, so only the matching documents
+        cross the network.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        filter : dict, optional
+            The keys and values a document must have.  The default
+            yields every document of the collection.
+
+        Yields
+        ------
+        dict
+            The matching documents.
+        """
+        yield from self.client[dbname][collname].find(filter or {})
+
     def find_one(self, dbname, collname, filter):
         """Finds the first document matching filter."""
         filter["_id"].replace(".", "")

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -3,7 +3,10 @@ from copy import copy, deepcopy
 
 import pytest
 
+from regolith.chained_db import ChainDB
+from regolith.client_manager import ClientManager
 from regolith.database import connect
+from regolith.fsclient import dump_yaml
 from regolith.runcontrol import DEFAULT_RC, load_rcfile
 from regolith.schemas import EXEMPLARS
 from regolith.tools import all_docs_from_collection
@@ -24,3 +27,112 @@ def test_collection_retrieval_python(make_mixed_db):
     mongo_expected_dict = deepcopy(EXEMPLARS[mongo_coll])
     assert fs_test_dict == fs_expected_dict
     assert mongo_test_dict == mongo_expected_dict
+
+
+@pytest.fixture
+def two_fs_dbs(tmp_path):
+    """Build two filesystem databases that share a collection, so the
+    chaining done by the client manager can be tested without mongo."""
+    names = ["first", "second"]
+    for name in names:
+        dbpath = tmp_path / name / "db"
+        dbpath.mkdir(parents=True)
+        if name == "first":
+            docs = {
+                "scopatz": {"_id": "scopatz", "name": "Anthony Scopatz", "position": "prof"},
+                "only_first": {"_id": "only_first", "name": "First Only"},
+            }
+        else:
+            docs = {
+                "scopatz": {"_id": "scopatz", "name": "A. Scopatz"},
+                "only_second": {"_id": "only_second", "name": "Second Only", "position": "prof"},
+            }
+        dump_yaml(dbpath / "people.yaml", docs)
+    rc = copy(DEFAULT_RC)
+    rc._update(
+        {
+            "builddir": str(tmp_path / "_build"),
+            "databases": [
+                {
+                    "name": name,
+                    "url": str(tmp_path / name),
+                    "path": "db",
+                    "local": True,
+                    "backend": "filesystem",
+                    "blacklist": [],
+                    "whitelist": [],
+                }
+                for name in names
+            ],
+        }
+    )
+    client = ClientManager(rc.databases, rc)
+    client.open()
+    for db in rc.databases:
+        client.load_database(db)
+    yield client
+
+
+def test_get_merges_the_versions_held_by_each_database(two_fs_dbs):
+    # Test reading one document that two databases both hold.  A scalar takes
+    # its value from the last database in rc.databases that has the key, and a
+    # key only one database has still comes through.
+    doc = two_fs_dbs.get("people", "scopatz")
+    assert doc["name"] == "A. Scopatz"
+    assert doc["position"] == "prof"
+
+
+def test_get_returns_a_document_only_one_database_holds(two_fs_dbs):
+    # Test reading documents that live in a single database, one in each
+    assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"
+    assert two_fs_dbs.get("people", "only_second")["name"] == "Second Only"
+
+
+def test_get_returns_none_when_no_database_holds_the_document(two_fs_dbs):
+    # Test asking for an id that is in neither database, and for a
+    # collection that does not exist at all
+    assert two_fs_dbs.get("people", "nobody") is None
+    assert two_fs_dbs.get("nonexistent", "scopatz") is None
+
+
+def test_get_agrees_with_the_chained_db(two_fs_dbs):
+    # Test that get resolves a shared document the same way open_dbs does,
+    # since the two must not drift apart
+    chained = {}
+    for db in two_fs_dbs.rc.databases:
+        for _id, doc in two_fs_dbs.dbs[db["name"]]["people"].items():
+            if _id in chained:
+                chained[_id].maps.append(doc)
+            else:
+                chained[_id] = ChainDB(doc)
+    for _id in chained:
+        assert two_fs_dbs.get("people", _id)["name"] == chained[_id]["name"]
+
+
+def test_find_without_a_filter_yields_every_merged_document(two_fs_dbs):
+    # Test that a document held by both databases is yielded once, merged
+    found = {doc["_id"]: doc for doc in two_fs_dbs.find("people")}
+    assert sorted(found) == ["only_first", "only_second", "scopatz"]
+    assert found["scopatz"]["name"] == "A. Scopatz"
+
+
+def test_find_filters_on_the_merged_value(two_fs_dbs):
+    # Test that the filter sees the merged document.  1. position is only in
+    # the first database for scopatz but must still match. 2. a filter on a
+    # value that was overridden must match the winning value, not the losing
+    # one.
+    positions = sorted(doc["_id"] for doc in two_fs_dbs.find("people", {"position": "prof"}))
+    assert positions == ["only_second", "scopatz"]
+    assert [doc["_id"] for doc in two_fs_dbs.find("people", {"name": "A. Scopatz"})] == ["scopatz"]
+    assert list(two_fs_dbs.find("people", {"name": "Anthony Scopatz"})) == []
+
+
+def test_find_and_get_return_copies_by_default(two_fs_dbs):
+    # Test that mutating a returned document does not change the state the
+    # client holds, which it would otherwise write out without knowing
+    doc = two_fs_dbs.get("people", "only_first")
+    doc["name"] = "mutated"
+    assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"
+    for found in two_fs_dbs.find("people", {"_id": "only_first"}):
+        found["name"] = "mutated again"
+    assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -73,26 +73,38 @@ def two_fs_dbs(tmp_path):
     yield client
 
 
-def test_get_merges_the_versions_held_by_each_database(two_fs_dbs):
-    # Test reading one document that two databases both hold.  A scalar takes
-    # its value from the last database in rc.databases that has the key, and a
-    # key only one database has still comes through.
-    doc = two_fs_dbs.get("people", "scopatz")
-    assert doc["name"] == "A. Scopatz"
-    assert doc["position"] == "prof"
+@pytest.mark.parametrize(
+    "_id, expected_name, expected_position",
+    [
+        # Test reading one document through every database that holds it
+        # C1: an id both databases hold, expect the two versions merged
+        # 1. name is in both, expect the last database in rc.databases to win
+        # 2. position is only in the first, expect it to come through anyway
+        ("scopatz", "A. Scopatz", "prof"),
+        # C2: an id only the first database holds, expect that version
+        ("only_first", "First Only", None),
+        # C3: an id only the second database holds, expect that version
+        ("only_second", "Second Only", "prof"),
+    ],
+)
+def test_get_merges_the_versions_each_database_holds(_id, expected_name, expected_position, two_fs_dbs):
+    doc = two_fs_dbs.get("people", _id)
+    assert doc["name"] == expected_name
+    assert doc.get("position") == expected_position
 
 
-def test_get_returns_a_document_only_one_database_holds(two_fs_dbs):
-    # Test reading documents that live in a single database, one in each
-    assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"
-    assert two_fs_dbs.get("people", "only_second")["name"] == "Second Only"
-
-
-def test_get_returns_none_when_no_database_holds_the_document(two_fs_dbs):
-    # Test asking for an id that is in neither database, and for a
-    # collection that does not exist at all
-    assert two_fs_dbs.get("people", "nobody") is None
-    assert two_fs_dbs.get("nonexistent", "scopatz") is None
+@pytest.mark.parametrize(
+    "collname, _id",
+    [
+        # Test asking for a document that is not there, which must not raise
+        # C1: an id no database holds, expect None
+        ("people", "nobody"),
+        # C2: a collection no database holds, expect None
+        ("nonexistent", "scopatz"),
+    ],
+)
+def test_get_returns_none_when_no_database_holds_the_document(collname, _id, two_fs_dbs):
+    assert two_fs_dbs.get(collname, _id) is None
 
 
 def test_get_agrees_with_the_chained_db(two_fs_dbs):
@@ -109,30 +121,38 @@ def test_get_agrees_with_the_chained_db(two_fs_dbs):
         assert two_fs_dbs.get("people", _id)["name"] == chained[_id]["name"]
 
 
-def test_find_without_a_filter_yields_every_merged_document(two_fs_dbs):
-    # Test that a document held by both databases is yielded once, merged
-    found = {doc["_id"]: doc for doc in two_fs_dbs.find("people")}
-    assert sorted(found) == ["only_first", "only_second", "scopatz"]
-    assert found["scopatz"]["name"] == "A. Scopatz"
+@pytest.mark.parametrize(
+    "filter, expected_ids",
+    [
+        # Test that find matches the merged document rather than any single
+        # database's version of it
+        # C1: no filter, expect every document, each merged and yielded once
+        (None, ["only_first", "only_second", "scopatz"]),
+        # C2: a filter on a key only one database supplies, expect both of the
+        # documents that carry it once merged
+        ({"position": "prof"}, ["only_second", "scopatz"]),
+        # C3: a filter on the value that wins the merge, expect that document
+        ({"name": "A. Scopatz"}, ["scopatz"]),
+        # C4: a filter on the value that lost the merge, expect nothing
+        ({"name": "Anthony Scopatz"}, []),
+    ],
+)
+def test_find_filters_on_the_merged_document(filter, expected_ids, two_fs_dbs):
+    assert sorted(doc["_id"] for doc in two_fs_dbs.find("people", filter)) == expected_ids
 
 
-def test_find_filters_on_the_merged_value(two_fs_dbs):
-    # Test that the filter sees the merged document.  1. position is only in
-    # the first database for scopatz but must still match. 2. a filter on a
-    # value that was overridden must match the winning value, not the losing
-    # one.
-    positions = sorted(doc["_id"] for doc in two_fs_dbs.find("people", {"position": "prof"}))
-    assert positions == ["only_second", "scopatz"]
-    assert [doc["_id"] for doc in two_fs_dbs.find("people", {"name": "A. Scopatz"})] == ["scopatz"]
-    assert list(two_fs_dbs.find("people", {"name": "Anthony Scopatz"})) == []
-
-
-def test_find_and_get_return_copies_by_default(two_fs_dbs):
-    # Test that mutating a returned document does not change the state the
-    # client holds, which it would otherwise write out without knowing
-    doc = two_fs_dbs.get("people", "only_first")
+@pytest.mark.parametrize(
+    "read_document",
+    [
+        # Test that a caller cannot change the state the client holds, which it
+        # would otherwise write out without knowing it had to
+        # C1: read through get, expect the client to keep its own value
+        lambda client: client.get("people", "only_first"),
+        # C2: read through find, expect the client to keep its own value
+        lambda client: next(iter(client.find("people", {"_id": "only_first"}))),
+    ],
+)
+def test_reads_return_copies_by_default(read_document, two_fs_dbs):
+    doc = read_document(two_fs_dbs)
     doc["name"] = "mutated"
-    assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"
-    for found in two_fs_dbs.find("people", {"_id": "only_first"}):
-        found["name"] = "mutated again"
     assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -156,3 +156,53 @@ def test_insert_many_of_nothing_is_not_a_modification(fs_db):
     client.insert_many("test", "people", [])
     assert client.is_dirty("test", "people") is False
     assert client.dump_database(db) == []
+
+
+def test_get_returns_one_document_by_id(fs_db):
+    # Test the id lookup that lets a caller avoid reading a whole collection
+    client, db, dbpath = fs_db
+    assert client.get("test", "people", "scopatz")["name"] == "Anthony Scopatz"
+
+
+def test_get_returns_none_for_a_missing_document_or_collection(fs_db):
+    # Test the misses, none of which should raise
+    client, db, dbpath = fs_db
+    assert client.get("test", "people", "nobody") is None
+    assert client.get("test", "nonexistent", "scopatz") is None
+    assert client.get("nonexistent", "people", "scopatz") is None
+
+
+def test_get_of_a_missing_database_does_not_create_it(fs_db):
+    # Test that a miss leaves dbs alone, since dbs is a defaultdict and a
+    # stray lookup would otherwise add an empty database that gets dumped
+    client, db, dbpath = fs_db
+    client.get("nonexistent", "people", "scopatz")
+    assert "nonexistent" not in client.dbs
+
+
+@pytest.mark.parametrize(
+    "filter,expected_ids",
+    [
+        # C1: no filter, expect every document in the collection
+        (None, ["scopatz"]),
+        # C2: a filter on a value that matches, expect that document
+        ({"name": "Anthony Scopatz"}, ["scopatz"]),
+        # C3: a filter on a value that does not match, expect nothing
+        ({"name": "Nobody"}, []),
+        # C4: a filter on a key no document has, expect nothing
+        ({"missing_key": "any"}, []),
+    ],
+)
+def test_find_matches_documents_on_every_filter_key(fs_db, filter, expected_ids):
+    # Test filtering a collection on the filesystem backend
+    client, db, dbpath = fs_db
+    assert [doc["_id"] for doc in client.find("test", "people", filter)] == expected_ids
+
+
+def test_find_one_by_id_agrees_with_a_scan(fs_db):
+    # Test that the id fast path in find_one returns what scanning would
+    client, db, dbpath = fs_db
+    client.insert_one("test", "people", {"_id": "sbillinge", "name": "Simon Billinge"})
+    by_id = client.find_one("test", "people", {"_id": "sbillinge"})
+    by_scan = client.find_one("test", "people", {"name": "Simon Billinge"})
+    assert by_id == by_scan

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -158,18 +158,24 @@ def test_insert_many_of_nothing_is_not_a_modification(fs_db):
     assert client.dump_database(db) == []
 
 
-def test_get_returns_one_document_by_id(fs_db):
-    # Test the id lookup that lets a caller avoid reading a whole collection
+@pytest.mark.parametrize(
+    "dbname, collname, _id, expected_name",
+    [
+        # Test looking one document up by id instead of reading a collection
+        # C1: a document the database holds, expect that document
+        ("test", "people", "scopatz", "Anthony Scopatz"),
+        # C2: an id the collection does not have, expect None
+        ("test", "people", "nobody", None),
+        # C3: a collection the database does not have, expect None
+        ("test", "nonexistent", "scopatz", None),
+        # C4: a database the client has not loaded, expect None
+        ("nonexistent", "people", "scopatz", None),
+    ],
+)
+def test_get_returns_one_document_by_id(dbname, collname, _id, expected_name, fs_db):
     client, db, dbpath = fs_db
-    assert client.get("test", "people", "scopatz")["name"] == "Anthony Scopatz"
-
-
-def test_get_returns_none_for_a_missing_document_or_collection(fs_db):
-    # Test the misses, none of which should raise
-    client, db, dbpath = fs_db
-    assert client.get("test", "people", "nobody") is None
-    assert client.get("test", "nonexistent", "scopatz") is None
-    assert client.get("nonexistent", "people", "scopatz") is None
+    doc = client.get(dbname, collname, _id)
+    assert (doc["name"] if doc is not None else None) == expected_name
 
 
 def test_get_of_a_missing_database_does_not_create_it(fs_db):
@@ -181,8 +187,9 @@ def test_get_of_a_missing_database_does_not_create_it(fs_db):
 
 
 @pytest.mark.parametrize(
-    "filter,expected_ids",
+    "filter, expected_ids",
     [
+        # Test filtering a collection on the filesystem backend
         # C1: no filter, expect every document in the collection
         (None, ["scopatz"]),
         # C2: a filter on a value that matches, expect that document
@@ -193,8 +200,7 @@ def test_get_of_a_missing_database_does_not_create_it(fs_db):
         ({"missing_key": "any"}, []),
     ],
 )
-def test_find_matches_documents_on_every_filter_key(fs_db, filter, expected_ids):
-    # Test filtering a collection on the filesystem backend
+def test_find_matches_documents_on_every_filter_key(filter, expected_ids, fs_db):
     client, db, dbpath = fs_db
     assert [doc["_id"] for doc in client.find("test", "people", filter)] == expected_ids
 

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -5,15 +5,42 @@ from pathlib import Path
 from regolith.mongoclient import MongoClient
 
 
+class FakePymongoCollection:
+    """A stand-in for a pymongo Collection that records the queries it
+    is asked, so a test can tell a pushed down query from a full
+    read."""
+
+    def __init__(self, docs, queries):
+        self._docs = docs
+        self.queries = queries
+
+    def find_one(self, filter):
+        self.queries.append(("find_one", filter))
+        for doc in self._docs:
+            if all(doc.get(key) == value for key, value in filter.items()):
+                return doc
+        return None
+
+    def find(self, filter=None):
+        self.queries.append(("find", filter))
+        for doc in self._docs:
+            if all(doc.get(key) == value for key, value in (filter or {}).items()):
+                yield doc
+
+
 class FakePymongoDatabase:
     """A stand-in for a pymongo Database that offers only the collection
     listing call that pymongo 4 still provides."""
 
-    def __init__(self, collection_names):
-        self._collection_names = collection_names
+    def __init__(self, collections, queries):
+        self._collections = collections
+        self.queries = queries
 
     def list_collection_names(self):
-        return list(self._collection_names)
+        return list(self._collections)
+
+    def __getitem__(self, collname):
+        return FakePymongoCollection(self._collections.get(collname, []), self.queries)
 
     def __getattr__(self, name):
         # pymongo 4 removed Database.collection_names, so reaching for any
@@ -21,18 +48,24 @@ class FakePymongoDatabase:
         raise AttributeError(f"pymongo 4 Database has no attribute {name!r}")
 
 
-def _client_with(collection_names):
-    """Build a MongoClient whose pymongo client is the fake database."""
+def _client_with(collections):
+    """Build a MongoClient whose pymongo client is the fake database.
+
+    Returns the client and the list its collections append queries to.
+    """
+    queries = []
+    if not isinstance(collections, dict):
+        collections = {name: [] for name in collections}
     client = MongoClient.__new__(MongoClient)
-    client.client = {"test": FakePymongoDatabase(collection_names)}
+    client.client = {"test": FakePymongoDatabase(collections, queries)}
     client.rc = None
-    return client
+    return client, queries
 
 
 def test_collection_names_uses_the_pymongo_4_api():
     # Test listing the collections of a database, which must go through
     # list_collection_names because pymongo 4 removed collection_names
-    client = _client_with(["people", "todos"])
+    client, _ = _client_with(["people", "todos"])
     assert client.collection_names("test") == ["people", "todos"]
 
 
@@ -40,7 +73,44 @@ def test_dump_database_lists_collections_with_the_pymongo_4_api(mocker, tmp_path
     # Test that dumping a mongo database lists its collections through the
     # pymongo 4 API, so that a mongo to filesystem backup does not fail
     mocker.patch("regolith.mongoclient.subprocess.check_call")
-    client = _client_with(["people"])
+    client, _ = _client_with(["people"])
     db = {"name": "test", "url": str(tmp_path), "path": "db", "local": True}
     to_add = client.dump_database(db)
     assert to_add == [str(Path("db") / "people.json")]
+
+
+def test_get_asks_the_server_for_one_document():
+    # Test that reading one document sends an _id query to the server rather
+    # than reading the collection, which is the whole point of the method
+    docs = [{"_id": "scopatz", "name": "Anthony Scopatz"}, {"_id": "sbillinge", "name": "Simon Billinge"}]
+    client, queries = _client_with({"people": docs})
+    assert client.get("test", "people", "scopatz")["name"] == "Anthony Scopatz"
+    assert queries == [("find_one", {"_id": "scopatz"})]
+
+
+def test_get_returns_none_when_the_server_has_no_such_document():
+    # Test the miss, which must not raise
+    client, _ = _client_with({"people": [{"_id": "scopatz", "name": "Anthony Scopatz"}]})
+    assert client.get("test", "people", "nobody") is None
+
+
+def test_find_sends_the_filter_to_the_server():
+    # Test that the filter is pushed down, so only matching documents cross
+    # the network rather than the whole collection
+    docs = [
+        {"_id": "scopatz", "position": "prof"},
+        {"_id": "sbillinge", "position": "prof"},
+        {"_id": "student", "position": "grad"},
+    ]
+    client, queries = _client_with({"people": docs})
+    found = [doc["_id"] for doc in client.find("test", "people", {"position": "prof"})]
+    assert found == ["scopatz", "sbillinge"]
+    assert queries == [("find", {"position": "prof"})]
+
+
+def test_find_without_a_filter_reads_the_whole_collection():
+    # Test that an absent filter still becomes a valid empty mongo query
+    docs = [{"_id": "scopatz"}, {"_id": "sbillinge"}]
+    client, queries = _client_with({"people": docs})
+    assert [doc["_id"] for doc in client.find("test", "people")] == ["scopatz", "sbillinge"]
+    assert queries == [("find", {})]

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from regolith.mongoclient import MongoClient
 
 
@@ -79,38 +81,45 @@ def test_dump_database_lists_collections_with_the_pymongo_4_api(mocker, tmp_path
     assert to_add == [str(Path("db") / "people.json")]
 
 
-def test_get_asks_the_server_for_one_document():
-    # Test that reading one document sends an _id query to the server rather
-    # than reading the collection, which is the whole point of the method
-    docs = [{"_id": "scopatz", "name": "Anthony Scopatz"}, {"_id": "sbillinge", "name": "Simon Billinge"}]
-    client, queries = _client_with({"people": docs})
-    assert client.get("test", "people", "scopatz")["name"] == "Anthony Scopatz"
-    assert queries == [("find_one", {"_id": "scopatz"})]
+PEOPLE_DOCS = [
+    {"_id": "scopatz", "name": "Anthony Scopatz", "position": "prof"},
+    {"_id": "sbillinge", "name": "Simon Billinge", "position": "prof"},
+    {"_id": "student", "name": "A Student", "position": "grad"},
+]
 
 
-def test_get_returns_none_when_the_server_has_no_such_document():
-    # Test the miss, which must not raise
-    client, _ = _client_with({"people": [{"_id": "scopatz", "name": "Anthony Scopatz"}]})
-    assert client.get("test", "people", "nobody") is None
+@pytest.mark.parametrize(
+    "_id, expected_name",
+    [
+        # Test that reading one document sends an _id query to the server
+        # instead of reading the collection, which is the point of the method
+        # C1: a document the server holds, expect that document
+        ("scopatz", "Anthony Scopatz"),
+        # C2: an id the server does not hold, expect None
+        ("nobody", None),
+    ],
+)
+def test_get_asks_the_server_for_one_document(_id, expected_name):
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    doc = client.get("test", "people", _id)
+    assert (doc["name"] if doc is not None else None) == expected_name
+    assert queries == [("find_one", {"_id": _id})]
 
 
-def test_find_sends_the_filter_to_the_server():
-    # Test that the filter is pushed down, so only matching documents cross
-    # the network rather than the whole collection
-    docs = [
-        {"_id": "scopatz", "position": "prof"},
-        {"_id": "sbillinge", "position": "prof"},
-        {"_id": "student", "position": "grad"},
-    ]
-    client, queries = _client_with({"people": docs})
-    found = [doc["_id"] for doc in client.find("test", "people", {"position": "prof"})]
-    assert found == ["scopatz", "sbillinge"]
-    assert queries == [("find", {"position": "prof"})]
-
-
-def test_find_without_a_filter_reads_the_whole_collection():
-    # Test that an absent filter still becomes a valid empty mongo query
-    docs = [{"_id": "scopatz"}, {"_id": "sbillinge"}]
-    client, queries = _client_with({"people": docs})
-    assert [doc["_id"] for doc in client.find("test", "people")] == ["scopatz", "sbillinge"]
-    assert queries == [("find", {})]
+@pytest.mark.parametrize(
+    "filter, expected_ids, expected_query",
+    [
+        # Test that the filter reaches the server, so only the matching
+        # documents cross the network rather than the whole collection
+        # C1: no filter, expect every document and a valid empty mongo query
+        (None, ["scopatz", "sbillinge", "student"], {}),
+        # C2: a filter several documents match, expect all of them
+        ({"position": "prof"}, ["scopatz", "sbillinge"], {"position": "prof"}),
+        # C3: a filter no document matches, expect nothing
+        ({"position": "postdoc"}, [], {"position": "postdoc"}),
+    ],
+)
+def test_find_sends_the_filter_to_the_server(filter, expected_ids, expected_query):
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    assert [doc["_id"] for doc in client.find("test", "people", filter)] == expected_ids
+    assert queries == [("find", expected_query)]


### PR DESCRIPTION
client_manager.py, fsclient.py, mongoclient.py: builders and helpers can only reach data through all_docs_from_collection, which returns every document of a collection.  There is no way to ask a backend for one document or for a filtered subset, so MongoClient cannot use a server side query and FileSystemClient cannot avoid reading the whole collection.

Add get(collname, _id) and find(collname, filter) to the clients. MongoClient answers get from the server's index on _id and sends the filter to the server; FileSystemClient looks the id up in its dict; and find_one takes the same fast path when the filter is only an _id.

ClientManager fans out over rc.databases, asks each backing client for the documents it holds, and merges the versions with ChainDB in rc.databases order, so get and find resolve a shared document exactly as open_dbs does.  find reads each database once rather than looking each id up again, because a document is matched on its merged value, which no single database knows.  Both copy what they return by default: the documents are the clients' own, and mutating one would change state the client does not know it has to write.

This is the seam the pushdown work needs; it does not speed anything up on its own, since open_dbs still loads every needed collection eagerly.  The source map and lazy loading that use it come next.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64