### PR TITLE
fix: keep a dropped record out of the document it was deleted from

### DIFF
--- a/news/mc-dropped-stays-dropped.rst
+++ b/news/mc-dropped-stays-dropped.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -29,6 +29,27 @@ HELD_STATI = ("backburner", "wishlist")
 ID_IN_DOCUMENT = re.compile(r"\^([\w.-]+)")
 
 
+def live(records):
+    """Return the records a document should still show.
+
+    Deleting a line is how somebody deletes a thing, and the sync marks
+    what they deleted ``dropped`` rather than removing it, so that an
+    accident can be undone.  The document is what they deleted it from,
+    so it is the one place a dropped record does not come back.
+
+    Parameters
+    ----------
+    records : iterable of dict
+        The records to sift.
+
+    Returns
+    -------
+    list of dict
+        The records that are not dropped.
+    """
+    return [record for record in records if record.get("status") != "dropped"]
+
+
 def ids_in_document(text):
     """Return the ids a document carries, in the order they appear.
 
@@ -203,7 +224,7 @@ class MissionControlBuilder(BuilderBase):
         """
         orders = orders or {}
         by_person = defaultdict(list)
-        for project in self.gtx["mc_projects"]:
+        for project in live(self.gtx["mc_projects"]):
             by_person[project.get("lead") or UNASSIGNED].append(project)
         return {
             person: self.render_person(person, projects, orders.get(person, []))
@@ -228,10 +249,10 @@ class MissionControlBuilder(BuilderBase):
         projects = in_document_order(projects, order, lambda p: p["_id"])
         number_of = {project["_id"]: n for n, project in enumerate(projects, start=1)}
         goals = in_document_order(
-            [g for g in self.gtx["mc_goals"] if g["project"] in number_of], order, lambda g: g["_id"]
+            [g for g in live(self.gtx["mc_goals"]) if g["project"] in number_of], order, lambda g: g["_id"]
         )
         goal_number = self.number_goals(goals, number_of)
-        tasks = [t for t in self.gtx["mc_tasks"] if t["goal"] in goal_number]
+        tasks = [t for t in live(self.gtx["mc_tasks"]) if t["goal"] in goal_number]
 
         lines = [f"# Mission control — {self.display_name(person)}", ""]
         lines += self.render_projects(projects)
@@ -305,9 +326,13 @@ class MissionControlBuilder(BuilderBase):
         is chosen by the due date of the task at the top, so a sub task
         stays with the one it belongs to.
         """
+        shown = {task["_id"] for task in tasks}
         children = defaultdict(list)
         for task in tasks:
-            children[task.get("parent")].append(task)
+            # a sub task whose task has gone is shown in its own right, rather
+            # than hanging off something that is no longer there
+            parent = task.get("parent")
+            children[parent if parent in shown else None].append(task)
         by_week = defaultdict(list)
         for task in children[None]:
             due = as_date(task.get("due_date"))
@@ -433,6 +458,4 @@ class MissionControlBuilder(BuilderBase):
         if goal["status"] == "finished":
             end = as_date(goal.get("end_date"))
             return f"  (finished {end.isoformat()})" if end else "  (finished)"
-        if goal["status"] == "dropped":
-            return "  (dropped)"
         return ""

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from gooey import GooeyParser
 
-from regolith.builders.missioncontrolbuilder import UNASSIGNED, MissionControlBuilder
+from regolith.builders.missioncontrolbuilder import UNASSIGNED, MissionControlBuilder, live
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.mc import DocumentError, changes, parse_document
 from regolith.schemas import SCHEMAS, validate
@@ -81,7 +81,7 @@ class MCSyncHelper(DbHelperBase):
     def people(self, renderer):
         """Return everyone a document could belong to, and the
         orphans."""
-        leads = {project.get("lead") or UNASSIGNED for project in self.gtx["mc_projects"]}
+        leads = {project.get("lead") or UNASSIGNED for project in live(self.gtx["mc_projects"])}
         return sorted(leads | {UNASSIGNED})
 
     def mine(self, person):
@@ -96,11 +96,19 @@ class MCSyncHelper(DbHelperBase):
         -------
         dict
             ``{collection: {id: record}}`` for what is theirs.
+
+        Notes
+        -----
+        What was dropped is left out.  It is not in their document, so
+        counting it would have every sync drop it again and read as a
+        document losing more than it holds.
         """
         lead = None if person == UNASSIGNED else person
-        projects = {project["_id"]: project for project in self.gtx["mc_projects"] if project.get("lead") == lead}
-        goals = {goal["_id"]: goal for goal in self.gtx["mc_goals"] if goal.get("project") in projects}
-        tasks = {task["_id"]: task for task in self.gtx["mc_tasks"] if task.get("goal") in goals}
+        projects = {
+            project["_id"]: project for project in live(self.gtx["mc_projects"]) if project.get("lead") == lead
+        }
+        goals = {goal["_id"]: goal for goal in live(self.gtx["mc_goals"]) if goal.get("project") in projects}
+        tasks = {task["_id"]: task for task in live(self.gtx["mc_tasks"]) if task.get("goal") in goals}
         return {"mc_projects": projects, "mc_goals": goals, "mc_tasks": tasks}
 
     def read_one(self, path, person):

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -140,7 +140,8 @@ def parse_document(text, taken=()):
     -------
     dict
         ``person``, and ``projects``, ``goals`` and ``tasks`` as lists of
-        records in the order the document put them.
+        records in the order the document put them, plus ``mentioned``,
+        the ids the document showed without saying anything to store.
 
     Raises
     ------
@@ -169,6 +170,7 @@ class _Reader:
         self.monday = None
         self.by_number = {}
         self.stack = []
+        self.mentioned = []
 
     def mint(self):
         _id = short_id(self.ids)
@@ -276,6 +278,9 @@ class _Reader:
         # the archive says what a period was; the current sections say what is
         _id = found.group("id") or self.mint()
         if self.section == "archive":
+            # nothing in the archive is written back, but a line that is there
+            # is a line nobody deleted, so it must not read as one
+            self.mentioned.append(_id)
             return True
         goal = {
             "_id": _id,
@@ -339,6 +344,7 @@ class _Reader:
             "projects": self.projects,
             "goals": self.goals,
             "tasks": self.tasks,
+            "mentioned": self.mentioned,
         }
 
 
@@ -479,6 +485,9 @@ def changes(parsed, person, existing, today=None):
         writes["mc_tasks"].append(record)
         seen["mc_tasks"].add(record["_id"])
 
+    # the archive shows a goal without saying anything to store about it, so
+    # what it shows is neither written nor taken for deleted
+    seen["mc_goals"].update(parsed.get("mentioned", ()))
     drops = {collection: sorted(set(records) - seen[collection]) for collection, records in existing.items()}
     return writes, drops
 

--- a/tests/test_mc_changes.py
+++ b/tests/test_mc_changes.py
@@ -162,3 +162,16 @@ def test_adopting_leaves_something_genuinely_new_alone():
     read_line = {"_id": "minted", "text": "something else"}
     assert adopt(read_line, {"realid": {"_id": "realid", "text": "a goal"}}, set()) == {}
     assert read_line["_id"] == "minted"
+
+
+def test_a_goal_only_the_archive_shows_is_not_deleted():
+    # Test that history is not read as a deletion.  The archive shows a goal
+    # from a period that has passed and says nothing to store about it, so it
+    # appears in no other section, and taking that for a deleted line would
+    # have every sync drop everything anybody ever finished
+    archived = stored(_id="g-old", period="2026Q2", first_period="2026Q2", status="finished")
+    document = parsed(goals=[read(_id="g-live")], tasks=())
+    document["mentioned"] = ["g-old"]
+    writes, drops = changes(document, "pliu", existing(goals=[stored(_id="g-live"), archived]), today=TODAY)
+    assert drops["mc_goals"] == []
+    assert [g["_id"] for g in writes["mc_goals"]] == ["g-live"]

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -200,3 +200,17 @@ def test_a_document_that_says_nothing_new_changes_nothing(mc_repo):
     before = stored(mc_repo, "mc_goals", "mcg001")
     main(["helper", "mc_sync"])
     assert stored(mc_repo, "mc_goals", "mcg001") == before
+
+
+def test_what_was_dropped_is_not_dropped_again(mc_repo, capsys):
+    # Test that a deletion settles.  What was dropped is no longer in the
+    # document, so counting it again would have every later sync report a
+    # deletion nobody made, and enough of them would read as a damaged file
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text().replace("- [ ] 1.1.1  a task  ^mct001\n", ""))
+    main(["helper", "mc_sync"])
+    capsys.readouterr()
+    main(["helper", "mc_sync"])
+    assert "dropped 0" in capsys.readouterr().out
+    assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "dropped"

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -425,3 +425,49 @@ def test_what_a_project_is_about_is_written_under_it():
     builder.gtx = {"mc_projects": [described], "mc_goals": [], "mc_tasks": []}
     document = "\n".join(builder.documents()["pliu"])
     assert "   what this project is about" in document
