### PR TITLE
perf: write only the task f_todo and a_todo touched

### DIFF
--- a/news/narrow-writes-for-f-todo-and-a-todo.rst
+++ b/news/narrow-writes-for-f-todo-and-a-todo.rst
@@ -1,0 +1,31 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``f_todo`` sets the one task it finished, and ``a_todo`` sets the one position
+  it appends, rather than writing the whole task list back.  ``u_todo`` already
+  did.  Against a mongo database the whole list went over the network for a
+  change to one entry of it.  A document that has no task list yet still has the
+  list written, since setting a numbered field on it would store a mapping
+  rather than a list.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``FileSystemClient.update_field`` appends when the step into a list is the
+  next free position, and pads with nulls beyond it, which is what ``$set`` does
+  on mongo.  It raised ``IndexError``, so the two backends disagreed about
+  appending.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/fsclient.py
+++ b/src/regolith/fsclient.py
@@ -523,7 +523,8 @@ class FileSystemClient:
         _id : str
             The id of the document.
         path : str
-            The field to set.
+            The field to set.  A step into a list may be the next free
+            position, which appends, as ``$set`` does on mongo.
         value : object
             The value to set it to.
 
@@ -542,7 +543,15 @@ class FileSystemClient:
             target = target[int(step)] if isinstance(target, list) else target[step]
         last = steps[-1]
         if isinstance(target, list):
-            target[int(last)] = value
+            index = int(last)
+            # Mongo's $set appends when the index is the next free one, and
+            # pads with nulls beyond it.  Match that, since a database can be
+            # backed either way and the two must agree.
+            if index >= len(target):
+                target.extend([None] * (index - len(target)))
+                target.append(value)
+            else:
+                target[index] = value
         else:
             target[last] = value
         self.mark_dirty(dbname, collname)

--- a/src/regolith/helpers/a_todohelper.py
+++ b/src/regolith/helpers/a_todohelper.py
@@ -180,6 +180,9 @@ class TodoAdderHelper(DbHelperBase):
             importance = int(rc.importance)
 
         todolist = person.get("todos", [])
+        # Whether the stored document already has a list to append to decides
+        # how the new task can be written, below
+        had_todos = len(todolist) > 0
         if not rc.deadline:
             rc.deadline = False
         todo_uuid = get_uuid()
@@ -237,7 +240,17 @@ class TodoAdderHelper(DbHelperBase):
             rc.client.update_one(rc.database, "projecta", {"_id": target_prum.get("_id")}, target_prum)
         indices = [todo.get("running_index", 0) for todo in todolist]
         todolist[-1]["running_index"] = max(indices) + 1
-        rc.client.update_one(rc.database, rc.coll, {"_id": rc.assigned_to}, {"todos": todolist}, upsert=True)
+        # Append by setting the one new position, so the tasks already stored
+        # are not sent back with it.  A document with no todos yet has no list
+        # for that to append to, and setting a numbered field on it would
+        # store a mapping rather than a list, so that case writes the list.
+        appended = False
+        if had_todos:
+            appended = rc.client.update_field(
+                rc.database, rc.coll, rc.assigned_to, f"todos.{len(todolist) - 1}", todolist[-1]
+            )
+        if not appended:
+            rc.client.update_one(rc.database, rc.coll, {"_id": rc.assigned_to}, {"todos": todolist}, upsert=True)
         print(f'The task "{rc.description}" for {rc.assigned_to} has been added in {TARGET_COLL} collection.')
 
         return

--- a/src/regolith/helpers/f_todohelper.py
+++ b/src/regolith/helpers/f_todohelper.py
@@ -161,12 +161,16 @@ class TodoFinisherHelper(DbHelperBase):
                         for i, todo_u in enumerate(todolist_update):
                             if rc.index == todo_u.get("running_index"):
                                 todolist_update[i] = todo
