### PR TITLE
feat: read a mission control document back

### DIFF
--- a/news/mission-control-parser.rst
+++ b/news/mission-control-parser.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -273,6 +273,8 @@ class MissionControlBuilder(BuilderBase):
             lines.append(f"{n}. **{project['name']}**  ^{project['_id']}")
             if project.get("project_deliverable"):
                 lines.append(f"   deliverable: {project['project_deliverable']}")
+            if project.get("collaborators"):
+                lines.append(f"   with: {', '.join(project['collaborators'])}")
         lines.append("")
         return lines
 

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -385,7 +385,7 @@ class MissionControlBuilder(BuilderBase):
             lines += [f"### Goals — {period}", ""]
             for goal in shown:
                 lines.append(
-                    f"- {goal_number[goal['_id']]}  {struck(goal['text'], goal['status'])}  "
+                    f"- {goal_number[goal['_id']]}  {self.archived_text(goal, period)}  "
                     f"^{goal['_id']}{self.outcome(goal, period)}"
                 )
             lines.append("")
@@ -408,6 +408,17 @@ class MissionControlBuilder(BuilderBase):
         if goal["first_period"] != goal["period"]:
             return f"  (carried since {goal['first_period']})"
         return ""
+
+    @staticmethod
+    def archived_text(goal, period):
+        """Return a goal's text as the archive should show it.
+
+        A period is over, so anything that left it is struck through:
+        what finished in it, and what rolled out of it, both being done
+        with as far as that period is concerned.
+        """
+        done = goal["status"] == "finished" or goal["period"] != period
+        return struck(goal["text"], "finished" if done else goal["status"])
 
     @staticmethod
     def outcome(goal, period):

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -12,6 +12,10 @@ UPDATER_HELPER_SPECS = {
         "regolith.helpers.a_expensehelper:ExpenseAdderHelper",
         "regolith.helpers.a_expensehelper:subparser",
     ),
