### PR TITLE
perf: stop a_todo reading two collections it does not need

### DIFF
--- a/news/a-todo-defer-collection-reads.rst
+++ b/news/a-todo-defer-collection-reads.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``a_todo`` no longer reads the ``todos`` and ``projecta`` collections in full
+  before it starts.  It looks both people up by id, and only searches
+  ``projecta`` when a milestone uuid is given, so a plain add reads neither
+  collection whole.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/a_todohelper.py
+++ b/src/regolith/helpers/a_todohelper.py
@@ -131,8 +131,9 @@ class TodoAdderHelper(DbHelperBase):
         rc.col2 = "projecta"
         if not rc.database:
             rc.database = rc.databases[0]["name"]
-        gtx[rc.coll] = sorted(all_docs_from_collection(rc.client, rc.coll), key=_id_key)
-        gtx["projecta"] = sorted(all_docs_from_collection(rc.client, rc.col2), key=_id_key)
+        # db_updater looks its two people up by id and only goes through
+        # projecta when a milestone uuid is given, so neither collection is
+        # gathered here
         gtx["all_docs_from_collection"] = all_docs_from_collection
         gtx["float"] = float
         gtx["str"] = str
@@ -201,7 +202,8 @@ class TodoAdderHelper(DbHelperBase):
             todolist[-1]["tags"] = rc.tags
         if rc.milestone_uuid:
             # get the prum that contains the milestone that has the uuid rc.milestone_uuid
-            target_prum = fragment_retrieval(self.gtx["projecta"], ["milestones"], rc.milestone_uuid)
+            projecta = sorted(all_docs_from_collection(rc.client, rc.col2), key=_id_key)
+            target_prum = fragment_retrieval(projecta, ["milestones"], rc.milestone_uuid)
             if not target_prum:
                 raise RuntimeError(
                     f"No milestone ids were found that match your entry ({rc.milestone_uuid}).\n"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1731,3 +1731,40 @@ def test_todo_helpers_fetch_one_document_by_id(helper_target, extra_args, make_d
     assert not any(
         call.args[1] == "todos" for call in read_all.call_args_list
     ), "the whole todos collection was still read"
+
+
+@pytest.mark.parametrize(
+    "extra_args, expected_reads",
+    [
+        # Test which collections a_todo goes through in full.  It looks both
+        # people up by id and only searches projecta for a milestone, so a
+        # plain add should read neither collection whole.
+        # C1: adding a todo, expect no collection read in full
+        ([], set()),
+        # C2: adding a todo against a milestone, expect only projecta read,
+        # since the milestone is found by searching its uuids
+        (["--milestone_uuid", "milestone_uuid_sb1_2"], {"projecta"}),
+    ],
+)
+def test_a_todo_reads_only_what_it_searches(extra_args, expected_reads, make_db, mocker):
+    repo = make_db
+    os.chdir(repo)
+    read_all = mocker.patch.object(
+        ClientManager, "all_documents", autospec=True, side_effect=ClientManager.all_documents
+    )
+    args = [
+        "helper",
+        "a_todo",
+        "test the reads",
+        "6",
+        "50",
+        "--assigned-to",
+        "sbillinge",
+    ] + extra_args
+    try:
+        main(args)
+    except Exception:
+        # What is under test is which collections were read, not the outcome
+        pass
+    read = {call.args[1] for call in read_all.call_args_list}
+    assert read == expected_reads


### PR DESCRIPTION
a_todohelper.py: construct_global_ctx gathered the whole todos collection and the whole projecta collection before db_updater ran.  Nothing read the todos entry, and projecta is only searched when a milestone uuid is given, so adding one todo read both collections in full for nothing.  The update path itself was already cheap: two find_one lookups by id and one write.

Neither collection is gathered up front now, and projecta is read inside the branch that searches it, where the search over milestone uuids does need the whole collection.

tests/test_helpers.py: the new cases record which collections are read in full, for an add with and without a milestone uuid.  Verified to fail against the old helper, which read both either way.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64