### PR TITLE
test: have the fake mongo collection encode what it is sent

### DIFF
--- a/news/fake-mongo-encodes-what-it-is-sent.rst
+++ b/news/fake-mongo-encodes-what-it-is-sent.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news: test only, it changes nothing about how regolith behaves.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
 
+import bson
 import matplotlib
 import pytest
 from pymongo import MongoClient
@@ -34,6 +35,28 @@ ALTERNATE_REGOLITH_MONGODB_NAME = "mongo_test"
 # CalledProcessError.  Either way the mongo backed tests cannot run here, so
 # the fixtures treat both the same and yield False to skip them.
 MONGO_LAUNCH_ERRORS = (CalledProcessError, FileNotFoundError)
+
+
+def assert_mongo_encodable(what, document):
+    """Fail if mongo could not be sent this document.
+
+    pymongo encodes every command before it leaves the client, so a value
+    it cannot encode raises before a server ever sees it.  A
+    ``datetime.date`` is the one that keeps catching us out: regolith
+    stores dates as iso strings and has to convert before writing.
+    Checking here means a test fails rather than a production run.
+
+    Parameters
+    ----------
+    what : str
+        What is being sent, named for the failure message.
+    document : dict
+        The document to check.
+    """
+    try:
+        bson.encode(document)
+    except Exception as exc:
+        raise AssertionError(f"mongo cannot be sent this {what}: {exc}\n  {document!r}") from exc
 
 
 def rmtree(dirname):

--- a/tests/test_mongoclient.py
+++ b/tests/test_mongoclient.py
@@ -1,11 +1,14 @@
 """Tests for the mongo backed client that do not need a live mongod."""
 
+import datetime as dt
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from regolith.mongoclient import MongoClient
+
+from .conftest import assert_mongo_encodable
 
 
 class FakePymongoCollection:
@@ -18,6 +21,7 @@ class FakePymongoCollection:
         self.queries = queries
 
     def find_one(self, filter):
+        assert_mongo_encodable("filter", filter)
         self.queries.append(("find_one", filter))
         for doc in self._docs:
             if all(doc.get(key) == value for key, value in filter.items()):
@@ -25,11 +29,14 @@ class FakePymongoCollection:
         return None
 
     def update_one(self, filter, update):
+        assert_mongo_encodable("filter", filter)
+        assert_mongo_encodable("update", update)
         self.queries.append(("update_one", filter, update))
         matched = sum(1 for doc in self._docs if all(doc.get(k) == v for k, v in filter.items()))
         return SimpleNamespace(matched_count=matched)
 
     def find(self, filter=None):
+        assert_mongo_encodable("filter", filter or {})
         self.queries.append(("find", filter))
         for doc in self._docs:
             if all(doc.get(key) == value for key, value in (filter or {}).items()):
@@ -161,3 +168,12 @@ def test_update_field_reports_a_miss():
     # so rather than raising
     client, _ = _client_with({"people": PEOPLE_DOCS})
     assert client.update_field("test", "people", "nobody", "name", "x") is False
+
+
+def test_the_fake_collection_refuses_what_mongo_would_refuse():
+    # Test the guard itself.  A test that sends an unencodable value must fail
+    # here rather than passing and failing against a real server, which is how
+    # the datetime.date bug in update_field reached production.
+    client, _ = _client_with({"people": PEOPLE_DOCS})
+    with pytest.raises(AssertionError, match="mongo cannot be sent this update"):
+        client.client["test"]["people"].update_one({"_id": "scopatz"}, {"$set": {"end_date": dt.date(2026, 9, 6)}})


### PR DESCRIPTION
tests/conftest.py, tests/test_mongoclient.py: the fake collection recorded the calls made to it but never encoded them, so a test could pass while sending a document mongo would refuse.  That is how the datetime.date in update_field got past a green suite and failed against atlas, and it is the second mongo only defect to do so.

The fake now runs bson.encode over every filter and update it is handed, through assert_mongo_encodable in conftest, which reports what could not be sent and shows the document.  A test that writes an unencodable value fails where it is written rather than in production.

conftest holds the helper so the mission control work can use it on the document shapes it will be writing.

Verified against the unfixed update_field: a plain test that writes a task carrying an end_date, and says nothing about encoding, now fails with the offending document named.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64