### PR TITLE
feat: list the mission control projects and goals

### DIFF
--- a/news/mc-listers.rst
+++ b/news/mc-listers.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -97,6 +97,14 @@ LISTER_HELPER_SPECS = {
         "regolith.helpers.l_grantshelper:GrantsListerHelper",
         "regolith.helpers.l_grantshelper:subparser",
     ),
+    "l_mcgoals": (
+        "regolith.helpers.l_mcgoalshelper:MCGoalsListerHelper",
+        "regolith.helpers.l_mcgoalshelper:subparser",
+    ),
+    "l_mcprojects": (
+        "regolith.helpers.l_mcprojectshelper:MCProjectsListerHelper",
+        "regolith.helpers.l_mcprojectshelper:subparser",
+    ),
     "l_members": (
         "regolith.helpers.l_membershelper:MembersListerHelper",
         "regolith.helpers.l_membershelper:subparser",

--- a/src/regolith/helpers/l_mcgoalshelper.py
+++ b/src/regolith/helpers/l_mcgoalshelper.py
@@ -1,0 +1,113 @@
+"""List the mission control goals.
+
+What ``l_milestones`` did, on the collections that replace projecta.
+Goals are what milestones were, so this is the view that answers what
+somebody agreed to get done this period and how far along it is.
+"""
+
+from gooey import GooeyParser
+
+from regolith.helpers.basehelper import SoutHelperBase
+from regolith.mc import CLOSED, HELD
+from regolith.tools import all_docs_from_collection, key_value_pair_filter
+
+TARGET_COLL = "mc_goals"
+HELPER_TARGET = "l_mcgoals"
+
+
+def subparser(subpi):
+    if isinstance(subpi, GooeyParser):
+        pass
+    subpi.add_argument("-l", "--lead", help="List the goals of the projects this person leads, by id.")
+    subpi.add_argument("-p", "--person", help="List the goals of the projects this person is on, by id.")
+    subpi.add_argument("--period", help="List the goals of this period, e.g. 2026Q3.")
+    subpi.add_argument(
+        "--carried",
+        action="store_true",
+        help="List only the goals that have been carried from an earlier period, and say "
+        "which one they started in.",
+    )
+    subpi.add_argument(
+        "--held",
+        action="store_true",
+        help=f"List the goals on the {' and '.join(HELD)} instead of the ones being worked on.",
+    )
+    subpi.add_argument(
+        "--all",
+        action="store_true",
+        help=f"Include the goals that are {' and '.join(CLOSED)}, and every period.",
+    )
+    subpi.add_argument("-v", "--verbose", action="store_true", help="Say more about each one.")
+    subpi.add_argument("-f", "--filter", nargs="+", help="Search the collection by giving key value pairs.")
+    return subpi
+
+
+class MCGoalsListerHelper(SoutHelperBase):
+    """List the mission control goals."""
+
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}", "mc_projects"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        rc = self.rc
+        rc.coll = f"{TARGET_COLL}"
+        self.gtx[rc.coll] = list(all_docs_from_collection(rc.client, rc.coll))
+        self.gtx["mc_projects"] = list(all_docs_from_collection(rc.client, "mc_projects"))
+
+    def sout(self):
+        rc = self.rc
+        goals = key_value_pair_filter(self.gtx[rc.coll], rc.filter) if rc.filter else self.gtx[rc.coll]
+        projects = {project["_id"]: project for project in self.gtx["mc_projects"]}
+
+        if rc.lead:
+            goals = [g for g in goals if projects.get(g["project"], {}).get("lead") == rc.lead]
+        if rc.person:
+            goals = [g for g in goals if self.is_on(projects.get(g["project"], {}), rc.person)]
+        if rc.held:
+            goals = [g for g in goals if g.get("status") in HELD]
+        elif not rc.all:
+            goals = [g for g in goals if g.get("status") not in CLOSED + HELD]
+        if rc.carried:
+            goals = [g for g in goals if g.get("first_period") != g.get("period")]
+        period = rc.period or (None if rc.all else self.latest(goals))
+        if period:
+            goals = [g for g in goals if g.get("period") == period]
+
+        for project_id, its_goals in self.by_project(goals):
+            project = projects.get(project_id, {})
+            print(f"{project_id}  ({project.get('lead', 'nobody')})  {project.get('name', '')}")
+            for goal in its_goals:
+                print(f"    {self.line(goal)}")
+                if rc.verbose and goal.get("notes"):
+                    for note in goal["notes"]:
+                        print(f"        {note}")
+        return
+
+    @staticmethod
+    def is_on(project, person):
+        """Return True if somebody leads a project or is on it."""
+        return project.get("lead") == person or person in project.get("collaborators", [])
+
+    @staticmethod
+    def latest(goals):
+        """Return the most recent period any of these goals is in."""
+        periods = [g.get("period") for g in goals if g.get("period")]
+        return max(periods) if periods else None
+
+    @staticmethod
+    def by_project(goals):
+        """Return the goals grouped under the project they belong to."""
+        grouped = {}
+        for goal in goals:
+            grouped.setdefault(goal["project"], []).append(goal)
+        return sorted((k, sorted(v, key=lambda g: g["_id"])) for k, v in grouped.items())
+
+    @staticmethod
+    def line(goal):
+        """Return the one line that says what a goal is."""
+        carried = ""
+        if goal.get("first_period") and goal["first_period"] != goal.get("period"):
+            carried = f"  (carried since {goal['first_period']})"
+        return f"{goal['_id']}  ({goal.get('status', '?')})  {goal.get('text', '')}{carried}"

