### PR TITLE
feat: read collections when they are asked for, not when the dbs open

### DIFF
--- a/news/lazy-source-mapped-loading.rst
+++ b/news/lazy-source-mapped-loading.rst
@@ -1,0 +1,33 @@
+**Added:**
+
+* ``ClientManager.collection_sources`` reports which databases hold a collection,
+  and ``load_collection`` reads one collection on demand.  The clients gain
+  ``available_collections`` and ``load_collection`` alongside them.
+
+**Changed:**
+
+* Collections are read when they are first asked for rather than when the
+  databases are opened.  ``open_dbs`` now builds only a source map, from one
+  directory listing per filesystem database and one ``list_collection_names``
+  per mongo database, reading no documents; ``rc.client.chained_db`` chains each
+  collection on first access.  A command that declares no ``needed_colls``, or
+  that declares more than it uses, no longer pays for the collections it never
+  touches.
+* ``dump_database(force=True)`` writes every *loaded* collection rather than
+  every collection, since unread collections cannot have been modified.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/app.py
+++ b/src/regolith/app.py
@@ -39,6 +39,8 @@ def shutdown():
 def collection_page(dbname, collname):
     rc = app.rc
     try:
+        # Collections load on demand, so ask for this one before reading it
+        rc.client.load_collection(collname)
         coll = rc.client[dbname][collname]
     except (KeyError, AttributeError):
         abort(404)

--- a/src/regolith/chained_db.py
+++ b/src/regolith/chained_db.py
@@ -5,7 +5,7 @@ ChainDBSingleton Copyright 2015-2016, the xonsh developers
 
 import itertools
 from collections import ChainMap
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 
 class ChainDBSingleton(object):
@@ -74,3 +74,49 @@ def _convert_to_dict(cm):
         return r
     else:
         return cm
+
+
+class LazyChainedDB(Mapping):
+    """The chained collections of the databases, each one built the
+    first time it is asked for.
+
+    Reading one collection must not pull in every other collection, so
+    the chaining is done per collection on demand rather than for the
+    whole database when it is opened.  Iterating this mapping, as
+    validation does, still reaches every collection and so still loads
+    them all.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self._chained = {}
+
+    def __getitem__(self, collname):
+        if collname not in self._chained:
+            self._chained[collname] = self._client.chain_collection(collname)
+        return self._chained[collname]
+
+    def __contains__(self, collname):
+        # Answer from the source map, so that testing for a collection does
+        # not read it
+        return collname in self._client.chained_collection_names()
+
+    def __iter__(self):
+        return iter(self._client.chained_collection_names())
+
+    def __len__(self):
+        return len(self._client.chained_collection_names())
+
+    def materialize(self):
+        """Return every chained collection as a plain dict.
+
+        This reads every collection of every database, so use it only
+        where the whole database is genuinely wanted, such as handing the
+        data to a caller that outlives the connection.
+
+        Returns
+        -------
+        dict
+            The chained collections, keyed by collection name.
+        """
+        return {collname: self[collname] for collname in self}

--- a/src/regolith/client_manager.py
+++ b/src/regolith/client_manager.py
@@ -35,6 +35,7 @@ class ClientManager:
         self.rc = rc
         self.closed = True
         self.chained_db = None
+        self._sources = {}
         # self.open()
         self._collfiletypes = {}
         self._collexts = {}
@@ -56,6 +57,7 @@ class ClientManager:
 
     def open(self):
         """Opens the database connections."""
+        self._sources = {}
         for client in self.clients:
             client.open()
 
@@ -65,9 +67,94 @@ class ClientManager:
             client.close()
 
     def load_database(self, db):
+        """Record which collections a database holds, without reading
+        them.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``name`` and ``backend``.
+        """
         for client in self.clients:
             if isinstance(client, CLIENTS[db["backend"]]):
                 client.load_database(db)
+                for collname in client.available_collections(db["name"]):
+                    self._sources.setdefault(collname, []).append(db)
+
+    def collection_sources(self, collname):
+        """Return the databases that hold a collection.
+
+        The list is in ``rc.databases`` order, which is the order the
+        merge resolves in.
+
+        Parameters
+        ----------
+        collname : str
+            The name of the collection.
+
+        Returns
+        -------
+        list of dict
+            The descriptions of the databases holding the collection.
+        """
+        return self._sources.get(collname, [])
+
+    def chained_collection_names(self):
+        """Return the names of every collection any database holds.
+
+        Returns
+        -------
+        set of str
+            The collection names.
+        """
+        return set(self._sources)
+
+    def load_collection(self, collname):
+        """Read one collection into memory from each database that holds
+        it.
+
+        Parameters
+        ----------
+        collname : str
+            The name of the collection to read.
+        """
+        for db in self.collection_sources(collname):
+            client = self._client_for(db)
+            if client is not None:
+                client.load_collection(db["name"], collname)
+
+    def chain_collection(self, collname):
+        """Build the chained view of one collection.
+
+        Parameters
+        ----------
+        collname : str
+            The name of the collection to chain.
+
+        Returns
+        -------
+        dict
+            The merged documents, keyed by id.
+
+        Raises
+        ------
+        KeyError
+            When no database holds the collection.
+        """
+        sources = self.collection_sources(collname)
+        if not sources:
+            raise KeyError(collname)
+        chained = {}
+        for db in sources:
+            client = self._client_for(db)
+            if client is None:
+                continue
+            for _id, doc in client.raw_collection(db["name"], collname).items():
+                if _id in chained:
+                    chained[_id].maps.append(doc)
+                else:
+                    chained[_id] = ChainDB(doc)
+        return chained
 
     def import_database(self, db: dict):
         for client in self.clients:
@@ -192,7 +279,7 @@ class ClientManager:
             The merged document, or None when no database holds it.
         """
         docs = []