+    "a_mcproject": (
+        "regolith.helpers.a_mcprojecthelper:MCProjectAdderHelper",
+        "regolith.helpers.a_mcprojecthelper:subparser",
+    ),
     "a_grppub_readlist": (
         "regolith.helpers.a_grppub_readlisthelper:GrpPubReadListAdderHelper",
         "regolith.helpers.a_grppub_readlisthelper:subparser",

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -1,0 +1,134 @@
+"""Add a project to mission control.
+
+Typing a project into a document creates it just as well, and for
+anything wordy that is the easier way.  This is for the moment in a
+conversation when a project is mentioned and writing it down should cost
+nothing: name it, say who leads it if anybody does yet, and carry on.
+
+Creating cannot conflict with a document, because a new project is in no
+document until the next render puts it in one.  Everything the document
+carries is read back from it, so it stays the place to say what a
+project is called or who is on it; this is the place to record what the
+document never shows, such as which grant pays for it.
+"""
+
+import datetime as dt
+
+from gooey import GooeyParser
+
+from regolith.fsclient import _id_key
+from regolith.helpers.basehelper import DbHelperBase
+from regolith.mc import short_id
+from regolith.schemas import MC_STATI
+from regolith.tools import all_docs_from_collection
+
+TARGET_COLL = "mc_projects"
+HELPER_TARGET = "a_mcproject"
+
+
+def slug(text):
+    """Return a name as an id someone would be willing to type.
+
+    Parameters
+    ----------
+    text : str
+        The name of the project.
+
+    Returns
+    -------
+    str
+        The name in lower case with anything but letters, numbers and
+        hyphens replaced by a hyphen.
+    """
+    kept = [c if (c.isalnum() or c == "-") else "-" for c in text.lower()]
+    return "-".join(part for part in "".join(kept).split("-") if part)
+
+
+def subparser(subpi):
+    date_kwargs = {}
+    if isinstance(subpi, GooeyParser):
+        date_kwargs["widget"] = "DateChooser"
+
+    subpi.add_argument("name", help="A name for the project.")
+    subpi.add_argument(
+        "-l",
+        "--lead",
+        help="The id of the person leading it.  Without one the project is "
+        "unassigned, and is written to the unassigned document until somebody "
+        "moves it into theirs.",
+    )
+    subpi.add_argument(
+        "-w",
+        "--with",
+        dest="collaborators",
+        nargs="+",
+        help="The ids of the people on it, group members and others alike.",
+    )
+    subpi.add_argument("-g", "--grants", nargs="+", help="The ids of the grants that pay for it.")
+    subpi.add_argument("--pi", dest="pi_id", help="The id of the principal investigator.")
+    subpi.add_argument("-d", "--deliverable", help="What the project produces, e.g. submit the paper.")
+    subpi.add_argument("--description", help="What the project is, for the project report.")
+    subpi.add_argument(
+        "-s",
+        "--status",
+        default="proposed",
+        help=f"The status of the project.  One of {MC_STATI}.  Default is proposed.",
+    )
+    subpi.add_argument(
+        "--begin-date",
+        help="The date the project began.  Default is today.",
+        **date_kwargs,
+    )
+    subpi.add_argument("--id", dest="_id", help="An id for it.  Default is made from the name.")
+    subpi.add_argument("--database", help="The database to write to.")
+    return subpi
+
+
+class MCProjectAdderHelper(DbHelperBase):
+    """Add a project to mission control."""
+
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        rc = self.rc
+        rc.coll = f"{TARGET_COLL}"
+        if not rc.database:
+            rc.database = rc.databases[0]["name"]
+        self.gtx[rc.coll] = sorted(all_docs_from_collection(rc.client, rc.coll), key=_id_key)
+
+    def db_updater(self):
+        rc = self.rc
+        taken = {project["_id"] for project in self.gtx[rc.coll]}
+        _id = rc._id or slug(rc.name) or short_id(taken)
+        if _id in taken:
+            raise ValueError(
+                f"There is already a project called {_id}. Give it another name, or "
+                f"pass --id with an id of your own."
+            )
+        if rc.status not in MC_STATI:
+            raise ValueError(f"The status should be one of {MC_STATI}. Please pick one of those.")
+
+        project = {
+            "_id": _id,
+            "name": rc.name,
+            "status": rc.status,
+            "begin_date": rc.begin_date or dt.date.today(),
+        }
+        for key, value in [
+            ("lead", rc.lead),
+            ("collaborators", rc.collaborators),
+            ("grants", rc.grants),
+            ("pi_id", rc.pi_id),
+            ("project_deliverable", rc.deliverable),
+            ("project_description", rc.description),
+        ]:
+            if value:
+                project[key] = value
+        rc.client.insert_one(rc.database, rc.coll, project)
+
+        whose = f"to {rc.lead}" if rc.lead else "unassigned"
+        print(f'The project "{rc.name}" has been added {whose} as {_id}.')
+        return

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -4,6 +4,8 @@ Kept apart from ``regolith.tools`` so that reading or writing a mission
 control document does not import the rest of it.
 """
 
+import datetime as dt
+import re
 import secrets
 
 # Lowercase base32 without the characters that are read for one another, so
@@ -59,3 +61,247 @@ def struck(text, status):
         The text, struck through when it is finished.
     """
     return f"~~{text}~~" if status == "finished" else text
+
+
+class DocumentError(ValueError):
+    """Raised when a mission control document cannot be read.
+
+    Carries the line it gave up on, so a person can be told where to
+    look rather than that their file is bad.
+    """
+
+
+HEADING = re.compile(r"^(#+)\s+(.*?)\s*$")
+PROJECT_LINE = re.compile(r"^(\d+)\.\s+\*\*(?P<text>.*?)\*\*\s*(?:\^(?P<id>[\w.-]+))?\s*$")
+DELIVERABLE_LINE = re.compile(r"^\s+deliverable:\s*(?P<text>.*?)\s*$")
+GOAL_LINE = re.compile(
+    r"^-\s+(?P<number>[\d.]+)?\s*(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?\s*(?:\((?P<note>.*)\))?\s*$"
+)
+TASK_LINE = re.compile(
+    r"^(?P<indent>\s*)-\s+\[(?P<box>[ xX])\]\s+(?P<number>[\d.]+)?\s*"
+    r"(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?\s*$"
+)
+STRUCK = re.compile(r"^~~(?P<text>.*)~~$")
+GOALS_HEADING = re.compile(r"^Goals\s+—\s+(?P<period>\S+)$")
+WEEK_HEADING = re.compile(r"^Week of\s+(?P<monday>\d{4}-\d{2}-\d{2})$")
+
+
+def read_text(raw):
+    """Return the text of a line and what its marks say about its
+    status.
+
+    A finished line is struck through, and a task is also ticked.  When
+    the two disagree the strike is believed: the box is what gets
+    forgotten.
+
+    Parameters
+    ----------
+    raw : str
+        The text as written, possibly struck through.
+
+    Returns
+    -------
+    tuple of (str, bool)
+        The text without its marks, and whether it is struck.
+    """
+    struck_out = STRUCK.match(raw)
+    return (struck_out.group("text").strip(), True) if struck_out else (raw.strip(), False)
+
+
+def parse_document(text, taken=()):
+    """Return the projects, goals and tasks a mission control document
+    describes.
+
+    The document is what people type into, so it is read forgivingly: a
+    line that is not one of the shapes below is left alone rather than
+    treated as an error.  What it does insist on is that the shapes it
+    does recognise make sense, since a task under no goal, or a goal
+    under no project, cannot be stored.
+
+    A line with no ``^id`` is something somebody typed, and is given one.
+    Ids are the only thing here that is not the person's to write, so
+    they are minted rather than demanded.
+
+    Parameters
+    ----------
+    text : str
+        The document.
+    taken : iterable of str, optional
+        Ids in use elsewhere, so a newly minted one does not collide with
+        another person's document.
+
+    Returns
+    -------
+    dict
+        ``person``, and ``projects``, ``goals`` and ``tasks`` as lists of
+        records in the order the document put them.
+
+    Raises
+    ------
+    DocumentError
+        When a recognised line cannot be placed, naming the line.
+    """
+    ids = set(taken) | set(re.findall(r"\^([\w.-]+)", text))
+    state = _Reader(ids)
+    for number, line in enumerate(text.splitlines(), start=1):
+        state.read(line, number)
+    return state.result()
+
+
+class _Reader:
+    """Reads a document a line at a time, holding where it has got
+    to."""
+
+    def __init__(self, ids):
+        self.ids = set(ids)
+        self.person = None
+        self.projects = []
+        self.goals = []
+        self.tasks = []
+        self.section = None
+        self.period = None
+        self.monday = None
+        self.by_number = {}
+        self.stack = []
+
+    def mint(self):
+        _id = short_id(self.ids)
+        self.ids.add(_id)
+        return _id
+
+    def read(self, line, number):
+        """Take one line of the document."""
+        heading = HEADING.match(line)
+        if heading:
+            self.enter(heading.group(1), heading.group(2))
+            return
+        if not line.strip():
+            return
+        if self.section == "projects" and self.project(line):
+            return
+        if self.section in ("goals", "backburner", "wishlist", "archive") and self.goal(line, number):
+            return
+        if self.section == "week" and self.task(line, number):
+            return
+
+    def enter(self, hashes, title):
+        """Note which section of the document we have reached."""
+        if len(hashes) == 1:
+            self.person = title.split("—")[-1].strip()
+            return
+        self.stack = []
+        goals = GOALS_HEADING.match(title)
+        week = WEEK_HEADING.match(title)
+        if title == "Projects":
+            self.section = "projects"
+        elif goals:
+            # a goals heading inside the archive is a period that has passed
+            self.section = "archive" if self.section == "archive" else "goals"
+            self.period = goals.group("period")
+        elif week:
+            self.section = "week"
+            self.monday = dt.date.fromisoformat(week.group("monday"))
+        elif title in ("Backburner", "Wishlist"):
+            self.section = title.lower()
+        elif title == "Archive":
+            self.section = "archive"
+        else:
+            self.section = None
+
+    def project(self, line):
+        """Read a line of the projects section."""
+        deliverable = DELIVERABLE_LINE.match(line)
+        if deliverable and self.projects:
+            self.projects[-1]["project_deliverable"] = deliverable.group("text")
+            return True
+        found = PROJECT_LINE.match(line)
+        if not found:
+            return False
+        text, struck_out = read_text(found.group("text"))
+        project = {
+            "_id": found.group("id") or self.mint(),
+            "name": text,
+            "status": "finished" if struck_out else "active",
+        }
+        self.projects.append(project)
+        self.by_number[found.group(1)] = project["_id"]
+        return True
+
+    def goal(self, line, number):
+        """Read a line of a goals, backburner, wishlist or archive
+        section."""
+        found = GOAL_LINE.match(line)
+        if not found or found.group("text") is None:
+            return False
+        text, struck_out = read_text(found.group("text"))
+        if not text:
+            return False
+        goal_number = found.group("number")
+        if goal_number is None:
+            raise DocumentError(f"line {number}: a goal needs a number saying which project it is of")
+        project_number = goal_number.split(".")[0]
+        if project_number not in self.by_number:
+            raise DocumentError(f"line {number}: there is no project {project_number}")
+        # the archive says what a period was; the current sections say what is
+        _id = found.group("id") or self.mint()
+        if self.section == "archive":
+            return True
+        goal = {
+            "_id": _id,
+            "project": self.by_number[project_number],
+            "period": self.period,
+            "text": text,
+            "status": self.goal_status(struck_out),
+        }
+        self.goals.append(goal)
+        self.by_number[goal_number] = _id
+        return True
+
+    def goal_status(self, struck_out):
+        """Return the status a goal's section and marks give it."""
+        if struck_out:
+            return "finished"
+        return {"backburner": "backburner", "wishlist": "wishlist"}.get(self.section, "active")
+
+    def task(self, line, number):
+        """Read a line of a week section."""
+        found = TASK_LINE.match(line)
+        if not found:
+            return False
+        text, struck_out = read_text(found.group("text"))
+        depth = len(found.group("indent")) // 2
+        ticked = found.group("box").lower() == "x"
+        task = {
+            "_id": found.group("id") or self.mint(),
+            # a strike is believed over a box, since the box is what gets forgotten
+            "status": "finished" if (struck_out or ticked) else "active",
+            "text": text,
+            "due_date": self.monday,
+        }
+        del self.stack[depth:]
+        if depth:
+            if not self.stack:
+                raise DocumentError(f"line {number}: this is indented under nothing")
+            parent = self.stack[-1]
+            task["parent"] = parent["_id"]
+            task["goal"] = parent["goal"]
+        else:
+            task_number = found.group("number")
+            if task_number is None:
+                raise DocumentError(f"line {number}: a task needs a number saying which goal it is of")
+            goal_number = ".".join(task_number.split(".")[:-1])
+            if goal_number not in self.by_number:
+                raise DocumentError(f"line {number}: there is no goal {goal_number}")
+            task["goal"] = self.by_number[goal_number]
+        self.stack.append(task)
+        self.tasks.append(task)
+        return True
+
+    def result(self):
+        """Return what was read."""
+        return {
+            "person": self.person,
+            "projects": self.projects,
+            "goals": self.goals,
+            "tasks": self.tasks,
+        }

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -74,6 +74,7 @@ class DocumentError(ValueError):
 HEADING = re.compile(r"^(#+)\s+(.*?)\s*$")
 PROJECT_LINE = re.compile(r"^(\d+)\.\s+\*\*(?P<text>.*?)\*\*\s*(?:\^(?P<id>[\w.-]+))?\s*$")
 DELIVERABLE_LINE = re.compile(r"^\s+deliverable:\s*(?P<text>.*?)\s*$")
+WITH_LINE = re.compile(r"^\s+with:\s*(?P<people>.*?)\s*$")
 GOAL_LINE = re.compile(
     r"^-\s+(?P<number>[\d.]+)?\s*(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?\s*(?:\((?P<note>.*)\))?\s*$"
 )
@@ -213,6 +214,11 @@ class _Reader:
         deliverable = DELIVERABLE_LINE.match(line)
         if deliverable and self.projects:
             self.projects[-1]["project_deliverable"] = deliverable.group("text")
+            return True
+        with_line = WITH_LINE.match(line)
+        if with_line and self.projects:
+            people = [who.strip() for who in with_line.group("people").split(",")]
+            self.projects[-1]["collaborators"] = [who for who in people if who]
             return True
         found = PROJECT_LINE.match(line)
         if not found:

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -1,0 +1,101 @@
+"""Tests for adding a project to mission control from the command
+line."""
+
+import copy
+import os
+
+import pytest
+
+from regolith.database import connect
+from regolith.helpers.a_mcprojecthelper import slug
+from regolith.main import main
+from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
+
+
+@pytest.mark.parametrize(
+    "name, expected_id",
+    [
+        # Test the id a project name is given, since it is what gets typed and
+        # read aloud when referring to the project
+        # C1: words, expect them joined by hyphens
+        ("shock compressed WC", "shock-compressed-wc"),
+        # C2: punctuation somebody typed, expect it gone
+        ("WC/diamond: texture!", "wc-diamond-texture"),
+        # C3: hyphens already there, expect them kept and not doubled
+        ("wc-diamond  texture", "wc-diamond-texture"),
+        # C4: nothing usable, expect nothing, so a made up id is used instead
+        ("!!!", ""),
+    ],
+)
+def test_a_project_name_becomes_an_id_worth_typing(name, expected_id):
+    assert slug(name) == expected_id
+
+
+@pytest.mark.parametrize(
+    "args, expected_in_output",
+    [
+        # Test adding a project, which is the moment in a conversation when
+        # writing one down should cost nothing
+        # C1: a project nobody leads yet, expect it called unassigned
+        (["helper", "a_mcproject", "a new idea"], "unassigned"),
+        # C2: a project with a lead, expect it assigned to them
+        (["helper", "a_mcproject", "a led idea", "-l", "sbillinge"], "to sbillinge"),
+    ],
+)
+def test_adding_a_project_says_whose_it_is(args, expected_in_output, make_db, capsys):
+    os.chdir(make_db)
+    main(args)
+    assert expected_in_output in capsys.readouterr().out
+
+
+def test_a_project_is_stored_with_what_was_given(make_db):
+    # Test that what the command line carries reaches the collection, and that
+    # what it does not carry is left out rather than stored empty
+    os.chdir(make_db)
+    main(
+        [
+            "helper",
+            "a_mcproject",
+            "grain boundaries",
+            "-l",
+            "sbillinge",
+            "-w",
+            "ascopatz",
+            "afriend",
+            "-g",
+            "dmref15",
+            "--pi",
+            "sbillinge",
+            "-d",
+            "a short paper",
+            "--begin-date",
+            "2026-09-01",
+        ]
+    )
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        project = rc.client.get("mc_projects", "grain-boundaries")
+    assert project["lead"] == "sbillinge"
+    assert project["collaborators"] == ["ascopatz", "afriend"]
+    assert project["grants"] == ["dmref15"]
+    assert project["project_deliverable"] == "a short paper"
+    assert project["status"] == "proposed"
+    assert "project_description" not in project
+
+
+def test_adding_a_project_that_is_already_there_says_how_to_pick_another(make_db):
+    # Test that a clashing id is reported with what to do about it, rather
+    # than overwriting the project that is already there
+    os.chdir(make_db)
+    main(["helper", "a_mcproject", "clash test project"])
+    with pytest.raises(ValueError, match="already a project"):
+        main(["helper", "a_mcproject", "clash test project"])
+
+
+def test_a_status_that_is_not_one_of_them_lists_the_ones_that_are(make_db):
+    # Test that a status outside the vocabulary says which are allowed
+    os.chdir(make_db)
+    with pytest.raises(ValueError, match="should be one of"):
+        main(["helper", "a_mcproject", "bad status project", "-s", "nonsense"])

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -1,0 +1,187 @@
+"""Tests for reading a mission control document back."""
+
+import datetime as dt
+
+import pytest
+
+from regolith.builders.missioncontrolbuilder import MissionControlBuilder
+from regolith.mc import DocumentError, parse_document
+from tests.test_missioncontrolbuilder import GOALS, PROJECTS, SUB_TASKS, TASKS
+
+DOCUMENT = """# Mission control — Adib Kabir
+
+## Projects
+
+1. **nanodiamond-pdf**  ^ak_nano
+   deliverable: submit the paper
+
+## Goals — 2026Q3
+
+- 1.1  get clean PDFs  ^a8s8ec  (carried since 2026Q2)
+- 1.2  ~~a fitting recipe~~  ^dab3ap
+
+## Week of 2026-09-07
+
+- [ ] 1.1.1  reprocess the September data  ^66e5ty
+  - [x] ~~re-integrate the images~~  ^bfvvj6
+  - [ ] check the Qmax cutoff  ^4mynvu
+- [x] 1.2.1  talk to Simon  ^uxah3a
+
+## Backburner
+
+- 1.3  port the solver  ^gpu111
+
+## Wishlist
+
+- 1.4  a tutorial  ^tut222
+
+## Archive
+
+### Goals — 2026Q2
+
+- 1.1  ~~get clean PDFs~~  ^a8s8ec  (→ rolled to 2026Q3)
+"""
+
+
+@pytest.fixture
+def read():
+    """Return the document above, read back."""
+    return parse_document(DOCUMENT)
+
+
+def test_the_document_says_who_it_is_for(read):
+    # Test that the heading names the person, since the file is theirs
+    assert read["person"] == "Adib Kabir"
+
+
+@pytest.mark.parametrize(
+    "kind, expected_ids",
+    [
+        # Test what is read out of each part of the document
+        # C1: the projects, in the order they are written
+        ("projects", ["ak_nano"]),
+        # C2: the goals of the current period, the backburner and the wishlist,
+        # but not the archive, which only says what a past period was
+        ("goals", ["a8s8ec", "dab3ap", "gpu111", "tut222"]),
+        # C3: the tasks, including the ones nested under another
+        ("tasks", ["66e5ty", "bfvvj6", "4mynvu", "uxah3a"]),
+    ],
+)
+def test_each_part_of_the_document_is_read(kind, expected_ids, read):
+    assert [item["_id"] for item in read[kind]] == expected_ids
+
+
+@pytest.mark.parametrize(
+    "_id, expected_status",
+    [
+        # Test what a line's marks and its section say about its status
+        # C1: a goal written plainly in the current period, expect active
+        ("a8s8ec", "active"),
+        # C2: a goal struck through, expect finished
+        ("dab3ap", "finished"),
+        # C3: a goal under the backburner heading, expect backburner
+        ("gpu111", "backburner"),
+        # C4: a goal under the wishlist heading, expect wishlist
+        ("tut222", "wishlist"),
+    ],
+)
+def test_a_goal_takes_its_status_from_its_marks_and_its_section(_id, expected_status, read):
+    goal = next(g for g in read["goals"] if g["_id"] == _id)
+    assert goal["status"] == expected_status
+
+
+@pytest.mark.parametrize(
+    "line, expected_status",
+    [
+        # Test the two ways a task is marked off, and what happens when they
+        # disagree.  The strike is believed, since the box is what gets
+        # forgotten.
+        # C1: ticked and struck, expect finished
+        ("- [x] 1.1.1  ~~done~~  ^aaa111", "finished"),
+        # C2: struck but not ticked, expect finished
+        ("- [ ] 1.1.1  ~~done~~  ^aaa111", "finished"),
+        # C3: ticked but not struck, expect finished
+        ("- [x] 1.1.1  done  ^aaa111", "finished"),
+        # C4: neither, expect still going
+        ("- [ ] 1.1.1  not done  ^aaa111", "active"),
+    ],
+)
+def test_a_strike_finishes_a_task_even_without_the_box(line, expected_status):
+    text = "## Projects\n\n1. **p**  ^p1\n\n## Goals — 2026Q3\n\n- 1.1  g  ^g1\n\n## Week of 2026-09-07\n\n" + line
+    assert parse_document(text)["tasks"][0]["status"] == expected_status
+
+
+def test_a_task_belongs_to_the_task_it_is_written_under(read):
+    # Test that indentation is what says a task is a sub task, and that it
+    # inherits the goal of the task above it
+    by_id = {t["_id"]: t for t in read["tasks"]}
+    assert by_id["bfvvj6"]["parent"] == "66e5ty"
+    assert by_id["4mynvu"]["parent"] == "66e5ty"
+    assert by_id["bfvvj6"]["goal"] == by_id["66e5ty"]["goal"]
+    assert "parent" not in by_id["66e5ty"]
+
+
+def test_a_task_is_due_in_the_week_it_is_written_under(read):
+    # Test that moving a task between week headings is what moves its due date
+    assert all(t["due_date"] == dt.date(2026, 9, 7) for t in read["tasks"])
+
+
+def test_something_typed_without_an_id_is_given_one(read):
+    # Test that a person can type a new line and have it become a record.  Ids
+    # are the one thing here that is not theirs to write.
+    text = DOCUMENT.replace("- 1.2  ~~a fitting recipe~~  ^dab3ap", "- 1.2  a brand new goal")
+    goals = parse_document(text)["goals"]
+    new = next(g for g in goals if g["text"] == "a brand new goal")
+    assert new["_id"] and new["_id"] not in DOCUMENT
+
+
+@pytest.mark.parametrize(
+    "line, expected_message",
+    [
+        # Test that a line which cannot be placed says so, naming the line,
+        # rather than being stored somewhere wrong
+        # C1: a task under no goal that exists
+        ("- [ ] 9.9.9  orphan task  ^zzz999", "there is no goal 9.9"),
+        # C2: a task indented under nothing
+        ("  - [ ] orphan sub task  ^zzz999", "indented under nothing"),
+        # C3: a task with no number at the top level
+        ("- [ ] no number  ^zzz999", "needs a number"),
+    ],
+)
+def test_a_line_that_cannot_be_placed_says_which(line, expected_message):
+    text = "## Projects\n\n1. **p**  ^p1\n\n## Goals — 2026Q3\n\n- 1.1  g  ^g1\n\n## Week of 2026-09-07\n\n" + line
+    with pytest.raises(DocumentError, match=expected_message):
+        parse_document(text)
+
+
+def test_prose_around_the_lines_is_left_alone():
+    # Test that a document is read forgivingly.  People will write notes to
+    # each other in it, and that must not stop it being read.
+    text = DOCUMENT.replace("## Goals — 2026Q3\n", "## Goals — 2026Q3\n\nSome note we typed in the meeting.\n")
+    assert len(parse_document(text)["goals"]) == 4
+
+
+@pytest.mark.parametrize(
+    "projects, goals, tasks",
+    [
+        # Test that what is rendered can be read back as what was rendered,
+        # which is what makes the document safe to edit
+        # C1: goals in every section, and a task under each
+        (PROJECTS, GOALS, TASKS),
+        # C2: tasks nested two deep
+        (PROJECTS, GOALS, SUB_TASKS),
+    ],
+)
+def test_a_rendered_document_reads_back_as_what_was_rendered(projects, goals, tasks):
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {"mc_projects": projects, "mc_goals": goals, "mc_tasks": tasks}
+    document = "\n".join(builder.documents()["pliu"])
+    read = parse_document(document)
+    rendered_goals = {g["_id"] for g in goals if g["period"] == "2026Q3"}
+    assert {g["_id"] for g in read["goals"]} == rendered_goals
+    assert {t["_id"] for t in read["tasks"]} == {t["_id"] for t in tasks}
+    for task in read["tasks"]:
+        original = next(t for t in tasks if t["_id"] == task["_id"])
+        assert task["text"] == original["text"]
+        assert task["status"] == original["status"]
+        assert task.get("parent") == original.get("parent")

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -185,3 +185,30 @@ def test_a_rendered_document_reads_back_as_what_was_rendered(projects, goals, ta
         assert task["text"] == original["text"]
         assert task["status"] == original["status"]
         assert task.get("parent") == original.get("parent")
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        # Test reading back who is on a project, which is written under it
+        # C1: several people, expect them separated
+        ("   with: sgeorge, akabir, seggert", ["sgeorge", "akabir", "seggert"]),
+        # C2: one person, expect a list of one
+        ("   with: sgeorge", ["sgeorge"]),
+        # C3: spacing somebody typed by hand, expect it ignored
+        ("   with:  sgeorge ,akabir ", ["sgeorge", "akabir"]),
+        # C4: a trailing comma, expect no empty person
+        ("   with: sgeorge, akabir,", ["sgeorge", "akabir"]),
+    ],
+)
+def test_who_is_on_a_project_is_read_back(line, expected):
+    text = f"## Projects\n\n1. **p**  ^p1\n{line}\n"
+    assert parse_document(text)["projects"][0]["collaborators"] == expected
+
+
+def test_a_project_read_back_keeps_its_deliverable_and_its_people():
+    # Test that the two lines under a project do not displace one another
+    text = "## Projects\n\n1. **p**  ^p1\n   deliverable: submit it\n   with: sgeorge\n"
+    project = parse_document(text)["projects"][0]
+    assert project["project_deliverable"] == "submit it"
+    assert project["collaborators"] == ["sgeorge"]

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -175,8 +175,9 @@ def test_a_goal_is_rendered_under_its_status(heading, expected_goal, documents):
         # record, since a goal that moves period is one record that moved
         # C1: in the current period, expect how long it has been carried
         "Get the fits converging  ^g-converge  (carried since 2026Q2)",
