### PR TITLE
fix: name a database before its collections have been read

### DIFF
--- a/news/fix-client-keys-before-load.rst
+++ b/news/fix-client-keys-before-load.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* A write to a database none of whose collections had been read yet was dropped
+  without a word.  ``ClientManager`` asks each client whether it backs a database
+  before routing ``insert_one``, ``insert_many``, ``update_one``, ``delete_one``
+  or ``find_one`` to it, and ``FileSystemClient.keys`` named only the databases
+  it had already read a collection from.  Since collections became lazy this was
+  none of them at the point a command started.  It named a database only because
+  every helper happened to read a collection before writing.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -383,7 +383,19 @@ class FileSystemClient:
         self.closed = True
 
     def keys(self):
-        return self.dbs.keys()
+        """Return the names of the databases this client is backing.
+
+        A database is named here from the moment it is loaded, before any
+        of its collections have been read, because the client is asked
+        whether it holds a database in order to decide where a write
+        should go.
+
+        Returns
+        -------
+        set of str
+            The names of the databases.
+        """
+        return set(self._available) | set(self.dbs)
 
     def __getitem__(self, key):
         return self.dbs[key]

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -226,3 +226,34 @@ def test_loading_a_collection_is_silent_but_logged(fs_db, caplog, capsys):
         client.raw_collection("test", "people")
     assert capsys.readouterr().err == ""
     assert any("people" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "write, expected_name",
+    [
+        # Test that a write reaches a database whose collections have not been
+        # read yet.  The client is asked whether it holds the database before
+        # the write is routed to it, so a client that names no database until
+        # something is read would drop the write silently.
+        # C1: inserting a document, expect it to be stored
+        (lambda c: c.insert_one("test", "people", {"_id": "new", "name": "New Person"}), "New Person"),
+        # C2: inserting several documents, expect them stored
+        (lambda c: c.insert_many("test", "people", [{"_id": "new", "name": "New Person"}]), "New Person"),
+        # C3: updating a document, expect the new value
+        (lambda c: c.update_one("test", "people", {"_id": "new"}, {"name": "New Person"}), "New Person"),
+    ],
+)
+def test_a_write_reaches_a_database_whose_collections_are_unread(write, expected_name, fs_db):
+    client, db, dbpath = fs_db
+    assert "test" in client.keys()
+    assert client.dbs.get("test", {}) == {}
+    write(client)
+    assert client.get("test", "people", "new")["name"] == expected_name
+
+
+def test_a_database_is_named_before_its_collections_are_read(fs_db):
+    # Test that loading a database names it straight away, since routing a
+    # write depends on the client saying which databases it backs
+    client, db, dbpath = fs_db
+    assert set(client.keys()) == {"test"}
+    assert client.dbs.get("test", {}) == {}


### PR DESCRIPTION
fsclient.py: ClientManager asks each client whether it backs a database in order to route insert_one, insert_many, update_one, delete_one and find_one to it.  FileSystemClient.keys answered from self.dbs, which since #1311 holds only the collections that have actually been read, so immediately after opening it named no databases at all and every one of those calls silently did nothing.

keys now answers from the databases the client has loaded, whether or not any of their collections have been read.

Nothing shows this today only because every helper reads a collection in construct_global_ctx before it writes, which populates self.dbs as a side effect.  Remove that incidental read from any helper and its writes stop happening, with no error.

tests/test_fsclient.py: the new cases write to a database with nothing read and check the write lands.  Verified to fail against the old keys.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64