### PR TITLE
fix: stop the todo helpers overflowing on distant due dates

### DIFF
--- a/news/fix-todo-order-overflow.rst
+++ b/news/fix-todo-order-overflow.rst
@@ -1,0 +1,33 @@
+**Added:**
+
+* ``tools.get_todo_order``, which weighs a task for sorting by how long is left
+  before it is due.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``regolith helper f_todo`` and ``regolith helper u_todo`` no longer crash with
+  ``OverflowError: math range error`` when a task is due, or overdue, by more
+  than about two years.  All three todo helpers computed the sort weight as
+  ``1 / (1 + exp(abs(days_to_due - 0.5)))``, which overflows once the exponent
+  passes 710.  They now share ``tools.get_todo_order``, which uses the form that
+  underflows to zero instead.
+* ``regolith helper l_todo`` sorts a task that is due, or overdue, by more than
+  about two years alongside the other distant tasks.  It caught the overflow but
+  substituted infinity, which sorted such a task as the most urgent rather than
+  the least.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/f_todohelper.py
+++ b/src/regolith/helpers/f_todohelper.py
@@ -1,7 +1,6 @@
 """Helper for marking a task as finished in todos collection."""
 
 import datetime as dt
-import math
 
 import dateutil.parser as date_parser
 from gooey import GooeyParser