-        # C2: in the period it came from, expect where it went
-        "Get the fits converging  ^g-converge  (→ rolled to 2026Q3)",
+        # C2: in the period it came from, expect it struck through and where
+        # it went, since that period is done with it
+        "~~Get the fits converging~~  ^g-converge  (→ rolled to 2026Q3)",
         # C3: a goal that closed, expect it struck through and dated
         "~~Reproduce the 2019 result~~  ^g-repro  (finished 2026-06-30)",
     ],
@@ -377,3 +378,26 @@ def test_a_sub_task_is_not_listed_as_a_task_of_its_own(nested):
     # one of the week's tasks
     assert nested.count("^t-sub1") == 1
     assert "1.1.2" not in nested
+
+
+@pytest.mark.parametrize(
+    "expected_line",
+    [
+        # Test that the archive strikes through everything a past period is
+        # done with, which is what finished in it and what rolled out of it
+        # C1: a goal that finished in that period
+        "- 1.4  ~~Reproduce the 2019 result~~  ^g-repro  (finished 2026-06-30)",
+        # C2: a goal that rolled out of it, which that period is equally done
+        # with even though the goal itself is still going
+        "- 1.1  ~~Get the fits converging~~  ^g-converge  (→ rolled to 2026Q3)",
+    ],
+)
+def test_the_archive_strikes_through_what_left_the_period(expected_line, documents):
+    assert expected_line in documents["pliu"]
+
+
+def test_a_rolled_goal_is_not_struck_in_the_period_it_moved_to(documents):
+    # Test that striking it in the archive does not strike it where it is now,
+    # since it is still to be done
+    current = documents["pliu"].split("## Goals — 2026Q3")[1].split("\n##")[0]
+    assert "- 1.1  Get the fits converging  ^g-converge  (carried since 2026Q2)" in current

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -17,6 +17,7 @@ PROJECTS = [
         "_id": "p-pdf",
         "name": "Nanoparticle structure from the PDF",
         "project_deliverable": "Submit the paper",
+        "collaborators": ["ascopatz", "afriend"],
         "lead": "pliu",
         "status": "active",
     },
