### PR TITLE
style: write ids with hyphens rather than underscores

### DIFF
--- a/news/mc-hyphenated-ids.rst
+++ b/news/mc-hyphenated-ids.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -40,6 +40,8 @@ def slug(text):
         The name in lower case with anything but letters, numbers and
         hyphens replaced by a hyphen.
     """
+    # an underscore becomes a hyphen along with everything else that is not a
+    # letter or a number: underscores in ids are being retired
     kept = [c if (c.isalnum() or c == "-") else "-" for c in text.lower()]
     return "-".join(part for part in "".join(kept).split("-") if part)
 
@@ -79,7 +81,12 @@ def subparser(subpi):
         help="The date the project began.  Default is today.",
         **date_kwargs,
     )
-    subpi.add_argument("--id", dest="_id", help="An id for it.  Default is made from the name.")
+    subpi.add_argument(
+        "--id",
+        dest="_id",
+        help="An id for it.  Default is made from the name.  Either way it is put "
+        "in lower case with hyphens, since ids no longer carry underscores.",
+    )
     subpi.add_argument("--database", help="The database to write to.")
     return subpi
 
@@ -102,7 +109,9 @@ class MCProjectAdderHelper(DbHelperBase):
     def db_updater(self):
         rc = self.rc
         taken = {project["_id"] for project in self.gtx[rc.coll]}
-        _id = rc._id or slug(rc.name) or short_id(taken)
+        # an id given by hand goes through the same slug, so an underscore
+        # cannot get in that way either
+        _id = slug(rc._id) if rc._id else (slug(rc.name) or short_id(taken))
         if _id in taken:
             raise ValueError(
                 f"There is already a project called {_id}. Give it another name, or "

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -10,6 +10,8 @@ import secrets
 
 # Lowercase base32 without the characters that are read for one another, so
 # an id can be said aloud in a meeting and typed back correctly
+# No underscore: ids are written with hyphens.  The patterns below still read
+# one, so a document written before that stays readable.
 ID_ALPHABET = "abcdefghijkmnpqrstuvwxyz23456789"
 ID_LENGTH = 6
 

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -99,3 +99,26 @@ def test_a_status_that_is_not_one_of_them_lists_the_ones_that_are(make_db):
     os.chdir(make_db)
     with pytest.raises(ValueError, match="should be one of"):
         main(["helper", "a_mcproject", "bad status project", "-s", "nonsense"])
+
+
+@pytest.mark.parametrize(
+    "given_id, expected_id",
+    [
+        # Test that an id given by hand is put in the form ids now take, since
+        # underscores in them are being retired
+        # C1: underscores, expect hyphens
+        ("sg_shock_compressed_wc", "sg-shock-compressed-wc"),
+        # C2: upper case, expect lower
+        ("AB-Upper-Case", "ab-upper-case"),
+        # C3: already in the right form, expect it unchanged
+        ("cd-already-fine", "cd-already-fine"),
+    ],
+)
+def test_an_id_given_by_hand_is_put_in_the_form_ids_take(given_id, expected_id, make_db):
+    os.chdir(make_db)
+    main(["helper", "a_mcproject", f"project for {given_id}", "--id", given_id])
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        assert rc.client.get("mc_projects", expected_id) is not None

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -12,7 +12,7 @@ DOCUMENT = """# Mission control — Adib Kabir
 
 ## Projects
 
-1. **nanodiamond-pdf**  ^ak_nano
+1. **nanodiamond-pdf**  ^ak-nano
    deliverable: submit the paper
 
 ## Goals — 2026Q3
@@ -59,7 +59,7 @@ def test_the_document_says_who_it_is_for(read):
     [
         # Test what is read out of each part of the document
         # C1: the projects, in the order they are written
-        ("projects", ["ak_nano"]),
+        ("projects", ["ak-nano"]),
         # C2: the goals of the current period, the backburner and the wishlist,
         # but not the archive, which only says what a past period was
         ("goals", ["a8s8ec", "dab3ap", "gpu111", "tut222"]),


### PR DESCRIPTION
a_mcprojecthelper.py, mc.py, tests: underscores in ids are being retired, so nothing in mission control writes one.  short_id never could, its alphabet has no underscore.  slug turned one into a hyphen already, and an id given by hand now goes through it too, so --id sg_my_project is stored as sg-my-project rather than as given.

Reading still accepts an underscore.  Documents and databases written before this exist, and refusing to read them would be a poor way to retire a spelling.

The mission control sample data in regolith-notes is rewritten with hyphens, and the converter hyphenates the ids it carries over from projecta, so a migration does not reintroduce them.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64