### PR TITLE
fix: encode dates in the value update_field writes

### DIFF
--- a/news/fix-update-field-date-encoding.rst
+++ b/news/fix-update-field-date-encoding.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* No news: fixes a bug introduced in #1320 and never released.
 
 **Changed:**
 
@@ -16,11 +16,7 @@
 
 **Fixed:**
 
-* ``f_todo``, ``u_todo`` and ``a_todo`` no longer fail against a mongo database
-  with ``bson.errors.InvalidDocument: cannot encode object: datetime.date`` when
-  the task they write carries a date.  ``update_field`` sent the value to the
-  server without the cleanup that turns a ``datetime.date`` into the iso string
-  regolith stores, which ``update_one`` has always done.
+* <news item>
 
 **Security:**
 

--- a/news/fix-update-field-date-encoding.rst
+++ b/news/fix-update-field-date-encoding.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``f_todo``, ``u_todo`` and ``a_todo`` no longer fail against a mongo database
+  with ``bson.errors.InvalidDocument: cannot encode object: datetime.date`` when
+  the task they write carries a date.  ``update_field`` sent the value to the
+  server without the cleanup that turns a ``datetime.date`` into the iso string
+  regolith stores, which ``update_one`` has always done.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/mongoclient.py
+++ b/src/regolith/mongoclient.py
@@ -705,7 +705,12 @@ class MongoClient:
         bool
             Whether a document was found and set.
         """
-        result = self.client[dbname][collname].update_one({"_id": _id}, {"$set": {path: value}})
+        # Mongo cannot encode a datetime.date, and regolith stores dates as iso
+        # strings, so the value goes through the same cleanup an update_one
+        # does.  Only the value: bson_cleanup also rewrites the periods in keys,
+        # which would turn a path like "todos.3" into "todos-3" and set a field
+        # of that name instead of the fourth entry of the list.
+        result = self.client[dbname][collname].update_one({"_id": _id}, {"$set": {path: bson_cleanup(value)}})
         return result.matched_count > 0
 
     def update_one(self, dbname, collname, filter, update, **kwargs):

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -1,5 +1,6 @@
 """Tests for the mongo backed client that do not need a live mongod."""
 
+import datetime as dt
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -161,3 +162,39 @@ def test_update_field_reports_a_miss():
     # so rather than raising
     client, _ = _client_with({"people": PEOPLE_DOCS})
     assert client.update_field("test", "people", "nobody", "name", "x") is False
+
+
+@pytest.mark.parametrize(
+    "value, expected_sent",
+    [
+        # Test that a value is encodable by the time it reaches the server.
+        # Mongo cannot encode a datetime.date, and regolith stores dates as iso
+        # strings, so update_field has to clean the value the way update_one
+        # does.
+        # C1: a task carrying a date, which is what finishing one sends
+        (
+            {"description": "a task", "end_date": dt.date(2026, 9, 6)},
+            {"description": "a task", "end_date": "2026-09-06"},
+        ),
+        # C2: a bare date
+        (dt.date(2026, 9, 6), "2026-09-06"),
+        # C3: dates nested in a list, which the recursion has to reach
+        ({"notes": [{"on": dt.date(2026, 1, 2)}]}, {"notes": [{"on": "2026-01-02"}]}),
+        # C4: a value with no dates in it, expect it sent unchanged
+        ({"description": "a task"}, {"description": "a task"}),
+    ],
+)
+def test_update_field_sends_an_encodable_value(value, expected_sent):
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    client.update_field("test", "people", "scopatz", "todos.3", value)
+    assert queries == [("update_one", {"_id": "scopatz"}, {"$set": {"todos.3": expected_sent}})]
+
+
+def test_update_field_does_not_rewrite_the_path():
+    # Test that the path survives cleaning.  bson_cleanup replaces the periods
+    # in keys, so cleaning the whole $set would turn "todos.3" into "todos-3"
+    # and set a field of that name rather than the fourth entry of the list.
+    client, queries = _client_with({"people": PEOPLE_DOCS})
+    client.update_field("test", "people", "scopatz", "todos.3", {"end_date": dt.date(2026, 9, 6)})
+    ((_, _, update),) = queries
+    assert list(update["$set"]) == ["todos.3"]


### PR DESCRIPTION
mongoclient.py: update_field sent its value to the server as it was given, so a task carrying a datetime.date failed with bson.errors.InvalidDocument.  Mongo cannot encode a date, and regolith stores dates as iso strings, which is what bson_cleanup produces and what update_one has always applied before writing.

update_field now cleans the value the same way.  Only the value: bson_cleanup also replaces the periods in keys, so cleaning the whole $set would rewrite a path like "todos.3" to "todos-3" and set a field of that name rather than the fourth entry of the list.

Reached f_todo, u_todo and a_todo, all of which write a task through update_field, and only against the mongo backend; the filesystem backend stores dates as they are.

tests/test_mongoclient.py: the new cases cover a task carrying a date, a bare date, dates nested in a list, and a value with none, and check the path is not rewritten.  Verified to fail against the old update_field.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64