### PR TITLE
perf: fetch one person's todos by id rather than the whole collection

### DIFF
--- a/news/todo-helpers-get-by-id.rst
+++ b/news/todo-helpers-get-by-id.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``l_todo``, ``u_todo`` and ``f_todo`` fetch the one person's document they need
+  by id instead of reading the whole ``todos`` collection and searching it.  On a
+  mongo backend that is an indexed query in place of downloading every person's
+  todos, which dominated the time these helpers took.
+* ``u_todo`` and ``f_todo`` no longer gather the ``todos`` collection into the
+  template context, which nothing read, and ``l_todo`` gathers only the two
+  collections it goes through in full.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/f_todohelper.py
+++ b/src/regolith/helpers/f_todohelper.py
@@ -5,11 +5,9 @@ import datetime as dt
 import dateutil.parser as date_parser
 from gooey import GooeyParser
 
-from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.tools import (
     all_docs_from_collection,
-    document_by_value,
     get_pi_id,
     get_todo_order,
     key_value_pair_filter,
@@ -85,7 +83,6 @@ class TodoFinisherHelper(DbHelperBase):
             rc.pi_id = get_pi_id(rc)
 
         rc.coll = f"{TARGET_COLL}"
-        gtx[rc.coll] = sorted(all_docs_from_collection(rc.client, rc.coll), key=_id_key)
         gtx["all_docs_from_collection"] = all_docs_from_collection
         gtx["float"] = float
         gtx["str"] = str
@@ -109,7 +106,7 @@ class TodoFinisherHelper(DbHelperBase):
                     "or you need to enter your group id in the command line"
                 )
                 return
-        person = document_by_value(all_docs_from_collection(rc.client, "todos"), "_id", rc.assigned_to)
+        person = rc.client.get("todos", rc.assigned_to)
         filterid = {"_id": rc.assigned_to}
         if not person:
             raise TypeError(f"Id {rc.assigned_to} can't be found in todos collection")

--- a/src/regolith/helpers/l_todohelper.py
+++ b/src/regolith/helpers/l_todohelper.py
@@ -15,7 +15,6 @@ from regolith.helpers.basehelper import SoutHelperBase
 from regolith.schemas import PROJECTUM_ACTIVE_STATI, alloweds
 from regolith.tools import (
     all_docs_from_collection,
-    document_by_value,
     get_pi_id,
     get_todo_order,
     key_value_pair_filter,
@@ -119,11 +118,12 @@ class TodoListerHelper(SoutHelperBase):
         if "groups" in self.needed_colls:
             rc.pi_id = get_pi_id(rc)
         rc.coll = f"{TARGET_COLL}"
-        colls = [
-            sorted(all_docs_from_collection(rc.client, collname), key=_id_key) for collname in self.needed_colls
-        ]
-        for db, coll in zip(self.needed_colls, colls):
-            gtx[db] = coll
+        # sout reads one document of the target collection by id, so only the
+        # collections it goes through in full are gathered here
+        for collname in self.needed_colls:
+            if collname == TARGET_COLL:
+                continue
+            gtx[collname] = sorted(all_docs_from_collection(rc.client, collname), key=_id_key)
         gtx["all_docs_from_collection"] = all_docs_from_collection
         gtx["float"] = float
         gtx["str"] = str
@@ -141,7 +141,7 @@ class TodoListerHelper(SoutHelperBase):
                 )
                 return
         try:
-            person = document_by_value(all_docs_from_collection(rc.client, "todos"), "_id", rc.assigned_to)
+            person = rc.client.get("todos", rc.assigned_to)
             gather_todos = person.get("todos", [])
         except Exception:
             print("The id you entered can't be found in todos.yml.")

--- a/src/regolith/helpers/u_todohelper.py
+++ b/src/regolith/helpers/u_todohelper.py
@@ -6,12 +6,10 @@ import dateutil.parser as date_parser
 from dateutil.relativedelta import relativedelta
 from gooey import GooeyParser
 
