### PR TITLE
feat: read the mission control documents back into the collections

### DIFF
--- a/news/mission-control-sync.rst
+++ b/news/mission-control-sync.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -12,6 +12,10 @@ UPDATER_HELPER_SPECS = {
         "regolith.helpers.a_expensehelper:ExpenseAdderHelper",
         "regolith.helpers.a_expensehelper:subparser",
     ),
+    "mc_sync": (
+        "regolith.helpers.mcsynchelper:MCSyncHelper",
+        "regolith.helpers.mcsynchelper:subparser",
+    ),
     "a_mcproject": (
         "regolith.helpers.a_mcprojecthelper:MCProjectAdderHelper",
         "regolith.helpers.a_mcprojecthelper:subparser",

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -1,0 +1,153 @@
+"""Read the mission control documents back into the collections.
+
+This is the half that makes a document worth typing into.  Everything
+somebody wrote in one is read back: the text, the boxes, the strikes,
+the order, which section a thing sits in and which week a task is under.
+
+Nothing is deleted.  A line somebody removed marks its record
+``dropped``, so a document wrecked by accident costs nothing that a
+render cannot put back, and a document that cannot be read at all is
+skipped whole rather than half applied.
+"""
+
+from pathlib import Path
+
+from gooey import GooeyParser
+
+from regolith.builders.missioncontrolbuilder import UNASSIGNED, MissionControlBuilder
+from regolith.helpers.basehelper import DbHelperBase
+from regolith.mc import DocumentError, changes, parse_document
+from regolith.schemas import SCHEMAS, validate
+from regolith.tools import all_docs_from_collection
+
+HELPER_TARGET = "mc_sync"
+COLLECTIONS = ("mc_projects", "mc_goals", "mc_tasks")
+# a document that has lost more than this share of what it held is more
+# likely to be damaged than edited
+DROP_SHARE = 1 / 3
+
+
+def subparser(subpi):
+    if isinstance(subpi, GooeyParser):
+        pass
+    subpi.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Apply a document even when most of what it held has gone from it.",
+    )
+    subpi.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Say what would be written without writing it.",
+    )
+    subpi.add_argument("--database", help="The database to write to.")
+    return subpi
+
+
+class MCSyncHelper(DbHelperBase):
+    """Read every mission control document back into the collections."""
+
+    btype = HELPER_TARGET
+    needed_colls = list(COLLECTIONS) + ["people"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        rc = self.rc
+        if not rc.database:
+            rc.database = rc.databases[0]["name"]
+        for collection in COLLECTIONS:
+            self.gtx[collection] = list(all_docs_from_collection(rc.client, collection))
+        self.gtx["people"] = list(all_docs_from_collection(rc.client, "people"))
+
+    def db_updater(self):
+        rc = self.rc
+        renderer = MissionControlBuilder.__new__(MissionControlBuilder)
+        renderer.gtx = self.gtx
+        mcdir = Path(getattr(rc, "mission_control_dir", None) or f"{rc.builddir}/mission-control")
+        if not mcdir.is_dir():
+            print(f"There are no mission control documents in {mcdir}.")
+            print("Run 'regolith build mission-control' to write them first.")
+            return
+
+        for person in self.people(renderer):
+            path = mcdir / f"{renderer.document_name(person)}.md"
+            if path.is_file():
+                self.read_one(path, person)
+        return
+
+    def people(self, renderer):
+        """Return everyone a document could belong to, and the
+        orphans."""
+        leads = {project.get("lead") or UNASSIGNED for project in self.gtx["mc_projects"]}
+        return sorted(leads | {UNASSIGNED})
+
+    def mine(self, person):
+        """Return the records already stored for one person.
+
+        Parameters
+        ----------
+        person : str
+            The id of the person, or ``unassigned``.
+
+        Returns
+        -------
+        dict
+            ``{collection: {id: record}}`` for what is theirs.
+        """
+        lead = None if person == UNASSIGNED else person
+        projects = {project["_id"]: project for project in self.gtx["mc_projects"] if project.get("lead") == lead}
+        goals = {goal["_id"]: goal for goal in self.gtx["mc_goals"] if goal.get("project") in projects}
+        tasks = {task["_id"]: task for task in self.gtx["mc_tasks"] if task.get("goal") in goals}
+        return {"mc_projects": projects, "mc_goals": goals, "mc_tasks": tasks}
+
+    def read_one(self, path, person):
+        """Read one document and write what it says."""
+        rc = self.rc
+        try:
+            parsed = parse_document(path.read_text(encoding="utf-8"))
+        except DocumentError as error:
+            print(f"{path.name} was not read and nothing was written from it: {error}")
+            print("Fix the line it names and run this again.")
+            return
+
+        existing = self.mine(person)
+        writes, drops = changes(parsed, None if person == UNASSIGNED else person, existing)
+        held = sum(len(records) for records in existing.values())
+        dropped = sum(len(ids) for ids in drops.values())
+        if held and dropped > held * DROP_SHARE and not rc.force:
+            print(
+                f"{path.name} no longer holds {dropped} of the {held} things it had, which "
+                f"is more like damage than editing, so nothing was written from it."
+            )
+            print("Check the document, or run this again with --force to apply it anyway.")
+            return
+
+        for collection, records in writes.items():
+            for record in records:
+                valid, why = validate(collection, record, SCHEMAS)
+                if not valid:
+                    print(f"{path.name}: {record['_id']} does not fit {collection} and was not written.")
+                    print(f"  {why}")
+                    return
+        if rc.dry_run:
+            self.report(path, writes, drops, wrote=False)
+            return
+        for collection, records in writes.items():
+            for record in records:
+                rc.client.update_one(rc.database, collection, {"_id": record["_id"]}, record, upsert=True)
+        for collection, ids in drops.items():
+            for _id in ids:
+                rc.client.update_field(rc.database, collection, _id, "status", "dropped")
+        self.report(path, writes, drops, wrote=True)
+
+    @staticmethod
+    def report(path, writes, drops, wrote):
+        """Say what was written, so a surprise is seen rather than
+        found."""
+        written = sum(len(records) for records in writes.values())
+        dropped = sum(len(ids) for ids in drops.values())
+        did = "wrote" if wrote else "would write"
+        print(f"{path.name}: {did} {written}, dropped {dropped}")

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -311,3 +311,150 @@ class _Reader:
             "goals": self.goals,
             "tasks": self.tasks,
         }