--- a/src/regolith/helpers/l_mcprojectshelper.py
+++ b/src/regolith/helpers/l_mcprojectshelper.py
@@ -1,0 +1,119 @@
+"""List the mission control projects.
+
+What ``l_projecta`` did, on the collections that replace projecta.  The
+one that earns its keep is ``--orphans``: work that nobody is doing,
+either because nobody was given it or because whoever had it has left
+the group.  Nobody has to remember to reassign anything when somebody
+goes.
+"""
+
+from gooey import GooeyParser
+
+from regolith.helpers.basehelper import SoutHelperBase
+from regolith.mc import CLOSED, orphaned, unled
+from regolith.tools import all_docs_from_collection, key_value_pair_filter
+
+TARGET_COLL = "mc_projects"
+HELPER_TARGET = "l_mcprojects"
+
+
+def subparser(subpi):
+    if isinstance(subpi, GooeyParser):
+        pass
+    subpi.add_argument(
+        "-o",
+        "--orphans",
+        action="store_true",
+        help="List the projects nobody is doing: the ones with no lead, and the "
+        "ones led by somebody who has left the group.",
+    )
+    subpi.add_argument("-l", "--lead", help="List the projects led by this person, by id.")
+    subpi.add_argument("-p", "--person", help="List the projects this person is on, leading them or not, by id.")
+    subpi.add_argument("-g", "--grant", help="List the projects paid for by this grant, by id.")
+    subpi.add_argument(
+        "--all",
+        action="store_true",
+        help=f"Include the projects that are {' and '.join(CLOSED)}, which are left out by default.",
+    )
+    subpi.add_argument("-v", "--verbose", action="store_true", help="Say more about each one.")
+    subpi.add_argument(
+        "-f",
+        "--filter",
+        nargs="+",
+        help="Search the collection by giving key value pairs.",
+    )
+    return subpi
+
+
+class MCProjectsListerHelper(SoutHelperBase):
+    """List the mission control projects."""
+
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}", "people"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        rc = self.rc
+        rc.coll = f"{TARGET_COLL}"
+        self.gtx[rc.coll] = list(all_docs_from_collection(rc.client, rc.coll))
+        self.gtx["people"] = list(all_docs_from_collection(rc.client, "people"))
+
+    def sout(self):
+        rc = self.rc
+        if rc.orphans and (rc.lead or rc.person):
+            raise RuntimeError(
+                "Orphans are the projects with nobody on them, so asking for a person as "
+                "well asks for two different things. Please use one or the other."
+            )
+        projects = key_value_pair_filter(self.gtx[rc.coll], rc.filter) if rc.filter else self.gtx[rc.coll]
+        people = self.gtx["people"]
+
+        if rc.orphans:
+            projects = [p for p in projects if orphaned(p, people)]
+        elif not rc.all:
+            projects = [p for p in projects if p.get("status") not in CLOSED]
+        if rc.lead:
+            projects = [p for p in projects if p.get("lead") == rc.lead]
+        if rc.person:
+            projects = [
+                p for p in projects if p.get("lead") == rc.person or rc.person in p.get("collaborators", [])
+            ]
+        if rc.grant:
+            projects = [p for p in projects if rc.grant in as_list(p.get("grants"))]
+
+        for project in sorted(projects, key=lambda p: (p.get("lead") or "", p["_id"])):
+            print(self.line(project))
+            if rc.verbose:
+                for line in self.more(project):
+                    print(line)
+        return
+
+    @staticmethod
+    def line(project):
+        """Return the one line that says what a project is."""
+        lead = "nobody" if unled(project) else project["lead"]
+        return f"{project['_id']}  ({lead}, {project.get('status', '?')})  {project.get('name', '')}"
+
+    @staticmethod
+    def more(project):
+        """Return the rest of what is worth knowing about a project."""
+        lines = []
+        for label, key in [
+            ("deliverable", "project_deliverable"),
+            ("description", "project_description"),
+        ]:
+            if project.get(key):
+                lines.append(f"    {label}: {project[key]}")
+        if project.get("collaborators"):
+            lines.append(f"    with: {', '.join(project['collaborators'])}")
+        if project.get("grants"):
+            lines.append(f"    grants: {', '.join(as_list(project['grants']))}")
+        return lines
+
+
+def as_list(value):
+    """Return a value as a list, since a grant may be one or several."""
+    if not value:
+        return []
+    return [value] if isinstance(value, str) else list(value)

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -460,3 +460,77 @@ def _close(record, was, today):
     """Date a record that has just been finished, and only just."""
     if record["status"] == "finished" and was.get("status") != "finished":
         record.setdefault("end_date", today)