+
+
+@pytest.mark.parametrize(
+    "collection, dropped_id, gone, kept",
+    [
+        # Test that a thing somebody deleted from their document does not come
+        # back the next time the document is built.  Deleting a line is how a
+        # thing is deleted, and the sync marks it dropped rather than removing
+        # it, so the render is what has to honour the deletion.
+        # C1: a project was dropped, expect the document without it
+        ("mc_projects", "p-orphan", "^p-orphan", "^p-pdf"),
+        # C2: a goal was dropped, expect the document without it
+        ("mc_goals", "g-methods", "^g-methods", "^g-converge"),
+        # C3: a task was dropped, expect the document without it
+        ("mc_tasks", "t-bg", "^t-bg", "^t-plot"),
+    ],
+)
+def test_a_dropped_thing_does_not_come_back(collection, dropped_id, gone, kept):
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    records = {
+        "mc_projects": [dict(p, lead="pliu") for p in PROJECTS],
+        "mc_goals": GOALS,
+        "mc_tasks": TASKS,
+    }
+    builder.gtx = {
+        name: [dict(r, status="dropped") if r["_id"] == dropped_id else r for r in rs]
+        for name, rs in records.items()
+    }
+    document = "\n".join(builder.documents()["pliu"])
+    assert gone not in document
+    assert kept in document
+
+
+def test_a_sub_task_outlives_the_task_it_hung_off():
+    # Test that deleting a task does not silently take an unrelated sub task
+    # with it.  A sub task with no task above it is shown in its own right,
+    # numbered like any other, rather than disappearing from the document
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": PROJECTS,
+        "mc_goals": GOALS,
+        "mc_tasks": [dict(t, status="dropped") if t["_id"] == "t-bg" else t for t in SUB_TASKS],
+    }
+    document = "\n".join(builder.documents()["pliu"])
+    assert "^t-bg" not in document
+    assert "\n- [x] 1.1.1  ~~Rebuild the background model~~  ^t-sub1" in document


### PR DESCRIPTION
Deleting a line is how somebody deletes a thing, and mc_sync marked the record dropped as intended, but nothing downstream honoured that, so the deletion did not stick:

- missioncontrolbuilder rendered every record whatever its status, so the next build wrote the deleted lines straight back into the document, a dropped goal arriving with "(dropped)" after it
- mcsynchelper counted dropped records among the ones a document holds, so every later sync dropped them again and each one brought the file closer to reading as damaged
- mc.parse_document read the archive without noting the goals it shows. The archive is the only place a past period's goals appear, so they were absent from what the document said and every sync deleted them

Sub tasks are promoted rather than hidden when the task above them goes, so deleting one line cannot silently remove another.

No news: mission control has not been released, so this fixes bugs in code nobody has run but us.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64