### PR TITLE
perf: write only the task u_todo changed, not the whole list

### DIFF
--- a/news/update-one-todo-in-place.rst
+++ b/news/update-one-todo-in-place.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* ``update_field`` on the database clients, which sets one field of one document
+  and leaves the rest of it alone.  The field is named by a path, so
+  ``"todos.3"`` is the fourth entry of the ``todos`` list.
+
+**Changed:**
+
+* ``u_todo`` sets the one task it changed rather than writing the whole task
+  list back.  Against a mongo database the whole list was sent every time, and
+  it was the largest single cost of the update: 1.4 s of a 6.4 s run on a
+  production database.  Renumbering with ``-r`` still writes the list, since it
+  changes every entry.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/client_manager.py
+++ b/src/regolith/client_manager.py
@@ -374,6 +374,33 @@ class ClientManager:
         if client is not None:
             return client.find_one(dbname, collname, filter)
 
+    def update_field(self, dbname, collname, _id, path, value):
+        """Set one field of one document, leaving the rest of it alone.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection holding the document.
+        _id : str
+            The id of the document.
+        path : str
+            The field to set, with ``.`` separating the steps into nested
+            documents and lists.
+        value : object
+            The value to set it to.
+
+        Returns
+        -------
+        bool
+            Whether a document was found and set.
+        """
+        client = self._client_for_dbname(dbname)
+        if client is None:
+            return False
+        return client.update_field(dbname, collname, _id, path, value)
+
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""
         client = self._client_for_dbname(dbname)

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -504,6 +504,50 @@ class FileSystemClient:
         for doc in self.find(dbname, collname, filter):
             return doc
 
+    def update_field(self, dbname, collname, _id, path, value):
+        """Set one field of one document, leaving the rest of it alone.
+
+        The path names the field, with ``.`` separating the steps into
+        nested documents and lists, so ``"todos.3"`` is the fourth entry
+        of the ``todos`` list.  A collection lives in one file here, so
+        this is no cheaper than replacing the whole document; it exists
+        because on the mongo backend it is, and both clients have to
+        offer the same operation.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection holding the document.
+        _id : str
+            The id of the document.
+        path : str
+            The field to set.
+        value : object
+            The value to set it to.
+
+        Returns
+        -------
+        bool
+            Whether a document was found and set.
+        """
+        self.load_collection(dbname, collname, round_trip=True)
+        doc = self.dbs[dbname][collname].get(_id)
+        if doc is None:
+            return False
+        steps = path.split(".")
+        target = doc
+        for step in steps[:-1]:
+            target = target[int(step)] if isinstance(target, list) else target[step]
+        last = steps[-1]
+        if isinstance(target, list):
+            target[int(last)] = value
+        else:
+            target[last] = value
+        self.mark_dirty(dbname, collname)
+        return True
+
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""
         self.load_collection(dbname, collname, round_trip=True)

--- a/src/regolith/helpers/u_todohelper.py
+++ b/src/regolith/helpers/u_todohelper.py
@@ -303,12 +303,16 @@ class TodoUpdaterHelper(DbHelperBase):
                         for i, todo_u in enumerate(todolist_update):
                             if rc.index == todo_u.get("running_index"):
                                 todolist_update[i] = todo