@@ -12,6 +11,7 @@ from regolith.tools import (
     all_docs_from_collection,
     document_by_value,
     get_pi_id,
+    get_todo_order,
     key_value_pair_filter,
     print_task,
     strip_str,
@@ -129,7 +129,7 @@ class TodoFinisherHelper(DbHelperBase):
                 if isinstance(todo["due_date"], str):
                     todo["due_date"] = date_parser.parse(todo["due_date"]).date()
                 todo["days_to_due"] = (todo.get("due_date") - today).days
-                todo["order"] = 1 / (1 + math.exp(abs(todo["days_to_due"] - 0.5)))
+                todo["order"] = get_todo_order(todo["days_to_due"])
             todolist = sorted(
                 todolist, key=lambda k: (k["status"], k["importance"], k["order"], -k.get("duration", 10000))
             )

--- a/src/regolith/helpers/l_todohelper.py
+++ b/src/regolith/helpers/l_todohelper.py
@@ -5,7 +5,6 @@ actions.
 """
 
 import datetime as dt
-import math
 
 import dateutil.parser as date_parser
 from gooey import GooeyParser
@@ -18,6 +17,7 @@ from regolith.tools import (
     all_docs_from_collection,
     document_by_value,
     get_pi_id,
+    get_todo_order,
     key_value_pair_filter,
     print_task,
     strip_str,
@@ -276,8 +276,5 @@ def _format_todos(todo, today):
         todo["end_date"] = date_parser.parse(todo["end_date"]).date()
     todo["days_to_due"] = (todo.get("due_date") - today).days
     todo["sort_finished"] = (todo.get("end_date", dt.date(1900, 1, 1)) - dt.date(1900, 1, 1)).days
-    try:
-        todo["order"] = 1 / (1 + math.exp(abs(todo["days_to_due"] - 0.5)))
-    except OverflowError:
-        todo["order"] = float("inf")
+    todo["order"] = get_todo_order(todo["days_to_due"])
     return

--- a/src/regolith/helpers/u_todohelper.py
+++ b/src/regolith/helpers/u_todohelper.py
@@ -1,7 +1,6 @@
 """Helper for updating a task in todos of todos collection."""
 
 import datetime as dt
-import math
 
 import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
@@ -14,6 +13,7 @@ from regolith.tools import (
     all_docs_from_collection,
     document_by_value,
     get_pi_id,
+    get_todo_order,
     key_value_pair_filter,
     print_task,
     strip_str,
@@ -193,7 +193,7 @@ class TodoUpdaterHelper(DbHelperBase):
                     todo["end_date"] = date_parser.parse(todo["end_date"]).date()
                 todo["days_to_due"] = (todo.get("due_date") - today).days
                 todo["sort_finished"] = (todo.get("end_date", dt.date(1900, 1, 1)) - dt.date(1900, 1, 1)).days
-                todo["order"] = 1 / (1 + math.exp(abs(todo["days_to_due"] - 0.5)))
+                todo["order"] = get_todo_order(todo["days_to_due"])
             todolist = sorted(
                 todolist, key=lambda k: (k["status"], k["importance"], k["order"], -k.get("duration", 10000))
             )

--- a/src/regolith/tools.py
+++ b/src/regolith/tools.py
@@ -4,6 +4,7 @@ regolith tools.
 """
 
 import email.utils
+import math
 import os
 import pathlib
 import platform
@@ -1317,6 +1318,32 @@ def merge_collections_superior(a, b, target_id):
                 b.remove(i)
     bdis = b
     return intersect + bdis
+
+
+def get_todo_order(days_to_due):
+    """Return the sort weight of a task from how long is left before it
+    is due.
+
+    The weight peaks for a task due now and falls away as the due date
+    moves in either direction, so that sorting on it groups the tasks
+    that need attention.  It is computed in the form that underflows to
+    zero rather than the one that overflows: a task due, or overdue, by
+    more than about two years would otherwise raise ``OverflowError``.
+
+    Parameters
+    ----------
+    days_to_due : int or float
+        The number of days until the task is due, negative once it is
+        overdue.
+
+    Returns
+    -------
+    float
+        The weight, between zero and one half, approaching zero as the
+        due date recedes in either direction.
+    """
+    decay = math.exp(-abs(days_to_due - 0.5))
+    return decay / (1 + decay)
 
 
 def get_person_contact(name, people_coll, contacts_coll):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 import copy
 import datetime as dt
+import math
 import os
 from pathlib import PurePath
 
@@ -35,6 +36,7 @@ from regolith.tools import (
     get_tags,
     get_target_repo_info,
     get_target_token,
+    get_todo_order,
     get_uuid,
     grant_burn,
     group,
@@ -4023,3 +4025,57 @@ def test_dbpathname_has_no_foreign_separators(db):
     assert actual.parts == ("..", "..", "rg-db-private", "db")
     foreign_sep = "/" if os.sep == "\\" else "\\"
     assert foreign_sep not in str(actual)
+
+
+@pytest.mark.parametrize(
+    "days_to_due, expected_order",
+    [
+        # Test the sort weight of a task from the days left before it is due
+        # C1: due about now, expect the largest weight the curve reaches
+        # 1. due today, expect the peak
+        # 2. due tomorrow, expect the same, since the curve peaks between them
+        (0, 0.3775406687981454),
+        (1, 0.3775406687981454),
+        # C2: due further off, expect a smaller weight
+        (10, 7.484622751061123e-05),
+        # C3: overdue by the same amount, expect the same weight as due in it,
+        # since only the distance from the peak counts
+        (-9, 7.484622751061123e-05),
+        # C4: due beyond the point where the exponential overflows, expect
+        # zero rather than OverflowError
+        (711, 0.0),
+        (100000, 0.0),
+        # C5: overdue beyond that point, expect zero for the same reason
+        (-710, 0.0),
+        (-100000, 0.0),
+    ],
+)
+def test_get_todo_order_weighs_a_task_by_its_due_date(days_to_due, expected_order):
+    assert get_todo_order(days_to_due) == pytest.approx(expected_order)
+
+
+@pytest.mark.parametrize(
+    "days_to_due",
+    [
+        # Test that the weight still matches the plain expression wherever
+        # that expression can be evaluated at all, so ordering does not shift
+        # C1: due today, the peak of the curve
+        0,
+        # C2: a due date a few days out
+        7,
+        # C3: a due date far enough out to be tiny but not yet overflowing
+        709,
+        # C4: overdue, the mirror of C2
+        -7,
+    ],
+)
+def test_get_todo_order_matches_the_unguarded_expression(days_to_due):
+    unguarded = 1 / (1 + math.exp(abs(days_to_due - 0.5)))
+    assert get_todo_order(days_to_due) == pytest.approx(unguarded)
+
+
+def test_get_todo_order_falls_as_the_due_date_recedes():
+    # Test that the weight decreases monotonically away from the peak, which
+    # is what makes it usable as a sort key
+    orders = [get_todo_order(d) for d in [0, 5, 50, 500, 5000]]
+    assert orders == sorted(orders, reverse=True)


### PR DESCRIPTION
tools.py, f_todohelper.py, u_todohelper.py, l_todohelper.py: all three todo helpers weighed a task for sorting with

    1 / (1 + math.exp(abs(days_to_due - 0.5)))

which raises OverflowError once the exponent passes 710, so f_todo and u_todo crashed on any task due, or overdue, by more than about two years. l_todo had a try/except around it and the other two did not.

The three copies are now one function, tools.get_todo_order, written as exp(-a) / (1 + exp(-a)) rather than 1 / (1 + exp(a)).  The two are equal wherever the second can be evaluated, and the first underflows to zero where the second overflows, which is the limit the weight approaches as the due date recedes.

This also corrects l_todo.  Its except branch substituted float("inf"), but the weight falls towards zero as the due date recedes, and the sort is ascending, so a task due in several years was ordered as the most urgent rather than the least.  Such a task now sorts with the other distant ones.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64