+
+
+# what a lead is called when nobody is leading it.  Old projecta wrote "na" or
+# "tbd" by default; a mission control project simply has no lead
+NOBODY = ("", "na", "tbd", "none")
+# a project in one of these is done with, so it cannot be an orphan
+CLOSED = ("finished", "dropped")
+
+
+def unled(project):
+    """Return True if nobody is leading a project.
+
+    Parameters
+    ----------
+    project : dict
+        The project.
+
+    Returns
+    -------
+    bool
+        Whether it has a lead worth the name.
+    """
+    lead = project.get("lead")
+    return not lead or str(lead).strip().lower() in NOBODY
+
+
+def in_the_group(person_id, people):
+    """Return True if somebody is in the group at the moment.
+
+    Somebody who has left is not, which is what makes their unfinished
+    work show up as orphaned without anybody having to reassign it by
+    hand.
+
+    Parameters
+    ----------
+    person_id : str
+        The id to look for.
+    people : iterable of dict
+        The people collection.
+
+    Returns
+    -------
+    bool
+        Whether the people collection has them, and has them active.
+    """
+    for person in people:
+        if person.get("_id") == person_id:
+            return bool(person.get("active"))
+    return False
+
+
+def orphaned(project, people):
+    """Return True if a project has nobody to do it.
+
+    A project is orphaned when it is not finished or dropped, and either
+    nobody leads it or whoever does has left the group.  The second half
+    is what makes somebody's unfinished work reappear when they go,
+    rather than sitting under a name that is no longer around.
+
+    Parameters
+    ----------
+    project : dict
+        The project.
+    people : iterable of dict
+        The people collection.
+
+    Returns
+    -------
+    bool
+        Whether it needs somebody.
+    """
+    if project.get("status") in CLOSED:
+        return False
+    return unled(project) or not in_the_group(project["lead"], people)