-        for db in self.rc.databases:
+        for db in self.collection_sources(collname):
             client = self._client_for(db)
             if client is None:
                 continue
@@ -229,7 +316,7 @@ class ClientManager:
             The matching merged documents.
         """
         versions = {}
-        for db in self.rc.databases:
+        for db in self.collection_sources(collname):
             client = self._client_for(db)
             if client is None:
                 continue

--- a/src/regolith/database.py
+++ b/src/regolith/database.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     hglib = None
 
-from regolith.chained_db import ChainDB
+from regolith.chained_db import LazyChainedDB
 from regolith.client_manager import ClientManager
 from regolith.tools import dbdirname
 
@@ -212,22 +212,15 @@ def open_dbs(rc, dbs=None):
         dbs = []
     client = ClientManager(rc.databases, rc)
     client.open()
-    chained_db = {}
     for db in rc.databases:
         # if we only want to access some dbs and this db is not in that some
         db["whitelist"] = dbs
         if "blacklist" not in db:
             db["blacklist"] = [".travis.yml", ".travis.yaml"]
         load_database(db, client, rc)
-        for base, coll in client.dbs[db["name"]].items():
-            if base not in chained_db:
-                chained_db[base] = {}
-            for k, v in coll.items():
-                if k in chained_db[base]:
-                    chained_db[base][k].maps.append(v)
-                else:
-                    chained_db[base][k] = ChainDB(v)
-    client.chained_db = chained_db
+    # Chain each collection when it is first asked for rather than now, so a
+    # command only reads the collections it actually uses
+    client.chained_db = LazyChainedDB(client)
     return client
 
 

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -155,6 +155,9 @@ class FileSystemClient:
         self.dbs = None
         self.chained_db = None
         self._dirty = set()
+        self._available = {}
+        self._loaded = set()
+        self._dbpaths = {}
         self.open()
         self._collfiletypes = {}
         self._collexts = {}
@@ -168,6 +171,9 @@ class FileSystemClient:
             self.dbs = defaultdict(lambda: defaultdict(dict))
             self.chained_db = {}
             self._dirty = set()
+            self._available = {}
+            self._loaded = set()
+            self._dbpaths = {}
             self.closed = False
 
     def mark_dirty(self, dbname, collname):
@@ -204,44 +210,116 @@ class FileSystemClient:
             return (dbname, collname) in self._dirty
         return any(dirty_dbname == dbname for dirty_dbname, _ in self._dirty)
 
-    def load_json(self, db, dbpath):
-        """Loads the JSON part of a database."""
-        dbs = self.dbs
-        for f in [
-            file
-            for file in sorted(Path(dbpath).glob("*.json"))
-            if str(file) not in db["blacklist"]
-            and len(db["whitelist"]) == 0
-            or file.name.split(".")[0] in db["whitelist"]
-        ]:
-            base = f.stem
-            self._collfiletypes[base] = "json"
-            print("loading " + str(f) + "...", file=sys.stderr)
-            dbs[db["name"]][base] = load_json(f)
+    def _collection_files(self, db):
+        """Return the file of each collection of a database.
 
