### PR TITLE
docs: gather the speedup work into one release note

### DIFF
--- a/news/a-todo-defer-collection-reads.rst
+++ b/news/a-todo-defer-collection-reads.rst
@@ -1,13 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``a_todo`` no longer reads the ``todos`` and ``projecta`` collections in full
-  before it starts.  It looks both people up by id, and only searches
-  ``projecta`` when a milestone uuid is given, so a plain add reads neither
-  collection whole.
+* <news item>
 
 **Deprecated:**
 

--- a/news/client-get-find.rst
+++ b/news/client-get-find.rst
@@ -1,11 +1,6 @@
 **Added:**
 
-* ``get(collname, _id)`` and ``find(collname, filter)`` on the database clients.
-  ``ClientManager`` asks each database for the documents it holds and chains only
-  those, so a mongo backend answers an id lookup from its index and a filtered
-  query on the server instead of returning the whole collection.  The filesystem
-  client gains the same two methods, and ``find_one`` now looks an id up rather
-  than scanning.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 

--- a/news/consolidate-speedup-news.rst
+++ b/news/consolidate-speedup-news.rst
@@ -1,0 +1,45 @@
+**Added:**
+
+* Add ``REGOLITH_LOG_LEVEL``.  Set it to ``DEBUG`` to see which collections a
+  command reads and which database each came from, which is the quickest way to
+  find out why a command is slow.
+
+**Changed:**
+
+* Speed up every command, most of all those that work with todos.  Starting up
+  no longer imports every builder and helper, and with them pandas, matplotlib
+  and pypdf, so a command pays only for the target it was asked for.  A
+  collection is read when it is first used rather than when the databases are
+  opened, only from the databases that hold it, and with a faster YAML reader
+  unless it is going to be written.  The todo helpers fetch the one person's
+  record they need by id, and write back only the task they changed, instead of
+  reading and rewriting the whole collection.  On a group database with todos on
+  MongoDB Atlas, adding a task went from 21 s to about 5 s, and listing,
+  updating and finishing one from about 9 s to under 4 s.
+* Leave the database files untouched when a command only reads them.  Every
+  command used to rewrite every collection it had loaded on the way out, and a
+  git backed database was committed and pushed after a read.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Remove the ``xonsh`` and ``rever`` dependencies.  Neither is needed to run
+  regolith, and importing ``xonsh`` alone accounted for about a third of the
+  time a command took to start.
+
+**Fixed:**
+
+* Fix ``f_todo`` and ``u_todo`` failing with ``OverflowError: math range error``
+  for a task due, or overdue, by more than about two years, and ``l_todo``
+  ordering such a task as the most urgent rather than the least.
+* Fix listing the collections of a MongoDB database, and backing one up to the
+  filesystem, both of which raised ``AttributeError`` on pymongo 4.
+* Fix ``deploy`` and ``store`` failing to report a failed ``git`` command,
+  raising ``AttributeError`` instead of the intended warning.
+
+**Security:**
+
+* <news item>

--- a/news/fast-yaml-reads.rst
+++ b/news/fast-yaml-reads.rst
@@ -1,16 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* A collection is read with ruamel's safe loader, which is around nine times
-  faster than the round trip loader regolith used for everything.  A collection
-  that is about to be written is read again with the round trip loader, so the
-  comments and formatting of the file it came from still survive being written
-  back.  Reading a 100 kB collection drops from about 0.18 s to about 0.02 s, and
-  ``regolith helper l_todo`` on a 5.7 MB database from about 1.40 s to about
-  0.52 s.
+* <news item>
 
 **Deprecated:**
 

--- a/news/fix-client-keys-before-load.rst
+++ b/news/fix-client-keys-before-load.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* No news: fixes a regression never released, summarised in consolidate-speedup-news.
 
 **Changed:**
 
@@ -16,13 +16,7 @@
 
 **Fixed:**
 
-* A write to a database none of whose collections had been read yet was dropped
-  without a word.  ``ClientManager`` asks each client whether it backs a database
-  before routing ``insert_one``, ``insert_many``, ``update_one``, ``delete_one``
-  or ``find_one`` to it, and ``FileSystemClient.keys`` named only the databases
-  it had already read a collection from.  Since collections became lazy this was
-  none of them at the point a command started.  It named a database only because
-  every helper happened to read a collection before writing.
+* <news item>
 
 **Security:**
 

--- a/news/fix-pymongo4-collection-names.rst
+++ b/news/fix-pymongo4-collection-names.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
@@ -16,11 +16,7 @@
 
 **Fixed:**
 
