### PR TITLE
perf: route a document operation without asking the server

### DIFF
--- a/news/route-writes-without-a-round-trip.rst
+++ b/news/route-writes-without-a-round-trip.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Reading or writing one document no longer asks the server which databases
+  exist.  ``ClientManager`` decided which client backed a database by calling
+  ``client.keys()``, which for the mongo backend is ``list_database_names`` and
+  so a round trip, once per operation.  It now reads the backend from the rc,
+  which already records it.  A find followed by an update goes from five round
+  trips to three.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/client_manager.py
+++ b/src/regolith/client_manager.py
@@ -229,6 +229,29 @@ class ClientManager:
                 return client
         return None
 
+    def _client_for_dbname(self, dbname):
+        """Return the client that backs a database, found by its name.
+
+        The rc says which backend each database has, so routing a read or
+        a write does not need to ask a server what it holds.  Asking is
+        what ``MongoClient.keys`` does, and it costs a round trip.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database.
+
+        Returns
+        -------
+        FileSystemClient, MongoClient or None
+            The client for that database, or None when the rc has no
+            database of that name.
+        """
+        for db in self.rc.databases:
+            if db["name"] == dbname:
+                return self._client_for(db)
+        return None
+
     def _chain(self, docs):
         """Merge the versions of one document held by several databases.
 
@@ -329,30 +352,30 @@ class ClientManager:
 
     def insert_one(self, dbname, collname, doc):
         """Inserts one document to a database/collection."""
-        for client in self.clients:
-            if dbname in client.keys():
-                client.insert_one(dbname, collname, doc)
+        client = self._client_for_dbname(dbname)
+        if client is not None:
+            client.insert_one(dbname, collname, doc)
 
     def insert_many(self, dbname, collname, docs):
         """Inserts many documents into a database/collection."""
-        for client in self.clients:
-            if dbname in client.keys():
-                client.insert_many(dbname, collname, docs)
+        client = self._client_for_dbname(dbname)
+        if client is not None:
+            client.insert_many(dbname, collname, docs)
 
     def delete_one(self, dbname, collname, doc):
         """Removes a single document from a collection."""
-        for client in self.clients:
-            if dbname in client.keys():
-                client.delete_one(dbname, collname, doc)
+        client = self._client_for_dbname(dbname)
+        if client is not None:
+            client.delete_one(dbname, collname, doc)
 
     def find_one(self, dbname, collname, filter):
         """Finds the first document matching filter."""
-        for client in self.clients:
-            if dbname in client.keys():
-                return client.find_one(dbname, collname, filter)
+        client = self._client_for_dbname(dbname)
+        if client is not None:
+            return client.find_one(dbname, collname, filter)
 
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""
-        for client in self.clients:
-            if dbname in client.keys():
-                client.update_one(dbname, collname, filter, update, **kwargs)
+        client = self._client_for_dbname(dbname)
+        if client is not None:
+            client.update_one(dbname, collname, filter, update, **kwargs)

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -6,7 +6,7 @@ import pytest
 from regolith.chained_db import ChainDB, LazyChainedDB
 from regolith.client_manager import ClientManager
 from regolith.database import connect
-from regolith.fsclient import dump_yaml
+from regolith.fsclient import FileSystemClient, dump_yaml
 from regolith.runcontrol import DEFAULT_RC, load_rcfile
 from regolith.schemas import EXEMPLARS
 from regolith.tools import all_docs_from_collection
@@ -235,3 +235,33 @@ def test_materialize_reads_every_collection(two_fs_dbs):
     materialized = two_fs_dbs.chained_db.materialize()
     assert sorted(materialized) == ["abstracts", "people"]
     assert materialized["people"]["scopatz"]["name"] == "A. Scopatz"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        # Test that routing a document operation asks no server which
+        # databases exist.  MongoClient.keys is list_database_names, a round
+        # trip, and the rc already says which backend each database has.
+        # C1: reading one document by id
+        lambda client: client.find_one("first", "people", {"_id": "scopatz"}),
+        # C2: inserting a document
+        lambda client: client.insert_one("first", "people", {"_id": "new", "name": "New"}),
+        # C3: updating a document
+        lambda client: client.update_one("first", "people", {"_id": "scopatz"}, {"name": "A"}),
+        # C4: deleting a document
+        lambda client: client.delete_one("first", "people", {"_id": "scopatz"}),
+    ],
+)
+def test_routing_an_operation_does_not_ask_which_databases_exist(operation, two_fs_dbs, mocker):
+    keys = mocker.patch.object(FileSystemClient, "keys", autospec=True, side_effect=FileSystemClient.keys)
+    operation(two_fs_dbs)
+    assert keys.call_count == 0
+
+
+def test_an_operation_on_an_unknown_database_is_a_no_op(two_fs_dbs):
+    # Test that naming a database the rc does not have is ignored rather than
+    # raising, which is how the old routing behaved
+    assert two_fs_dbs.find_one("nonexistent", "people", {"_id": "scopatz"}) is None
+    two_fs_dbs.insert_one("nonexistent", "people", {"_id": "new"})
+    assert two_fs_dbs.get("people", "new") is None


### PR DESCRIPTION
client_manager.py: insert_one, insert_many, delete_one, find_one and update_one each decided which client backed a database by asking every client whether it held it.  For the mongo backend that question is list_database_names, a network round trip, paid once per operation even though the rc already records which backend each database has.

They now look the database up in rc.databases and take the client for its backend, which costs nothing.  A find followed by an update, which is what u_todo and f_todo do, goes from five round trips to three.

Naming a database the rc does not have is still a no-op rather than an error, which is how the old routing behaved.

tests/test_client_manager.py: the new cases assert that no operation calls keys.  Verified to fail against the old routing.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64