-                                rc.client.update_one(
+                                # Only this one task changed, so set it on its
+                                # own rather than writing the whole list back.
+                                # On a remote database the list can be large
+                                # and it is the bulk of what the update costs.
+                                rc.client.update_field(
                                     db_name,
                                     rc.coll,
-                                    {"_id": rc.assigned_to},
-                                    {"todos": todolist_update},
-                                    upsert=True,
+                                    rc.assigned_to,
+                                    f"todos.{i}",
+                                    todo,
                                 )
                                 print(
                                     f"The task \"({todo_u['running_index']}) {todo_u['description'].strip()}\" in "

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -675,6 +675,39 @@ class MongoClient:
         doc = coll.find_one(filter)
         return doc
 
+    def update_field(self, dbname, collname, _id, path, value):
+        """Set one field of one document, leaving the rest of it alone.
+
+        Only the field crosses the network, where replacing the document
+        would send all of it.  Updating one entry of a long list is the
+        case this exists for.
+
+        Nothing is validated against the schema, because validating means
+        reading the document back, which is the cost this avoids.  Use
+        ``update_one`` where the whole document should be checked.
+
+        Parameters
+        ----------
+        dbname : str
+            The name of the database holding the collection.
+        collname : str
+            The name of the collection holding the document.
+        _id : str
+            The id of the document.
+        path : str
+            The field to set, with ``.`` separating the steps into nested
+            documents and lists.
+        value : object
+            The value to set it to.
+
+        Returns
+        -------
+        bool
+            Whether a document was found and set.
+        """
+        result = self.client[dbname][collname].update_one({"_id": _id}, {"$set": {path: value}})
+        return result.matched_count > 0
+
     def update_one(self, dbname, collname, filter, update, **kwargs):
         """Updates one document."""
         from regolith.tools import validate_doc

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -294,3 +294,53 @@ def test_writing_after_a_fast_read_keeps_the_file_formatting(fs_db):
     after = (dbpath / "people.yaml").read_text()
     assert before.rstrip("\n") in after or "Anthony Scopatz" in after
     assert "Simon Billinge" in after
+
+
+@pytest.mark.parametrize(
+    "path, value, expected",
+    [
+        # Test setting one field of a document by its path
+        # C1: a top level field, expect only it to change
+        ("name", "Renamed", {"_id": "scopatz", "name": "Renamed"}),
+        # C2: a field that the document does not have yet, expect it added
+        ("position", "prof", {"_id": "scopatz", "name": "Anthony Scopatz", "position": "prof"}),
+    ],
+)
+def test_update_field_sets_one_field(path, value, expected, fs_db):
+    client, db, dbpath = fs_db
+    assert client.update_field("test", "people", "scopatz", path, value) is True
+    assert client.get("test", "people", "scopatz") == expected
+
+
+def test_update_field_reaches_into_a_list(fs_db):
+    # Test the case this exists for: replacing one entry of a list without
+    # rewriting the others
+    client, db, dbpath = fs_db
+    client.insert_one("test", "people", {"_id": "me", "todos": [{"i": 0}, {"i": 1}, {"i": 2}]})
+    assert client.update_field("test", "people", "me", "todos.1", {"i": "replaced"}) is True
+    assert client.get("test", "people", "me")["todos"] == [{"i": 0}, {"i": "replaced"}, {"i": 2}]
+
+
+@pytest.mark.parametrize(
+    "dbname, _id",
+    [
+        # Test that setting a field of something that is not there says so
+        # rather than raising
+        # C1: an id no document has, expect False
+        ("test", "nobody"),
+        # C2: a database the client does not back, expect False
+        ("nonexistent", "scopatz"),
+    ],
+)
+def test_update_field_reports_a_miss(dbname, _id, fs_db):
+    client, db, dbpath = fs_db
+    assert client.update_field(dbname, "people", _id, "name", "x") is False
+
+
+def test_update_field_marks_the_collection_dirty(fs_db):
+    # Test that the change is written out, since a field set is a write like
+    # any other
+    client, db, dbpath = fs_db
+    client.update_field("test", "people", "scopatz", "name", "Renamed")
+    assert client.is_dirty("test", "people") is True
+    assert client.dump_database(db) == [str(Path("db") / "people.yaml")]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1768,3 +1768,22 @@ def test_a_todo_reads_only_what_it_searches(extra_args, expected_reads, make_db,
         pass
     read = {call.args[1] for call in read_all.call_args_list}
     assert read == expected_reads
+
+
+def test_u_todo_writes_only_the_task_it_changed(make_db, mocker):
+    # Test that updating one task sets that task on its own rather than
+    # writing the whole list back.  On a remote database the list is the bulk
+    # of what the update sends.
+    repo = make_db
+    os.chdir(repo)
+    update_field = mocker.patch.object(
+        ClientManager, "update_field", autospec=True, side_effect=ClientManager.update_field
+    )
+    update_one = mocker.patch.object(
+        ClientManager, "update_one", autospec=True, side_effect=ClientManager.update_one
+    )
+    main(["helper", "u_todo", "-i", "1", "-t", "sbillinge", "--notes", "a note"])
+    paths = [call.args[4] for call in update_field.call_args_list]
+    assert paths and all(p.startswith("todos.") for p in paths)
+    written_whole = [c for c in update_one.call_args_list if "todos" in (c.args[4] or {})]
+    assert written_whole == [], "the whole todos list was written back"

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -1,6 +1,7 @@
 """Tests for the mongo backed client that do not need a live mongod."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -22,6 +23,11 @@ class FakePymongoCollection:
             if all(doc.get(key) == value for key, value in filter.items()):
                 return doc
         return None
+
+    def update_one(self, filter, update):
+        self.queries.append(("update_one", filter, update))
+        matched = sum(1 for doc in self._docs if all(doc.get(k) == v for k, v in filter.items()))
+        return SimpleNamespace(matched_count=matched)
 
     def find(self, filter=None):
         self.queries.append(("find", filter))
@@ -123,3 +129,35 @@ def test_find_sends_the_filter_to_the_server(filter, expected_ids, expected_quer
     client, queries = _client_with({"people": PEOPLE_DOCS})
     assert [doc["_id"] for doc in client.find("test", "people", filter)] == expected_ids
     assert queries == [("find", expected_query)]
+
+
+@pytest.mark.parametrize(
+    "path, value, expected_found",
+    [
+        # Test that setting one field sends only that field to the server,
+        # where replacing the document would send all of it
+        # C1: one entry of a list, which is the case this exists for
+        ("todos.3", {"description": "changed"}, True),
+        # C2: a top level field
+        ("name", "Renamed", True),
+    ],
+)
+def test_update_field_sends_only_that_field(path, value, expected_found):
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    assert client.update_field("test", "people", "scopatz", path, value) is expected_found
+    assert queries == [("update_one", {"_id": "scopatz"}, {"$set": {path: value}})]
+
+
+def test_update_field_does_not_read_the_document_first():
+    # Test that no find is issued.  update_one reads the document back in
+    # order to validate it, which is the round trip this avoids.
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    client.update_field("test", "people", "scopatz", "todos.3", {"description": "changed"})
+    assert not any(q[0].startswith("find") for q in queries)
+
+
+def test_update_field_reports_a_miss():
+    # Test that setting a field of a document the server does not have says
+    # so rather than raising
+    client, _ = _client_with({"people": PEOPLE_DOCS})
+    assert client.update_field("test", "people", "nobody", "name", "x") is False


### PR DESCRIPTION
u_todohelper.py, client_manager.py, fsclient.py, mongoclient.py: updating one task replaced the entire todos list of the person it belonged to.  On a mongo database the whole list goes over the network for a change to one entry of it, and a trace of a production run showed findAndModify at 1.418 seconds of a 6.430 second command, the largest single cost in it.

The clients gain update_field, which sets one field of one document.  The field is named by a path, so "todos.3" is the fourth entry of the list. Mongo sends one $set with only that entry; the filesystem client applies the path in memory, where it is no cheaper but has to behave the same.

update_field validates nothing on the mongo backend, because validating means reading the document back and that is the round trip being avoided. update_one still validates, and is still what to use when the whole document should be checked.

Renumbering with -r keeps writing the whole list, since it changes every entry and the narrow write would buy nothing.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64