-* ``MongoClient.collection_names`` and ``MongoClient.dump_database`` now list
-  collections with ``list_collection_names``.  They called
-  ``Database.collection_names``, which pymongo removed in 4.0, so listing the
-  collections of a mongo database and backing one up to the filesystem both
-  raised ``AttributeError``.
+* <news item>
 
 **Security:**
 

--- a/news/fix-todo-order-overflow.rst
+++ b/news/fix-todo-order-overflow.rst
@@ -1,7 +1,6 @@
 **Added:**
 
-* ``tools.get_todo_order``, which weighs a task for sorting by how long is left
-  before it is due.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
@@ -17,16 +16,7 @@
 
 **Fixed:**
 
-* ``regolith helper f_todo`` and ``regolith helper u_todo`` no longer crash with
-  ``OverflowError: math range error`` when a task is due, or overdue, by more
-  than about two years.  All three todo helpers computed the sort weight as
-  ``1 / (1 + exp(abs(days_to_due - 0.5)))``, which overflows once the exponent
-  passes 710.  They now share ``tools.get_todo_order``, which uses the form that
-  underflows to zero instead.
-* ``regolith helper l_todo`` sorts a task that is due, or overdue, by more than
-  about two years alongside the other distant tasks.  It caught the overflow but
-  substituted infinity, which sorted such a task as the most urgent rather than
-  the least.
+* <news item>
 
 **Security:**
 

--- a/news/lazy-builder-helper-imports.rst
+++ b/news/lazy-builder-helper-imports.rst
@@ -1,19 +1,10 @@
 **Added:**
 
-* ``regolith.lazy.LazyRegistry``, a mapping that imports each entry the first
-  time it is used.  ``BUILDERS`` and ``HELPERS`` hold import paths rather than
-  classes, so a command imports only the target it was asked for.
-* ``regolith.dbpaths`` and ``regolith.common`` hold the
-  few things the database layer needed from ``regolith.tools``, so the clients no
-  longer import the rest of it.  ``regolith.tools`` re-exports them.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* Starting up no longer imports pandas, matplotlib, pypdf, habanero or the
-  google api client.  Listing every builder and helper pulled all of them in,
-  even for ``regolith --version``, which touches no database.  ``import
-  regolith.main`` drops from about 816 ms to about 90 ms, and ``regolith
-  --version`` from about 980 ms to about 280 ms.
+* <news item>
 
 **Deprecated:**
 

--- a/news/lazy-source-mapped-loading.rst
+++ b/news/lazy-source-mapped-loading.rst
@@ -1,20 +1,10 @@
 **Added:**
 
-* ``ClientManager.collection_sources`` reports which databases hold a collection,
-  and ``load_collection`` reads one collection on demand.  The clients gain
-  ``available_collections`` and ``load_collection`` alongside them.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* Collections are read when they are first asked for rather than when the
-  databases are opened.  ``open_dbs`` now builds only a source map, from one
-  directory listing per filesystem database and one ``list_collection_names``
-  per mongo database, reading no documents; ``rc.client.chained_db`` chains each
-  collection on first access.  A command that declares no ``needed_colls``, or
-  that declares more than it uses, no longer pays for the collections it never
-  touches.
-* ``dump_database(force=True)`` writes every *loaded* collection rather than
-  every collection, since unread collections cannot have been modified.
+* <news item>
 
 **Deprecated:**
 

--- a/news/narrow-writes-for-f-todo-and-a-todo.rst
+++ b/news/narrow-writes-for-f-todo-and-a-todo.rst
@@ -1,15 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``f_todo`` sets the one task it finished, and ``a_todo`` sets the one position
-  it appends, rather than writing the whole task list back.  ``u_todo`` already
-  did.  Against a mongo database the whole list went over the network for a
-  change to one entry of it.  A document that has no task list yet still has the
-  list written, since setting a numbered field on it would store a mapping
-  rather than a list.
+* <news item>
 
 **Deprecated:**
 
@@ -21,10 +16,7 @@
 
 **Fixed:**
 
-* ``FileSystemClient.update_field`` appends when the step into a list is the
-  next free position, and pads with nulls beyond it, which is what ``$set`` does
-  on mongo.  It raised ``IndexError``, so the two backends disagreed about
-  appending.
+* <news item>
 
 **Security:**
 

--- a/news/no-dump-on-read.rst
+++ b/news/no-dump-on-read.rst
@@ -1,12 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``FileSystemClient.dump_database`` and ``ClientManager.dump_database`` take a
-  ``force`` keyword that writes every loaded collection, as the pre-existing
-  behavior did.
+* <news item>
 
 **Deprecated:**
 
@@ -18,11 +16,7 @@
 
 **Fixed:**
 
