### PR TITLE
fix: stop printing every collection that is read

### DIFF
--- a/news/quiet-collection-loading.rst
+++ b/news/quiet-collection-loading.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* ``REGOLITH_LOG_LEVEL``.  Set it to ``DEBUG`` to have regolith name each
+  collection as it is read, and from which database, which is the quickest way
+  to find out why a command is slow.
+
+**Changed:**
+
+* Reading a collection no longer prints to the console.  It is logged at debug
+  level instead, so ordinary output stays readable.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import logging
 import signal
-import sys
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
@@ -31,6 +30,8 @@ class DelayedKeyboardInterrupt:
         if self.signal_received:
             self.old_handler(*self.signal_received)
 
+
+logger = logging.getLogger(__name__)
 
 YAML_BASE_MAP = {CommentedMap: dict, CommentedSeq: list}
 
@@ -293,7 +294,7 @@ class FileSystemClient:
         f = self._available.get(dbname, {}).get(collname)
         if f is None:
             return
-        print("loading " + str(f) + "...", file=sys.stderr)
+        logger.debug("loading %s", f)
         if self._collfiletypes.get(collname) == "json":
             docs = load_json(f)
         else:
@@ -364,7 +365,7 @@ class FileSystemClient:
         Path(dbpath).mkdir(parents=True, exist_ok=True)
         to_add = []
         for collname in collnames:
-            # print("dumping " + collname + "...", file=sys.stderr)
+            # logger.debug("dumping %s", collname)
             collection = self.dbs[dbname][collname]
             filetype = self._collfiletypes.get(collname, "yaml")
             if filetype == "json":

--- a/src/regolith/main.py
+++ b/src/regolith/main.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import copy
+import logging
 import os
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
@@ -278,7 +279,26 @@ def create_parser():
     return p
 
 
+def _configure_logging():
+    """Send regolith's log messages to the console at the requested
+    level.
+
+    The level comes from the ``REGOLITH_LOG_LEVEL`` environment variable
+    and defaults to silence.  Set it to ``DEBUG`` to see which
+    collections are read from which database, which is the quickest way
+    to find out why a command is slow.
+    """
+    level = os.environ.get("REGOLITH_LOG_LEVEL")
+    if not level:
+        return
+    logging.basicConfig(
+        level=level.upper(),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+
 def main(args=None):
+    _configure_logging()
     rc = copy.copy(DEFAULT_RC)
     parser = create_parser()
     args0 = Namespace()

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -7,6 +7,7 @@ install for maintenance tasks, such as fs-to-mongo.
 
 import datetime
 import itertools
+import logging
 import os
 import shutil
 import subprocess
@@ -151,6 +152,9 @@ def export_json(collection: str, dbpath: str, dbname: str, host: str = None, uri
     except subprocess.CalledProcessError as exc:
         print("Status : FAIL", exc.returncode, exc.output)
         raise exc
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_mongo_col(col: Collection) -> dict:
@@ -436,6 +440,7 @@ class MongoClient:
             return
         if collname not in self._available.get(dbname, set()):
             return
+        logger.debug("loading %s.%s from mongo", dbname, collname)
         self.dbs[dbname][collname] = load_mongo_col(self.client[dbname][collname])
         self._loaded.add((dbname, collname))
 

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import tempfile
 from copy import copy
 from pathlib import Path
@@ -215,3 +216,13 @@ def test_find_one_by_id_agrees_with_a_scan(fs_db):
     by_id = client.find_one("test", "people", {"_id": "sbillinge"})
     by_scan = client.find_one("test", "people", {"name": "Simon Billinge"})
     assert by_id == by_scan
+
+
+def test_loading_a_collection_is_silent_but_logged(fs_db, caplog, capsys):
+    # Test that reading a collection prints nothing, since a helper's output is
+    # meant to be readable, while still saying what it read for debugging
+    client, db, dbpath = fs_db
+    with caplog.at_level(logging.DEBUG, logger="regolith.fsclient"):
+        client.raw_collection("test", "people")
+    assert capsys.readouterr().err == ""
+    assert any("people" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
fsclient.py: reading a collection printed "loading <file>..." to stderr, which put a line in front of the user for every collection a command touches.  Only the json half of the loader did this before the collections became lazy; unifying the two loaders in #1311 gave the yaml half the same print, so a yaml backed database became noisy.

The message is now logged at debug level, and mongoclient.py logs the same way when it downloads a collection, which is the more useful of the two when working out why a command is slow.

main.py: REGOLITH_LOG_LEVEL configures logging, so the messages can be turned back on with REGOLITH_LOG_LEVEL=DEBUG.  It defaults to silence.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64