--- a/tests/test_mc_listers.py
+++ b/tests/test_mc_listers.py
@@ -1,0 +1,134 @@
+"""Tests for listing the mission control projects and goals."""
+
+import pytest
+
+from regolith.helpers.l_mcgoalshelper import MCGoalsListerHelper
+from regolith.helpers.l_mcprojectshelper import MCProjectsListerHelper, as_list
+from regolith.mc import in_the_group, orphaned, unled
+
+PEOPLE = [
+    {"_id": "here", "name": "Still Here", "active": True},
+    {"_id": "gone", "name": "Has Left", "active": False},
+]
+
+
+@pytest.mark.parametrize(
+    "project, expected",
+    [
+        # Test who counts as having nobody leading them.  Old projecta wrote a
+        # placeholder rather than leaving the field out, so those count too.
+        # C1: no lead at all, as a mission control project has
+        ({}, True),
+        # C2: the placeholders projecta used
+        ({"lead": "na"}, True),
+        ({"lead": "tbd"}, True),
+        ({"lead": "TBD"}, True),
+        # C3: an empty string, which a form leaves behind
+        ({"lead": ""}, True),
+        # C4: somebody, expect it is led
+        ({"lead": "here"}, False),
+    ],
+)
+def test_a_project_with_nobody_leading_it_is_recognised(project, expected):
+    assert unled(project) is expected
+
+
+@pytest.mark.parametrize(
+    "person_id, expected",
+    [
+        # Test who is in the group at the moment, which is what decides
+        # whether their unfinished work is orphaned
+        # C1: somebody active, expect they are
+        ("here", True),
+        # C2: somebody who has left, expect they are not
+        ("gone", False),
+        # C3: somebody the people collection has never heard of
+        ("stranger", False),
+    ],
+)
+def test_who_is_in_the_group(person_id, expected):
+    assert in_the_group(person_id, PEOPLE) is expected
+
+
+@pytest.mark.parametrize(
+    "project, expected",
+    [
+        # Test what needs somebody.  A project is orphaned when it is not done
+        # with and either nobody leads it or whoever does has gone.
+        # C1: nobody leads it, expect it needs somebody
+        ({"status": "active"}, True),
+        # C2: led by somebody who has left, expect it comes back by itself,
+        # which is the point: nobody has to reassign anything when they go
+        ({"status": "active", "lead": "gone"}, True),
+        # C3: led by somebody who is here, expect it does not
+        ({"status": "active", "lead": "here"}, False),
+        # C4: nobody leads it but it is finished, expect it is done with
+        ({"status": "finished"}, False),
+        # C5: led by somebody who left, but dropped, expect it is done with
+        ({"status": "dropped", "lead": "gone"}, False),
+        # C6: proposed and unled, expect it still needs somebody
+        ({"status": "proposed"}, True),
+    ],
+)
+def test_what_counts_as_orphaned(project, expected):
+    assert orphaned(project, PEOPLE) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Test reading a grant field, which projecta wrote as one or as several
+        # C1: several, expect them as they are
+        (["a", "b"], ["a", "b"]),
+        # C2: one, written bare, expect a list of it
+        ("a", ["a"]),
+        # C3: none, expect nothing rather than an error
+        (None, []),
+    ],
+)
+def test_a_grant_may_be_one_or_several(value, expected):
+    assert as_list(value) == expected
+
+
+def test_a_project_line_says_who_and_what():
+    # Test the line a project is listed as, which is what gets read in a
+    # conversation about what needs doing
+    line = MCProjectsListerHelper.line(
+        {"_id": "a-project", "name": "A project", "lead": "here", "status": "active"}
+    )
+    assert line == "a-project  (here, active)  A project"
+    unassigned = MCProjectsListerHelper.line({"_id": "b-project", "name": "B", "status": "proposed"})
+    assert "(nobody, proposed)" in unassigned
+
+
+@pytest.mark.parametrize(
+    "goal, expected_ending",
+    [
+        # Test that a goal says how long it has been carried, since that is
+        # the thing worth noticing when reading a list of them
+        # C1: carried from an earlier period, expect it says since when
+        (
+            {"_id": "g1", "status": "active", "text": "a goal", "period": "2026Q3", "first_period": "2026Q2"},
+            "(carried since 2026Q2)",
+        ),
+        # C2: set this period, expect nothing added
+        (
+            {"_id": "g1", "status": "active", "text": "a goal", "period": "2026Q3", "first_period": "2026Q3"},
+            "a goal",
+        ),
+    ],
+)
+def test_a_goal_line_says_how_long_it_has_been_carried(goal, expected_ending):
+    assert MCGoalsListerHelper.line(goal).endswith(expected_ending)
+
+
+def test_goals_are_grouped_under_their_project():
+    # Test that goals are read project by project, the way the meeting goes
+    goals = [
+        {"_id": "g2", "project": "p1"},
+        {"_id": "g1", "project": "p1"},
+        {"_id": "g3", "project": "p2"},
+    ]
+    grouped = MCGoalsListerHelper.by_project(goals)
+    assert [project for project, _ in grouped] == ["p1", "p2"]
+    assert [g["_id"] for g in grouped[0][1]] == ["g1", "g2"]


### PR DESCRIPTION
helpers/l_mcprojectshelper.py, helpers/l_mcgoalshelper.py: what l_projecta and l_milestones did, on the collections that replace projecta.  Goals are what milestones were, so the second is the view that answers what somebody agreed to get done this period.

mc.py: orphaned says what needs somebody.  A project is orphaned when it is neither finished nor dropped and either nobody leads it or whoever does has left the group.  The second half is the useful half: somebody's unfinished work comes back by itself when they go, rather than sitting under a name that is no longer around, and nobody has to remember to reassign anything.

unled counts the placeholders projecta wrote where a mission control project simply has no lead, so "na" and "tbd" read as nobody and migrated data lands in the orphan list where it belongs.

l_mcprojects filters by lead, by anybody on a project, and by grant, and leaves out what is finished or dropped unless asked.  l_mcgoals groups under the project a goal belongs to, shows the current period by default, and can show only the goals carried from an earlier one, which is the thing worth noticing when reading a list of them.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64