-* Commands that only read the database no longer rewrite every collection file
-  on the way out.  The filesystem client now tracks which collections were
-  modified and dumps only those, so listers and builders leave the database
-  untouched and git-backed databases are no longer auto-committed and pushed
-  after a read.
+* <news item>
 
 **Security:**
 

--- a/news/quiet-collection-loading.rst
+++ b/news/quiet-collection-loading.rst
@@ -1,13 +1,10 @@
 **Added:**
 
-* ``REGOLITH_LOG_LEVEL``.  Set it to ``DEBUG`` to have regolith name each
-  collection as it is read, and from which database, which is the quickest way
-  to find out why a command is slow.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* Reading a collection no longer prints to the console.  It is logged at debug
-  level instead, so ordinary output stays readable.
+* <news item>
 
 **Deprecated:**
 

--- a/news/remove-xonsh-rever.rst
+++ b/news/remove-xonsh-rever.rst
@@ -1,12 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``regolith.database`` is a normal Python module.  It was ``database.xsh`` and
-  needed the xonsh import hook, which put it beyond the reach of black, flake8,
-  isort and docformatter because it was not valid Python.
+* <news item>
 
 **Deprecated:**
 
@@ -14,20 +12,11 @@
 
 **Removed:**
 
-* The xonsh dependency.  ``xonsh.api.subprocess`` and ``xonsh.api.os`` are
-  replaced by the standard library ``subprocess`` and ``shutil``, and
-  ``xonsh.main.setup`` no longer runs on ``import regolith``, which cuts the
-  import from about 147 ms to about 47 ms and ``regolith --version`` from about
-  1370 ms to about 980 ms.
-* The rever dependency, which was unused: there is no ``rever.xsh`` and no
-  release workflow invokes it.
+* <news item>
 
 **Fixed:**
 
-* ``deploy.py`` and ``storage.py`` can now catch a failing git command.  They
-  handle ``subprocess.CalledProcessError``, but ``xonsh.api.subprocess`` does
-  not define it, so those handlers raised ``AttributeError`` at the moment a
-  git command actually failed.
+* <news item>
 
 **Security:**
 

--- a/news/route-writes-without-a-round-trip.rst
+++ b/news/route-writes-without-a-round-trip.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
@@ -16,12 +16,7 @@
 
 **Fixed:**
 
-* Reading or writing one document no longer asks the server which databases
-  exist.  ``ClientManager`` decided which client backed a database by calling
-  ``client.keys()``, which for the mongo backend is ``list_database_names`` and
-  so a round trip, once per operation.  It now reads the backend from the rc,
-  which already records it.  A find followed by an update goes from five round
-  trips to three.
+* <news item>
 
 **Security:**
 

--- a/news/todo-helpers-get-by-id.rst
+++ b/news/todo-helpers-get-by-id.rst
@@ -1,16 +1,10 @@
 **Added:**
 
-* <news item>
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``l_todo``, ``u_todo`` and ``f_todo`` fetch the one person's document they need
-  by id instead of reading the whole ``todos`` collection and searching it.  On a
-  mongo backend that is an indexed query in place of downloading every person's
-  todos, which dominated the time these helpers took.
-* ``u_todo`` and ``f_todo`` no longer gather the ``todos`` collection into the
-  template context, which nothing read, and ``l_todo`` gathers only the two
-  collections it goes through in full.
+* <news item>
 
 **Deprecated:**
 

--- a/news/update-one-todo-in-place.rst
+++ b/news/update-one-todo-in-place.rst
@@ -1,16 +1,10 @@
 **Added:**
 
-* ``update_field`` on the database clients, which sets one field of one document
-  and leaves the rest of it alone.  The field is named by a path, so
-  ``"todos.3"`` is the fourth entry of the ``todos`` list.
+* No news: part of the performance work summarised in consolidate-speedup-news.
 
 **Changed:**
 
-* ``u_todo`` sets the one task it changed rather than writing the whole task
-  list back.  Against a mongo database the whole list was sent every time, and
-  it was the largest single cost of the update: 1.4 s of a 6.4 s run on a
-  production database.  Renumbering with ``-r`` still writes the list, since it
-  changes every entry.
+* <news item>
 
 **Deprecated:**
 


### PR DESCRIPTION
The performance work landed as fifteen pull requests, each with its own news item.  Read as a changelog that is fifteen entries about internals, most of which say nothing a user of regolith would act on.

Each of those is now "No news", and one item covers the lot: what got faster and by how much, the two dependencies that went, and the three bugs that were there before this work started.

Two of the fixes made along the way are deliberately left out.  The write that silently did nothing, and the append that raised IndexError on a filesystem database, were both introduced and fixed inside this work, so no released version had either and a changelog entry would only describe a bug nobody could have hit.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64