-    def load_yaml(self, db, dbpath):
-        """Loads the YAML part of a database."""
-        dbs = self.dbs
-        for f in [
-            file
-            for file in sorted(Path(dbpath).glob("*.y*ml"))
-            if str(file) not in db["blacklist"]
-            and len(db["whitelist"]) == 0
-            or file.name.split(".")[0] in db["whitelist"]
-        ]:
-            base, ext = f.stem, f.suffix
-            self._collexts[base] = ext
-            self._collfiletypes[base] = "yaml"
-            # print("loading " + f + "...", file=sys.stderr)
-            coll, inst = load_yaml(f, return_inst=True)
-            dbs[db["name"]][base] = coll
-            self._yamlinsts[Path(dbpath), base] = inst
+        The files are not read, so this costs one directory listing and no
+        parsing.
+
+        Parameters
+        ----------
+        db : dict
+            The database description, supplying ``blacklist`` and
+            ``whitelist``.
+
+        Returns
+        -------
+        dict
+            The path of each collection, keyed by collection name.
+        """
+        dbpath = dbpathname(db, self.rc)
+        files = {}
+        for pattern in ("*.json", "*.y*ml"):
+            for f in sorted(Path(dbpath).glob(pattern)):
+                if not (
+                    str(f) not in db["blacklist"]
+                    and len(db["whitelist"]) == 0
+                    or f.name.split(".")[0] in db["whitelist"]
+                ):
+                    continue
+                files[f.stem] = f
+        return files
 
     def load_database(self, db):
-        """Loads a database."""
-        dbpath = dbpathname(db, self.rc)
-        self.load_json(db, dbpath)
-        self.load_yaml(db, dbpath)
+        """Record which collections a database holds, without reading
+        them.
+
+        The documents of a collection are read by ``load_collection``, when
+        something first asks for them.
+
+        Parameters
+        ----------
+        db : dict
+            The database description.
+        """
+        dbname = db["name"]
+        self._dbpaths[dbname] = dbpathname(db, self.rc)
+        files = self._collection_files(db)
+        self._available[dbname] = files
+        for collname, f in files.items():
+            if f.suffix == ".json":
+                self._collfiletypes[collname] = "json"
+            else:
+                self._collexts[collname] = f.suffix
+                self._collfiletypes[collname] = "yaml"
+
+    def available_collections(self, dbname):
+        """Return the names of the collections a database holds.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database to list.
+
+        Returns
+        -------
+        set of str
+            The collection names, whether or not they have been read.
+        """
+        return set(self._available.get(dbname, {}))
+
+    def load_collection(self, dbname, collname):
+        """Read one collection into memory unless it is already there.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        """
+        if (dbname, collname) in self._loaded:
+            return
+        f = self._available.get(dbname, {}).get(collname)
+        if f is None:
+            return
+        print("loading " + str(f) + "...", file=sys.stderr)
+        if self._collfiletypes.get(collname) == "json":
+            docs = load_json(f)
+        else:
+            docs, inst = load_yaml(f, return_inst=True)
+            self._yamlinsts[self._dbpaths[dbname], collname] = inst
+        self.dbs[dbname][collname] = docs
+        self._loaded.add((dbname, collname))
+
+    def raw_collection(self, dbname, collname):
+        """Return the documents of one collection as this database holds
+        them, unmerged with any other database.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+
+        Returns
+        -------
+        dict
+            The documents, keyed by id.
+        """
+        self.load_collection(dbname, collname)
+        return self.dbs.get(dbname, {}).get(collname, {})
 
     def dump_json(self, docs, collname, dbpath):
         """Dumps json docs and returns filename."""
@@ -311,7 +389,7 @@ class FileSystemClient:
 
     def collection_names(self, dbname, include_system_collections=True):
         """Returns the collection names for a database."""
-        return set(self.dbs[dbname].keys())
+        return self.available_collections(dbname)
 
     def all_documents(self, collname, copy=True):
         """Returns an iterable over all documents in a collection."""
@@ -321,12 +399,14 @@ class FileSystemClient:
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""
+        self.load_collection(dbname, collname)
         coll = self.dbs[dbname][collname]
         coll[doc["_id"]] = doc
         self.mark_dirty(dbname, collname)
 
     def insert_many(self, dbname, collname, docs):
         """Inserts many documents into a database/collection."""
+        self.load_collection(dbname, collname)
         coll = self.dbs[dbname][collname]
         for doc in docs:
             coll[doc["_id"]] = doc
@@ -334,6 +414,7 @@ class FileSystemClient:
 
     def delete_one(self, dbname, collname, doc):
         """Removes a single document from a collection."""
+        self.load_collection(dbname, collname)
         coll = self.dbs[dbname][collname]
         del coll[doc["_id"]]
         self.mark_dirty(dbname, collname)
@@ -355,7 +436,7 @@ class FileSystemClient:
         dict or None
             The document, or None when the database has no such document.
         """