-                                rc.client.update_one(
+                                # Only this one task changed, so set it on
+                                # its own rather than writing the whole list
+                                # back, which is the bulk of what an update
+                                # to a remote database costs
+                                rc.client.update_field(
                                     db_name,
                                     rc.coll,
-                                    {"_id": rc.assigned_to},
-                                    {"todos": todolist_update},
-                                    upsert=True,
+                                    rc.assigned_to,
+                                    f"todos.{i}",
+                                    todo,
                                 )
                                 print(
                                     f"The task \"({todo_u['running_index']}) {todo_u['description'].strip()}\" "

--- a/tests/test_fsclient.py
+++ b/tests/test_fsclient.py
@@ -344,3 +344,23 @@ def test_update_field_marks_the_collection_dirty(fs_db):
     client.update_field("test", "people", "scopatz", "name", "Renamed")
     assert client.is_dirty("test", "people") is True
     assert client.dump_database(db) == [str(Path("db") / "people.yaml")]
+
+
+@pytest.mark.parametrize(
+    "path, value, expected_todos",
+    [
+        # Test how a step into a list behaves, which has to match what $set
+        # does on mongo since a database can be backed either way
+        # C1: an existing position, expect it replaced
+        ("todos.1", {"i": "replaced"}, [{"i": 0}, {"i": "replaced"}, {"i": 2}]),
+        # C2: the next free position, expect the value appended
+        ("todos.3", {"i": 3}, [{"i": 0}, {"i": 1}, {"i": 2}, {"i": 3}]),
+        # C3: a position past the end, expect the gap padded with nulls
+        ("todos.5", {"i": 5}, [{"i": 0}, {"i": 1}, {"i": 2}, None, None, {"i": 5}]),
+    ],
+)
+def test_update_field_steps_into_a_list_the_way_mongo_does(path, value, expected_todos, fs_db):
+    client, db, dbpath = fs_db
+    client.insert_one("test", "people", {"_id": "me", "todos": [{"i": 0}, {"i": 1}, {"i": 2}]})
+    assert client.update_field("test", "people", "me", path, value) is True
+    assert client.get("test", "people", "me")["todos"] == expected_todos

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1770,10 +1770,21 @@ def test_a_todo_reads_only_what_it_searches(extra_args, expected_reads, make_db,
     assert read == expected_reads
 
 
-def test_u_todo_writes_only_the_task_it_changed(make_db, mocker):
-    # Test that updating one task sets that task on its own rather than
-    # writing the whole list back.  On a remote database the list is the bulk
-    # of what the update sends.
+@pytest.mark.parametrize(
+    "args",
+    [
+        # Test that the todo helpers write only the task they touched rather
+        # than the whole list, which on a remote database is the bulk of what
+        # the write sends
+        # C1: finishing a task, expect only that task written
+        ["helper", "f_todo", "-i", "1", "-t", "sbillinge"],
+        # C2: updating a task, expect only that task written
+        ["helper", "u_todo", "-i", "1", "-t", "sbillinge", "--notes", "a note"],
+        # C3: adding a task, expect only the new position written
+        ["helper", "a_todo", "a new task", "6", "50", "--assigned-to", "sbillinge"],
+    ],
+)
+def test_todo_helpers_write_only_the_task_they_touched(args, make_db, mocker):
     repo = make_db
     os.chdir(repo)
     update_field = mocker.patch.object(
@@ -1782,8 +1793,8 @@ def test_u_todo_writes_only_the_task_it_changed(make_db, mocker):
     update_one = mocker.patch.object(
         ClientManager, "update_one", autospec=True, side_effect=ClientManager.update_one
     )
-    main(["helper", "u_todo", "-i", "1", "-t", "sbillinge", "--notes", "a note"])
+    main(args)
     paths = [call.args[4] for call in update_field.call_args_list]
     assert paths and all(p.startswith("todos.") for p in paths)
-    written_whole = [c for c in update_one.call_args_list if "todos" in (c.args[4] or {})]
-    assert written_whole == [], "the whole todos list was written back"
+    whole = [c for c in update_one.call_args_list if "todos" in (c.args[4] or {})]
+    assert whole == [], "the whole todos list was written back"


### PR DESCRIPTION
f_todohelper.py, a_todohelper.py: both wrote the whole task list of the person they were changing.  Against a mongo database that sends every task back to change or add one of them, and it was what kept them near seven seconds while u_todo, which was converted first, halved.

f_todo sets the one task it finished, the same shape as u_todo.  a_todo sets the one position it appends to.  Appending that way needs a list to append to: setting a numbered field on a document that has no task list yet would store a mapping rather than a list, so that case still writes the list, and so does anything else that reports no document matched.

fsclient.py: update_field raised IndexError when the step into a list was the next free position, where mongo's $set appends, and the two backends have to agree.  It now appends there, and pads with nulls past the end as mongo does.

tests/test_helpers.py: the guard covers all three helpers as cases rather than u_todo on its own.  Verified to fail for f_todo and a_todo against the old helpers, and to pass for u_todo, which was already narrow.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64