+
+
+HELD = ("backburner", "wishlist")
+OPEN = ("proposed", "active")
+
+
+def settled_status(read_status, existing_status, default="active"):
+    """Return the status a record should have after its document was
+    read.
+
+    A document does not say everything a status does.  Everything in the
+    goals section reads back as ``active``, so a goal that was
+    ``proposed`` would lose that on the first read for no reason anybody
+    intended.  What a document does say is when something is finished,
+    when it is held on the backburner or the wishlist, and when it has
+    come back from either.
+
+    Parameters
+    ----------
+    read_status : str
+        What the document said.
+    existing_status : str or None
+        What the record said, or None for something newly typed.
+    default : str, optional
+        The status for something newly typed that the document does not
+        pin down.  The default is ``active``.
+
+    Returns
+    -------
+    str
+        The status to store.
+    """
+    if read_status in ("finished",) + HELD:
+        return read_status
+    if existing_status is None:
+        return default
+    # it is in the ordinary sections, so it is not held and not finished
+    return existing_status if existing_status in OPEN else "active"
+
+
+def adopt(read, existing, claimed):
+    """Return the record a read line belongs to, matching on text if
+    need be.
+
+    The likeliest damage to a document is a lost id: a paste, an
+    autocorrect, somebody retyping a line.  Left alone that would store a
+    second copy of something that is already there and drop the first.
+    So a line whose id is not known is offered to a record with the same
+    text that nothing else has claimed.
+
+    Parameters
+    ----------
+    read : dict
+        The line as read, carrying an id the parser may have just minted.
+    existing : dict
+        The records already stored, keyed by id.
+    claimed : set
+        The ids already taken by other lines of this document.
+
+    Returns
+    -------
+    dict
+        The record it belongs to, empty for something genuinely new.
+    """
+    if read["_id"] in existing:
+        return existing[read["_id"]]
+    for _id, record in existing.items():
+        same = record.get("text") == read.get("text") and record.get("name") == read.get("name")
+        if _id not in claimed and same:
+            read["_id"] = _id
+            return record
+    return {}
+
+
+def changes(parsed, person, existing, today=None):
+    """Return the records a document says to write, and the ids to drop.
+
+    Nothing is deleted.  A line somebody removed sets the record's status
+    to ``dropped``, so a document wrecked by accident costs nothing that
+    a render cannot put back.
+
+    Parameters
+    ----------
+    parsed : dict
+        What ``parse_document`` read.
+    person : str or None
+        The id of the person whose document it is, which is what makes
+        them the lead of the projects in it.  None for the unassigned
+        document.
+    existing : dict
+        The records already stored for that person, as
+        ``{collection: {id: record}}``.
+    today : datetime.date, optional
+        The date to close things on.  The default is today.
+
+    Returns
+    -------
+    tuple of (dict, dict)
+        The records to write and the ids to drop, both as
+        ``{collection: [...]}``.
+    """
+    today = today or dt.date.today()
+    writes = {"mc_projects": [], "mc_goals": [], "mc_tasks": []}
+    seen = {"mc_projects": set(), "mc_goals": set(), "mc_tasks": set()}
+
+    for read in parsed["projects"]:
+        was = adopt(read, existing["mc_projects"], seen["mc_projects"])
+        record = dict(was)
+        record.update({k: v for k, v in read.items() if k != "status"})
+        record["status"] = settled_status(read["status"], was.get("status"), default="proposed")
+        record["lead"] = person if person else None
+        if record["lead"] is None:
+            record.pop("lead", None)
+        record.setdefault("begin_date", today)
+        _close(record, was, today)
+        writes["mc_projects"].append(record)
+        seen["mc_projects"].add(record["_id"])
+
+    for read in parsed["goals"]:
+        was = adopt(read, existing["mc_goals"], seen["mc_goals"])
+        record = dict(was)
+        record.update({k: v for k, v in read.items() if k != "status"})
+        record["status"] = settled_status(read["status"], was.get("status"))
+        # written once, so how long a goal has been carried is knowable
+        record.setdefault("first_period", read["period"])
+        _close(record, was, today)
+        writes["mc_goals"].append(record)
+        seen["mc_goals"].add(record["_id"])
+
+    for read in parsed["tasks"]:
+        was = adopt(read, existing["mc_tasks"], seen["mc_tasks"])
+        record = dict(was)
+        record.update({k: v for k, v in read.items() if k != "status"})
+        record["status"] = settled_status(read["status"], was.get("status"))
+        record.setdefault("first_due_date", read["due_date"])
+        _close(record, was, today)
+        writes["mc_tasks"].append(record)
+        seen["mc_tasks"].add(record["_id"])
+
+    drops = {collection: sorted(set(records) - seen[collection]) for collection, records in existing.items()}
+    return writes, drops
+
+
+def _close(record, was, today):
+    """Date a record that has just been finished, and only just."""
+    if record["status"] == "finished" and was.get("status") != "finished":
+        record.setdefault("end_date", today)