-        return self.dbs.get(dbname, {}).get(collname, {}).get(_id)
+        return self.raw_collection(dbname, collname).get(_id)
 
     def find(self, dbname, collname, filter=None):
         """Yield the documents of a collection that match a filter.
@@ -375,7 +456,7 @@ class FileSystemClient:
         dict
             The matching documents.
         """
-        for doc in self.dbs.get(dbname, {}).get(collname, {}).values():
+        for doc in self.raw_collection(dbname, collname).values():
             if doc_matches(doc, filter):
                 yield doc
 
@@ -389,6 +470,7 @@ class FileSystemClient:
 
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""
+        self.load_collection(dbname, collname)
         coll = self.dbs[dbname][collname]
         doc = self.find_one(dbname, collname, filter)
         newdoc = dict(filter if doc is None else doc)

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -255,6 +255,8 @@ class MongoClient:
         self.chained_db = dict()
         self.closed = True
         self.local = True
+        self._available = {}
+        self._loaded = set()
 
     def _preclean(self):
         mongodbpath = self.rc.mongodbpath
@@ -365,31 +367,34 @@ class MongoClient:
             self.closed = False
 
     def load_database(self, db: dict):
-        """Load the database information from mongo database.
+        """Record which collections the mongo database holds, without
+        reading them.
 
-        It populate the 'dbs' attribute with a dictionary like {database: {collection: docs_dict}}.
+        Only the collection names are fetched here.  The documents of a
+        collection are read by ``load_collection``, when something first
+        asks for them, and a query made through ``get`` or ``find`` never
+        reads them at all.
 
         Parameters
         ----------
         db : dict
             The dictionary of data base information, such as 'name'.
         """
-        dbs: dict = self.dbs
-        client: pymongo.MongoClient = self.client
         from pymongo.errors import OperationFailure
 
+        dbname = db["name"]
+        self._available[dbname] = set()
         try:
-            mongodb = client[db["name"]]
+            mongodb = self.client[dbname]
         except OperationFailure:
             print("WARNING: Database name provided in regolithrc.json not found in mongodb")
+            return
         try:
-            for colname in [
+            self._available[dbname] = {
                 coll
                 for coll in mongodb.list_collection_names()
                 if coll not in db["blacklist"] and len(db["whitelist"]) == 0 or coll in db["whitelist"]
-            ]:
-                col = mongodb[colname]
-                dbs[db["name"]][colname] = load_mongo_col(col)
+            }
         except OperationFailure as fail:
             print("Mongo's Error Message:" + str(fail) + "\n")
             print("The user does not have permission to access " + db["name"] + "\n\n")
@@ -398,6 +403,60 @@ class MongoClient:
                 "permission as well as finding is needed"
             )
         return
+
+    def available_collections(self, dbname):
+        """Return the names of the collections a database holds.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database to list.
+
+        Returns
+        -------
+        set of str
+            The collection names, whether or not they have been read.
+        """
+        return set(self._available.get(dbname, set()))
+
+    def load_collection(self, dbname, collname):
+        """Read one collection into memory unless it is already there.
+
+        This pulls the whole collection across the network, so prefer
+        ``get`` or ``find``, which let the server do the work.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+        """
+        if (dbname, collname) in self._loaded:
+            return
+        if collname not in self._available.get(dbname, set()):
+            return
+        self.dbs[dbname][collname] = load_mongo_col(self.client[dbname][collname])
+        self._loaded.add((dbname, collname))
+
+    def raw_collection(self, dbname, collname):
+        """Return the documents of one collection as this database holds
+        them, unmerged with any other database.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection to read.
+
+        Returns
+        -------
+        dict
+            The documents, keyed by id.
+        """
+        self.load_collection(dbname, collname)
+        return self.dbs.get(dbname, {}).get(collname, {})
 
     def import_database(self, db: dict):
         """Import the database from filesystem to the mongo backend.