-from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.schemas import PROJECTUM_ACTIVE_STATI, alloweds
 from regolith.tools import (
     all_docs_from_collection,
-    document_by_value,
     get_pi_id,
     get_todo_order,
     key_value_pair_filter,
@@ -146,7 +144,6 @@ class TodoUpdaterHelper(DbHelperBase):
             rc.pi_id = get_pi_id(rc)
 
         rc.coll = f"{TARGET_COLL}"
-        gtx[rc.coll] = sorted(all_docs_from_collection(rc.client, rc.coll), key=_id_key)
         gtx["all_docs_from_collection"] = all_docs_from_collection
         gtx["float"] = float
         gtx["str"] = str
@@ -171,7 +168,7 @@ class TodoUpdaterHelper(DbHelperBase):
                 )
                 return
         filterid = {"_id": rc.assigned_to}
-        person = document_by_value(all_docs_from_collection(rc.client, "todos"), "_id", rc.assigned_to)
+        person = rc.client.get("todos", rc.assigned_to)
         if not person:
             raise TypeError(f"Id {rc.assigned_to} can't be found in todos collection")
         todolist = person.get("todos", [])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 import requests_mock
 
+from regolith.client_manager import ClientManager
 from regolith.helpers.a_expensehelper import (
     MEAL_RATE_SPREAD,
     MEAL_RATES,
@@ -1693,3 +1694,40 @@ def test_expense_constructor_no_meals(no_meals, expect_meals):
     assert "flights" in purposes
     for meal in MEAL_RATES:
         assert (meal in purposes) is expect_meals
+
+
+@pytest.mark.parametrize(
+    "helper_target, extra_args",
+    [
+        # Test that the todo helpers fetch the one person's document they need
+        # by id, rather than reading the whole collection and searching it.  On
+        # a mongo backend the difference is an indexed query against a full
+        # download of every person's todos.
+        # C1: listing, expect the target collection fetched by id
+        ("l_todo", []),
+        # C2: updating, expect the same
+        ("u_todo", ["-i", "1", "--note", "a note"]),
+        # C3: finishing, expect the same
+        ("f_todo", ["-i", "1"]),
+    ],
+)
+def test_todo_helpers_fetch_one_document_by_id(helper_target, extra_args, make_db, mocker):
+    repo = make_db
+    os.chdir(repo)
+    # Spy on the client rather than on the module level helper, since the
+    # helpers bind all_docs_from_collection at import time and every whole
+    # collection read funnels through the client either way
+    get = mocker.patch.object(ClientManager, "get", autospec=True, side_effect=ClientManager.get)
+    read_all = mocker.patch.object(
+        ClientManager, "all_documents", autospec=True, side_effect=ClientManager.all_documents
+    )
+    try:
+        main(["helper", helper_target, "-t", "sbillinge"] + extra_args)
+    except Exception:
+        # The helper may not find matching data in the test database; what is
+        # under test is how it asked for the todos, not what it did with them
+        pass
+    assert any(call.args[1] == "todos" for call in get.call_args_list), "todos was not fetched by id"
+    assert not any(
+        call.args[1] == "todos" for call in read_all.call_args_list
+    ), "the whole todos collection was still read"


### PR DESCRIPTION
l_todohelper.py, u_todohelper.py, f_todohelper.py: the todos collection holds one document per person, and all three helpers wanted a single one of them.  Each read the entire collection and searched it in python:

    document_by_value(all_docs_from_collection(rc.client, "todos"),
                      "_id", rc.assigned_to)

On a mongo backend that downloads every person's todos to answer a lookup the server can do from its index on _id, and it was the bulk of what these helpers spent their time on.  They now call rc.client.get, which sends find_one({"_id": ...}) instead of find({}).

The helpers also read the collection a second time without using it. construct_global_ctx put the whole of todos in the template context, but none of these three renders a template and nothing read the entry, so u_todo and f_todo no longer gather it at all.  l_todo keeps gathering refereeReports and proposalReviews, which its sout does go through whole.

This changes nothing for a filesystem backend, where a collection lives in one file that has to be parsed either way.

tests/test_helpers.py: the guard spies on ClientManager rather than on the module level function, since the helpers bind all_docs_from_collection at import time. Verified to fail when the collection scan is put back.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64