--- a/tests/test_mc_changes.py
+++ b/tests/test_mc_changes.py
@@ -1,0 +1,164 @@
+"""Tests for turning a read document into writes and drops."""
+
+import datetime as dt
+
+import pytest
+
+from regolith.mc import adopt, changes, settled_status
+
+TODAY = dt.date(2026, 9, 20)
+
+
+def read(**kw):
+    """Return a line as the parser hands it over."""
+    base = {"_id": "g1", "project": "p1", "period": "2026Q3", "text": "a goal", "status": "active"}
+    base.update(kw)
+    return base
+
+
+def stored(**kw):
+    """Return a record as the collection holds it."""
+    base = {
+        "_id": "g1",
+        "project": "p1",
+        "period": "2026Q3",
+        "first_period": "2026Q3",
+        "text": "a goal",
+        "status": "active",
+    }
+    base.update(kw)
+    return base
+
+
+def parsed(projects=(), goals=(), tasks=()):
+    return {"person": "p", "projects": list(projects), "goals": list(goals), "tasks": list(tasks)}
+
+
+def existing(projects=(), goals=(), tasks=()):
+    return {
+        "mc_projects": {p["_id"]: p for p in projects},
+        "mc_goals": {g["_id"]: g for g in goals},
+        "mc_tasks": {t["_id"]: t for t in tasks},
+    }
+
+
+@pytest.mark.parametrize(
+    "read_status, existing_status, expected",
+    [
+        # Test what a status becomes after a document is read.  A document does
+        # not say everything a status does, so reading one must not flatten
+        # what it cannot express.
+        # C1: written plainly, and it was proposed, expect it stays proposed
+        ("active", "proposed", "proposed"),
+        # C2: written plainly, and it was active, expect it stays active
+        ("active", "active", "active"),
+        # C3: written plainly, and it was held back, expect it has come back
+        ("active", "backburner", "active"),
+        # C4: struck through, expect finished whatever it was
+        ("finished", "proposed", "finished"),
+        # C5: written under a holding heading, expect it is held
+        ("backburner", "active", "backburner"),
+        ("wishlist", "active", "wishlist"),
+        # C6: newly typed, expect the default rather than an error
+        ("active", None, "active"),
+    ],
+)
+def test_a_status_survives_being_read(read_status, existing_status, expected):
+    assert settled_status(read_status, existing_status) == expected
+
+
+def test_something_newly_typed_is_written():
+    # Test that a line somebody typed becomes a record, which is what makes
+    # the document worth typing into
+    writes, drops = changes(
+        parsed(goals=[read(_id="new1", text="typed in the meeting")]), "pliu", existing(), today=TODAY
+    )
+    assert [g["_id"] for g in writes["mc_goals"]] == ["new1"]
+    assert writes["mc_goals"][0]["first_period"] == "2026Q3"
+    assert drops["mc_goals"] == []
+
+
+def test_a_line_taken_out_is_dropped_rather_than_deleted():
+    # Test the rule that makes a wrecked document survivable: what is gone
+    # from it is marked, not removed
+    writes, drops = changes(parsed(), "pliu", existing(goals=[stored()]), today=TODAY)
+    assert drops["mc_goals"] == ["g1"]
+    assert writes["mc_goals"] == []
+
+
+@pytest.mark.parametrize(
+    "field, first_field, first_value",
+    [
+        # Test that where something started is written once and never again,
+        # since that is what says how long it has been carried
+        # C1: a goal keeps the period it was first set in
+        ("period", "first_period", "2026Q1"),
+    ],
+)
+def test_where_something_started_is_not_rewritten(field, first_field, first_value):
+    was = stored(**{first_field: first_value})
+    writes, _ = changes(parsed(goals=[read(**{field: "2026Q3"})]), "pliu", existing(goals=[was]), today=TODAY)
+    assert writes["mc_goals"][0][first_field] == first_value
+    assert writes["mc_goals"][0][field] == "2026Q3"
+
+
+def test_finishing_something_dates_it_once():
+    # Test that closing a goal records when, and that reading the document
+    # again does not move the date
+    was = stored(status="active")
+    writes, _ = changes(parsed(goals=[read(status="finished")]), "pliu", existing(goals=[was]), today=TODAY)
+    assert writes["mc_goals"][0]["end_date"] == TODAY
+    already = writes["mc_goals"][0]
+    writes, _ = changes(
+        parsed(goals=[read(status="finished")]), "pliu", existing(goals=[already]), today=dt.date(2026, 12, 25)
+    )
+    assert writes["mc_goals"][0]["end_date"] == TODAY
+
+
+@pytest.mark.parametrize(
+    "person, expected_lead",
+    [
+        # Test that the lead is whoever's document a project is written in,
+        # which is what makes moving a block between files an assignment
+        # C1: somebody's document, expect them
+        ("pliu", "pliu"),
+        # C2: the unassigned document, expect no lead at all
+        (None, None),
+    ],
+)
+def test_the_lead_is_whose_document_it_is(person, expected_lead):
+    project = {"_id": "p1", "name": "a project", "status": "active"}
+    writes, _ = changes(parsed(projects=[project]), person, existing(), today=TODAY)
+    assert writes["mc_projects"][0].get("lead") == expected_lead
+
+
+def test_a_line_whose_id_was_lost_finds_its_record_again():
+    # Test the likeliest damage to a document: an id gone from a line that is
+    # otherwise unchanged.  It must not store a second copy and drop the first.
+    was = stored(_id="realid", text="a goal")
+    writes, drops = changes(
+        parsed(goals=[read(_id="mintedid", text="a goal")]), "pliu", existing(goals=[was]), today=TODAY
+    )
+    assert [g["_id"] for g in writes["mc_goals"]] == ["realid"]
+    assert drops["mc_goals"] == []
+
+
+def test_two_lines_that_read_the_same_do_not_take_the_same_record():
+    # Test that matching on text hands a record to one line only, so typing a
+    # second line saying the same thing makes a second record
+    was = stored(_id="realid", text="a goal")
+    writes, _ = changes(
+        parsed(goals=[read(_id="realid", text="a goal"), read(_id="other", text="a goal")]),
+        "pliu",
+        existing(goals=[was]),
+        today=TODAY,
+    )
+    assert sorted(g["_id"] for g in writes["mc_goals"]) == ["other", "realid"]
+
+
+def test_adopting_leaves_something_genuinely_new_alone():
+    # Test that text matching does not swallow a new line that happens to be
+    # near an old one
+    read_line = {"_id": "minted", "text": "something else"}
+    assert adopt(read_line, {"realid": {"_id": "realid", "text": "a goal"}}, set()) == {}
+    assert read_line["_id"] == "minted"

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -1,0 +1,202 @@
+"""Tests for reading the mission control documents back in."""
+
+import copy
+import os
+
+import pytest
+
+from regolith.database import connect
+from regolith.fsclient import dump_yaml
+from regolith.main import main
+from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
+
+DOCUMENT = """# Mission control — Pei Liu
+
+## Projects
+
+1. **a project**  ^mc-a-project
+   with: ascopatz
+
+## Goals — 2026Q3
+
+- 1.1  a goal  ^mcg001
+
+## Week of 2026-09-07
+
+- [ ] 1.1.1  a task  ^mct001
+"""
+
+
+@pytest.fixture
+def mc_repo(tmp_path):
+    """Build a database with one project, goal and task, and its
+    document."""
+    db = tmp_path / "db"
+    db.mkdir()
+    mcdir = tmp_path / "mission-control"
+    mcdir.mkdir()
+    dump_yaml(db / "people.yaml", {"pliu": {"_id": "pliu", "name": "Pei Liu"}})
+    dump_yaml(
+        db / "mc_projects.yaml",
+        {"mc-a-project": {"_id": "mc-a-project", "name": "a project", "lead": "pliu", "status": "active"}},
+    )
+    dump_yaml(
+        db / "mc_goals.yaml",
+        {
+            "mcg001": {
+                "_id": "mcg001",
+                "project": "mc-a-project",
+                "period": "2026Q3",
+                "first_period": "2026Q3",
+                "text": "a goal",
+                "status": "active",
+            }
+        },
+    )
+    dump_yaml(
+        db / "mc_tasks.yaml",
+        {
+            "mct001": {
+                "_id": "mct001",
+                "goal": "mcg001",
+                "due_date": "2026-09-07",
+                "first_due_date": "2026-09-07",
+                "text": "a task",
+                "status": "active",
+            }
+        },
+    )
+    import json
+
+    (tmp_path / "regolithrc.json").write_text(
+        json.dumps(
+            {
+                "groupname": "ERGS",
+                "default_user_id": "pliu",
+                "mission_control_dir": str(mcdir),
+                "databases": [
+                    {
+                        "name": "mc",
+                        "url": str(tmp_path),
+                        "public": False,
+                        "path": "db",
+                        "local": True,
+                        "backend": "filesystem",
+                    }
+                ],
+            }
+        )
+    )
+    (mcdir / "pei.md").write_text(DOCUMENT)
+    os.chdir(tmp_path)
+    yield tmp_path, mcdir
+
+
+def stored(where, collection, _id):
+    """Return one record straight from the collection."""
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        return rc.client.get(collection, _id)
+
+
+@pytest.mark.parametrize(
+    "edit, collection, _id, field, expected",
+    [
+        # Test that what somebody writes in a document reaches the collection
+        # C1: a task struck through, expect it finished even with an empty box
+        (
+            lambda t: t.replace("a task  ^mct001", "~~a task~~  ^mct001"),
+            "mc_tasks",
+            "mct001",
+            "status",
+            "finished",
+        ),
+        # C2: a task ticked, expect it finished
+        (lambda t: t.replace("- [ ] 1.1.1", "- [x] 1.1.1"), "mc_tasks", "mct001", "status", "finished"),
+        # C3: a goal moved under the backburner heading, expect it held
+        (
+            lambda t: t.replace(
+                "## Goals — 2026Q3\n\n- 1.1  a goal  ^mcg001\n",
+                "## Goals — 2026Q3\n\n## Backburner\n\n- 1.1  a goal  ^mcg001\n",
+            ),
+            "mc_goals",
+            "mcg001",
+            "status",
+            "backburner",
+        ),
+        # C4: the wording changed, expect the new wording
+        (
+            lambda t: t.replace("a goal  ^mcg001", "a better goal  ^mcg001"),
+            "mc_goals",
+            "mcg001",
+            "text",
+            "a better goal",
+        ),
+        # C5: somebody added to the project, expect them on it
+        (
+            lambda t: t.replace("with: ascopatz", "with: ascopatz, afriend"),
+            "mc_projects",
+            "mc-a-project",
+            "collaborators",
+            ["ascopatz", "afriend"],
+        ),
+    ],
+)
+def test_an_edit_reaches_the_collection(edit, collection, _id, field, expected, mc_repo):
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(edit(path.read_text()))
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, collection, _id)[field] == expected
+
+
+def test_a_line_taken_out_is_dropped(mc_repo):
+    # Test that removing a line marks its record rather than deleting it, so
+    # nothing is lost to a slip of the keyboard
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text().replace("- [ ] 1.1.1  a task  ^mct001\n", ""))
+    main(["helper", "mc_sync", "--force"])
+    assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "dropped"
+
+
+def test_a_document_that_lost_most_of_itself_is_left_alone(mc_repo, capsys):
+    # Test the guard against damage: a document missing most of what it held
+    # is more likely broken than edited, so nothing is written from it
+    _, mcdir = mc_repo
+    (mcdir / "pei.md").write_text("# Mission control — Pei Liu\n")
+    main(["helper", "mc_sync"])
+    assert "more like damage than editing" in capsys.readouterr().out
+    assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "active"
+
+
+def test_a_document_that_cannot_be_read_is_skipped_whole(mc_repo, capsys):
+    # Test that one bad document leaves the collections alone rather than
+    # applying the half of it that made sense
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text() + "- [ ] 9.9.9  a task under nothing  ^mct999\n")
+    main(["helper", "mc_sync"])
+    out = capsys.readouterr().out
+    assert "was not read" in out and "there is no goal 9.9" in out
+    assert stored(mc_repo, "mc_tasks", "mct999") is None
+
+
+def test_a_dry_run_says_what_it_would_do_and_does_nothing(mc_repo, capsys):
+    # Test that the run which changes nothing still reports what it found
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text().replace("a task  ^mct001", "~~a task~~  ^mct001"))
+    main(["helper", "mc_sync", "--dry-run"])
+    assert "would write" in capsys.readouterr().out
+    assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "active"
+
+
+def test_a_document_that_says_nothing_new_changes_nothing(mc_repo):
+    # Test that reading a document straight after rendering it is a no-op,
+    # which is what makes syncing on every read safe
+    before = stored(mc_repo, "mc_goals", "mcg001")
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, "mc_goals", "mcg001") == before


### PR DESCRIPTION
mc.py, helpers/mcsynchelper.py: regolith helper mc_sync reads every document and writes what it says, which closes the round trip.  Editing one is now worth doing.

changes turns a read document into the records to write and the ids to drop.  Three things it has to get right that reading alone does not:

A status must survive being read.  Everything in the goals section reads back as active, so a goal that was proposed would lose that for no reason anybody intended.  What a document does say is when something is finished, when it is held on the backburner or the wishlist, and when it has come back from either; the rest is left as it was.

Where something started is written once.  first_period and first_due_date are set when a record is made and never again, so how long something has been carried stays knowable, and end_date is set the first time something finishes rather than every time it is read.

A line whose id has gone is offered to a record with the same text that nothing else has claimed.  A lost id is the likeliest damage a document takes, from a paste or a retype, and without this it would store a second copy of something already there and drop the first.

The helper refuses a document that has lost more than a third of what it held, since that is more like damage than editing, and --force applies it anyway.  A document that cannot be read is skipped whole rather than half applied, naming the line it gave up on.  Every record is validated before anything is written.  --dry-run says what would happen.

Nothing is deleted.  A line taken out marks its record dropped, so a document wrecked by accident costs nothing a render cannot put back.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64