--- a/src/regolith/runcontrol.py
+++ b/src/regolith/runcontrol.py
@@ -290,5 +290,7 @@ def connect_db(rc, colls=None):
     """
     with connect(rc, dbs=colls) as rc.client:
         dbs = rc.client.dbs
-        chained_db = rc.client.chained_db
+        # Collections chain on demand, and the client is closed on the way out
+        # of this block, so read them all while the connection is still open
+        chained_db = rc.client.chained_db.materialize()
     return chained_db, dbs

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -3,7 +3,7 @@ from copy import copy, deepcopy
 
 import pytest
 
-from regolith.chained_db import ChainDB
+from regolith.chained_db import ChainDB, LazyChainedDB
 from regolith.client_manager import ClientManager
 from regolith.database import connect
 from regolith.fsclient import dump_yaml
@@ -48,6 +48,8 @@ def two_fs_dbs(tmp_path):
                 "only_second": {"_id": "only_second", "name": "Second Only", "position": "prof"},
             }
         dump_yaml(dbpath / "people.yaml", docs)
+        if name == "second":
+            dump_yaml(dbpath / "abstracts.yaml", {"first": {"_id": "first", "text": "an abstract"}})
     rc = copy(DEFAULT_RC)
     rc._update(
         {
@@ -70,6 +72,9 @@ def two_fs_dbs(tmp_path):
     client.open()
     for db in rc.databases:
         client.load_database(db)
+    # open_dbs attaches the lazy chained view; mirror it so the fixture
+    # behaves like a real connection
+    client.chained_db = LazyChainedDB(client)
     yield client
 
 
@@ -156,3 +161,77 @@ def test_reads_return_copies_by_default(read_document, two_fs_dbs):
     doc = read_document(two_fs_dbs)
     doc["name"] = "mutated"
     assert two_fs_dbs.get("people", "only_first")["name"] == "First Only"
+
+
+@pytest.mark.parametrize(
+    "collname, expected_dbnames",
+    [
+        # Test the source map that says which databases hold a collection,
+        # built from a directory listing rather than by reading documents
+        # C1: a collection both databases hold, expect both in rc.databases
+        # order, since that is the order the merge resolves in
+        ("people", ["first", "second"]),
+        # C2: a collection only the second database holds, expect only it
+        ("abstracts", ["second"]),
+        # C3: a collection no database holds, expect nothing
+        ("nonexistent", []),
+    ],
+)
+def test_collection_sources_reports_the_databases_holding_a_collection(collname, expected_dbnames, two_fs_dbs):
+    sources = two_fs_dbs.collection_sources(collname)
+    assert [db["name"] for db in sources] == expected_dbnames
+
+
+def test_opening_the_databases_reads_no_documents(two_fs_dbs):
+    # Test that opening builds the source map without reading any collection,
+    # which is what stops a command paying for collections it never uses
+    assert two_fs_dbs.chained_collection_names() == {"people", "abstracts"}
+    for db in two_fs_dbs.rc.databases:
+        assert two_fs_dbs.dbs[db["name"]] == {}
+
+
+@pytest.mark.parametrize(
+    "read_collection, expected_loaded",
+    [
+        # Test that reading one collection leaves the others unread
+        # C1: chain a collection, expect only that collection read
+        (lambda client: client.chained_db["people"], {"people"}),
+        # C2: get one document, expect only that collection read
+        (lambda client: client.get("people", "scopatz"), {"people"}),
+        # C3: read the other collection, expect people left alone
+        (lambda client: client.chained_db["abstracts"], {"abstracts"}),
+    ],
+)
+def test_reading_one_collection_does_not_read_the_others(read_collection, expected_loaded, two_fs_dbs):
+    read_collection(two_fs_dbs)
+    loaded = set()
+    for db in two_fs_dbs.rc.databases:
+        loaded.update(two_fs_dbs.dbs[db["name"]])
+    assert loaded == expected_loaded
+
+
+def test_the_chained_db_matches_what_eager_chaining_produced(two_fs_dbs):
+    # Test that chaining a collection on demand gives the same documents as
+    # building the whole chained db up front did, so nothing downstream shifts
+    people = two_fs_dbs.chained_db["people"]
+    assert sorted(people) == ["only_first", "only_second", "scopatz"]
+    assert people["scopatz"]["name"] == "A. Scopatz"
+    assert people["scopatz"]["position"] == "prof"
+
+
+def test_a_missing_collection_is_absent_without_being_read(two_fs_dbs):
+    # Test that testing for a collection answers from the source map, and that
+    # a missing one behaves like a missing key rather than an empty collection
+    assert "nonexistent" not in two_fs_dbs.chained_db
+    assert "people" in two_fs_dbs.chained_db
+    assert two_fs_dbs.dbs["first"] == {}
+    with pytest.raises(KeyError):
+        two_fs_dbs.chained_db["nonexistent"]
+
+
+def test_materialize_reads_every_collection(two_fs_dbs):
+    # Test the explicit whole-database read that connect_db needs, since it
+    # hands data to callers that outlive the connection
+    materialized = two_fs_dbs.chained_db.materialize()
+    assert sorted(materialized) == ["abstracts", "people"]
+    assert materialized["people"]["scopatz"]["name"] == "A. Scopatz"

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -116,10 +116,13 @@ def test_dump_database_clears_dirty_state(fs_db):
     assert _mtimes(dbpath) == before
 
 
-def test_dump_database_force_writes_every_collection(fs_db):
-    # Test that force writes the unmodified collections too, which is what
-    # an in-place edit outside the client needs
+def test_dump_database_force_writes_every_loaded_collection(fs_db):
+    # Test that force writes collections that were read but not modified,
+    # which is what an in-place edit outside the client needs.  Collections
+    # are read on demand, so only the ones that were asked for are written.
     client, db, dbpath = fs_db
+    client.raw_collection("test", "people")
+    client.raw_collection("test", "abstracts")
     before = _mtimes(dbpath)
     written = client.dump_database(db, force=True)
     assert sorted(written) == [str(Path("db") / "abstracts.yaml"), str(Path("db") / "people.yaml")]

--- a/tests/test_runcontrol.py
+++ b/tests/test_runcontrol.py
@@ -13,7 +13,9 @@ def test_connect_db(make_db):
     filter_databases(rc)
     with connect(rc) as rc.client:
         expected_dbs = rc.client.dbs
-        expected_chdb = rc.client.chained_db
+        # Read the collections while the connection is open, since they chain
+        # on demand and connect_db must hand back data that outlives it
+        expected_chained_db = rc.client.chained_db.materialize()
     chained_db, dbs = connect_db(rc)
-    assert chained_db == expected_chdb
+    assert chained_db == expected_chained_db
     assert dbs == expected_dbs


### PR DESCRIPTION
database.py, client_manager.py, fsclient.py, mongoclient.py, chained_db.py: open_dbs read every needed collection from every database up front and wrapped every document in a ChainDB before anything knew what was wanted.  On a mongo backend that is a full collection download per command; load_mongo_col could only do find({}) because the layer above needed whole collections in order to build chained_db.

Opening now builds a source map instead: one directory listing per filesystem database, one list_collection_names per mongo database, and no documents.  ClientManager.collection_sources says which databases hold a collection, in rc.databases order so the merge still resolves the same way, and chain_collection builds the chained view of a single collection. rc.client.chained_db is a LazyChainedDB that calls it on first access, so reading one collection no longer reads the rest.  get and find skip the databases that do not hold the collection at all.

Every write path calls load_collection first.  Mutating a collection that was never read and then dumping it would have replaced the file with only the new documents.

Two behaviours follow from the change and are captured in the tests rather than worked around.  dump_database(force=True) writes every loaded collection, not every collection, because an unread one cannot have been modified.  connect_db hands its result to callers that outlive the connection, so it materializes the chained view before the client closes.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64