@@ -401,3 +402,16 @@ def test_a_rolled_goal_is_not_struck_in_the_period_it_moved_to(documents):
     # since it is still to be done
     current = documents["pliu"].split("## Goals — 2026Q3")[1].split("\n##")[0]
     assert "- 1.1  Get the fits converging  ^g-converge  (carried since 2026Q2)" in current
+
+
+def test_a_project_lists_who_is_on_it(documents):
+    # Test that the people on a project are written under it, as a reminder
+    # when talking about it
+    assert "   with: ascopatz, afriend" in documents["pliu"]
+
+
+def test_a_project_with_nobody_on_it_says_nothing(documents):
+    # Test that an empty list leaves the line out rather than writing a bare
+    # heading with nothing after it
+    assert "   with: \n" not in documents["unassigned"]
+    assert "with:" not in documents["unassigned"]


### PR DESCRIPTION
mc.py: parse_document turns a document into the projects, goals and tasks it describes, which is the half that makes one worth typing into.

What a line means comes from where it is written as much as from what it says.  The heading above a goal gives its period, or puts it on the backburner or the wishlist.  The week heading above a task gives its due date, so moving a task between weeks is how it rolls.  Indentation says a task belongs to the one above it, and it takes that task's goal.  A line with no id is something somebody typed, and is given one, since ids are the only thing in the document that is not theirs to write.

A struck through line is finished whether or not its box is ticked, and the strike is believed when the two disagree: the box is what gets forgotten.

Reading is forgiving of what it does not recognise, so notes typed in a meeting do not stop a document being read, and strict about what it does: a task under a goal that is not there, or indented under nothing, raises DocumentError naming the line rather than being stored somewhere wrong.

missioncontrolbuilder.py: the archive strikes through what rolled out of a period as well as what finished in it.  That period is done with both. The goal is not struck where it is now, since it is still to be done.

tests/test_mc_parser.py: among them, that a rendered document reads back as what was rendered, which is what makes one safe to edit.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64