### PR TITLE
feat: write a mission control document in lines an editor can read

### DIFF
--- a/news/mc-wrap-lines.rst
+++ b/news/mc-wrap-lines.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
-from regolith.mc import struck
+from regolith.mc import struck, wrap
 from regolith.tools import all_docs_from_collection
 
 UNASSIGNED = "unassigned"
@@ -240,7 +240,7 @@ class MissionControlBuilder(BuilderBase):
         lines += self.render_bucket("Backburner", goals, goal_number, "backburner")
         lines += self.render_bucket("Wishlist", goals, goal_number, "wishlist")
         lines += self.render_archive(goals, goal_number)
-        return lines
+        return [written for line in lines for written in wrap(line)]
 
     @staticmethod
     def number_goals(goals, number_of):
@@ -267,17 +267,23 @@ class MissionControlBuilder(BuilderBase):
 
     @staticmethod
     def render_projects(projects):
-        """Return the lines of the projects section."""
+        """Return the lines of the projects section.
+
+        What is written under a project is separated by blank lines.
+        Markdown reads lines that run together as one paragraph, which
+        would show a project as a single block of text wherever the
+        document is read as markdown rather than as a file.
+        """
         lines = ["## Projects", ""]
         for n, project in enumerate(projects, start=1):
             lines.append(f"{n}. **{project['name']}**  ^{project['_id']}")
             if project.get("project_deliverable"):
-                lines.append(f"   deliverable: {project['project_deliverable']}")
+                lines += ["", f"   deliverable: {project['project_deliverable']}"]
             if project.get("collaborators"):
-                lines.append(f"   with: {', '.join(project['collaborators'])}")
+                lines += ["", f"   with: {', '.join(project['collaborators'])}"]
             if project.get("project_description"):
-                lines.append(f"   {project['project_description']}")
-        lines.append("")
+                lines += ["", f"   {project['project_description']}"]
+            lines.append("")
         return lines
 
     def render_goals(self, goals, goal_number):

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -7,6 +7,7 @@ control document does not import the rest of it.
 import datetime as dt
 import re
 import secrets
+import textwrap
 
 # Lowercase base32 without the characters that are read for one another, so
 # an id can be said aloud in a meeting and typed back correctly
@@ -88,6 +89,10 @@ TASK_LINE = re.compile(
     r"(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?\s*$"
 )
 STRUCK = re.compile(r"^~~(?P<text>.*)~~$")
+# what starts something rather than carrying on the line above: a heading, a
+# bullet, a task box or a numbered project
+MARKER = re.compile(r"^\s*(?:#+\s+|-\s+(?:\[[ xX]\]\s+)?|\d+\.\s+)")
+WIDTH = 79
 GOALS_HEADING = re.compile(r"^Goals\s+—\s+(?P<period>\S+)$")
 WEEK_HEADING = re.compile(r"^Week of\s+(?P<monday>\d{4}-\d{2}-\d{2})$")
 
@@ -112,6 +117,90 @@ def read_text(raw):
     """
     struck_out = STRUCK.match(raw)
     return (struck_out.group("text").strip(), True) if struck_out else (raw.strip(), False)
+
+
+def indent_of(line):
+    """Return how far a line is indented, counting a tab as four."""
+    return len(line[: len(line) - len(line.lstrip())].expandtabs(4))
+
+
+def wrap(line, width=WIDTH):
+    """Return a rendered line broken to fit a plain text editor.
+
+    A goal or a task can run to a paragraph, and a document is read in an
+    editor that does not fold, where finding the end of a long line is a
+    chore.  So a written line is broken, and what carries on from it is
+    indented two further than the line it belongs to: enough for
+    ``join_wrapped`` to know it for a continuation, and few enough that
+    markdown still reads it as the same paragraph rather than as a code
+    block.
+
+    A heading and the line naming a project are left alone.  Neither can
+    be joined back up, the first because it must stay one line to be a
+    heading and the second because the indented lines under a project are
+    what the project is about.
+
+    Parameters
+    ----------
+    line : str
+        The line as rendered.
+    width : int, optional
+        The longest line to write.  The default is 79.
+
+    Returns
+    -------
+    list of str
+        The line, broken into as many as it needs.
+    """
+    if len(line) <= width or HEADING.match(line) or PROJECT_LINE.match(line):
+        return [line]
+    return textwrap.wrap(
+        line,
+        width=width,
+        subsequent_indent=" " * (indent_of(line) + 2),
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [line]
+
+
+def logical_lines(text):
+    """Return the document's lines with every broken one joined back up.
+
+    A line that is indented further than the line above it and does not
+    start something of its own is the rest of that line.  That is the
+    shape ``wrap`` writes, and it is also what somebody typing a
+    paragraph under a task does by hand, so both read the same way.
+
+    A line under the line naming a project is left alone, since that is
+    the project's description and not the rest of its name.
+
+    Parameters
+    ----------
+    text : str
+        The document as written.
+
+    Returns
+    -------
+    list of tuple of (int, str)
+        One line per thing the document says, each with the line of the
+        file it started on, so that an error names a line the writer can
+        find.
+    """
+    joined = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        carries_on = (
+            joined
+            and line.strip()
+            and joined[-1][1].strip()
+            and not MARKER.match(line)
+            and indent_of(line) > indent_of(joined[-1][1])
+            and not PROJECT_LINE.match(joined[-1][1])
+        )
+        if carries_on:
+            joined[-1] = (joined[-1][0], f"{joined[-1][1].rstrip()} {line.strip()}")
+        else:
+            joined.append((number, line))
+    return joined
 
 
 def parse_document(text, taken=()):
@@ -149,7 +238,7 @@ def parse_document(text, taken=()):
     """
     ids = set(taken) | set(re.findall(r"\^([\w.-]+)", text))
     state = _Reader(ids)
-    for number, line in enumerate(text.splitlines(), start=1):
+    for number, line in logical_lines(text):
         state.read(line, number)
     return state.result()
 

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from regolith.mc import ID_ALPHABET, ID_LENGTH, short_id, struck
+from regolith.mc import ID_ALPHABET, ID_LENGTH, WIDTH, logical_lines, short_id, struck, wrap
 
 
 @pytest.mark.parametrize(
@@ -53,3 +53,109 @@ def test_short_ids_do_not_repeat():
     for _ in range(500):
         ids.add(short_id(ids))
     assert len(ids) == 500
+
+
+LONG_TASK = (
+    "- [ ] 1.1.1  build an AI campaign using simple models such as random forest "
+    "to predict which samples are worth measuring  ^t1"
+)
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        # Test how a rendered line is broken to fit an editor that does not
+        # fold.  What carries on from a line is indented two further than it,
+        # which is what tells a reader, and the parser, that it is not new.
+        # C1: a line that already fits, expect it written as it is
+        ("- 1.1  a short goal  ^g1", ["- 1.1  a short goal  ^g1"]),
+        # C2: a long task, expect it broken with the rest indented under it
+        (
+            LONG_TASK,
+            [
+                "- [ ] 1.1.1  build an AI campaign using simple models such as random forest to",
+                "  predict which samples are worth measuring  ^t1",
+            ],
+        ),
+        # C3: a long sub task, expect the rest indented two further than it is
+        (
+            "  - [x] ~~a sub task whose text runs on well past the width a person can read " "comfortably~~  ^t2",
+            [
+                "  - [x] ~~a sub task whose text runs on well past the width a person can read",
+                "    comfortably~~  ^t2",
+            ],
+        ),
+        # C4: a heading longer than the width, expect it left alone, since a
+        # heading broken in two is no longer a heading
+        (
+            "# Mission control — Somebody With A Name That Runs On Much Longer Than It Needs To",
+            ["# Mission control — Somebody With A Name That Runs On Much Longer Than It Needs To"],
+        ),
+        # C5: the line naming a project, expect it left alone, since what is
+        # indented under a project is the project's description
+        (
+            "1. **a project whose name is far longer than anybody would want to type twice " "over**  ^p1",
+            ["1. **a project whose name is far longer than anybody would want to type twice " "over**  ^p1"],
+        ),
+        # C6: one word longer than the width, expect it left whole rather than
+        # broken, since a url or an id split in two is worse than a long line
+        (
+            "- 1.1  see https://example.com/a/path/that/is/far/longer/than/the/width/we/wrap/at/x  ^g1",
+            [
+                "- 1.1  see",
+                "  https://example.com/a/path/that/is/far/longer/than/the/width/we/wrap/at/x",
+                "  ^g1",
+            ],
+        ),
+    ],
+)
+def test_wrap_breaks_a_line_where_it_can_be_joined_back(line, expected):
+    assert wrap(line) == expected
+
+
+def test_wrap_writes_nothing_wider_than_the_width():
+    # Test the promise the width makes, over text with no break near it
+    written = wrap("- 1.1  " + " ".join(["word"] * 60) + "  ^g1")
+    assert max(len(line) for line in written) <= WIDTH
+
+
+@pytest.mark.parametrize(
+    "document, expected",
+    [
+        # Test which lines are read as the rest of the line above them.  A line
+        # indented further than the line above, that starts nothing of its own,
+        # carries it on.  This is what wrap writes and what somebody typing a
+        # paragraph under a task does by hand.
+        # C1: a line broken in two, expect one line back, numbered from where
+        # it started
+        (
+            "- [ ] 1.1.1  a task broken\n  over two lines  ^t1\n",
+            [(1, "- [ ] 1.1.1  a task broken over two lines  ^t1")],
+        ),
+        # C2: a sub task under a task, expect two lines, since a sub task
+        # starts something of its own
+        (
+            "- [ ] 1.1.1  a task  ^t1\n  - [ ] a sub task  ^t2\n",
+            [(1, "- [ ] 1.1.1  a task  ^t1"), (2, "  - [ ] a sub task  ^t2")],
+        ),
+        # C3: a description under the line naming a project, expect two lines,
+        # since that is what the project is about and not the rest of its name
+        (
+            "1. **a project**  ^p1\n   what it is about\n",
+            [(1, "1. **a project**  ^p1"), (2, "   what it is about")],
+        ),
+        # C4: a blank line between the two, expect two lines, since a paragraph
+        # somebody started is not the rest of the one before it
+        (
+            "   deliverable: a paper\n\n   what it is about\n",
+            [(1, "   deliverable: a paper"), (2, ""), (3, "   what it is about")],
+        ),
+        # C5: a line indented the same as the one above, expect two lines
+        (
+            "   deliverable: a paper\n   with: ascopatz\n",
+            [(1, "   deliverable: a paper"), (2, "   with: ascopatz")],
+        ),
+    ],
+)
+def test_logical_lines_joins_what_was_broken(document, expected):
+    assert logical_lines(document) == expected

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -11,6 +11,7 @@ from regolith.builders.missioncontrolbuilder import (
     in_document_order,
     week_of,
 )
+from regolith.mc import WIDTH, parse_document
 
 PROJECTS = [
     {
@@ -425,3 +426,43 @@ def test_what_a_project_is_about_is_written_under_it():
     builder.gtx = {"mc_projects": [described], "mc_goals": [], "mc_tasks": []}
     document = "\n".join(builder.documents()["pliu"])
     assert "   what this project is about" in document
+
+
+def test_a_project_is_written_as_paragraphs_markdown_can_render():
+    # Test that what is written under a project is separated by blank lines.
+    # Markdown runs consecutive lines into one paragraph, so without them a
+    # project reads as a single block wherever the document is rendered
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    described = dict(PROJECTS[0], project_description="what this project is about")
+    builder.gtx = {"mc_projects": [described], "mc_goals": [], "mc_tasks": []}
+    document = "\n".join(builder.documents()["pliu"])
+    assert "^p-pdf\n\n   deliverable: Submit the paper\n\n   with: " in document
+    assert "ascopatz, afriend\n\n   what this project is about\n" in document
+
+
+LONG = (
+    "build an AI campaign using simple models such as random forest to predict "
+    "which of the samples in the matrix are worth measuring at the beamline"
+)
+
+
+def test_a_wrapped_document_reads_back_the_same():
+    # Test the two halves against each other over text long enough to be
+    # broken several times: a project's description, a goal, a task and the sub
+    # task under it all come back whole, and no line is wider than the width
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], project_description=LONG)],
+        "mc_goals": [dict(GOALS[0], text=LONG)],
+        "mc_tasks": [
+            dict(TASKS[0], text=LONG),
+            dict(TASKS[0], _id="t-sub", parent="t-bg", text=f"a sub task, {LONG}"),
+        ],
+    }
+    lines = builder.documents()["pliu"]
+    read = parse_document("\n".join(lines) + "\n")
+    assert max(len(line) for line in lines) <= WIDTH
+    assert read["projects"][0]["project_description"] == LONG
+    assert read["goals"][0]["text"] == LONG
+    assert [task["text"] for task in read["tasks"]] == [LONG, f"a sub task, {LONG}"]
+    assert read["tasks"][1]["parent"] == read["tasks"][0]["_id"]


### PR DESCRIPTION
The documents are edited in a text editor rather than a markdown one, and a goal or a task can run to a paragraph, so finding the end of a line was a chore.  mc.wrap breaks a written line at 79 characters and mc.logical_lines joins one back up, a line indented further than the line above it and starting nothing of its own being the rest of it.  That is also what somebody typing a paragraph under a task does by hand, so both read alike, and a line of any length is still accepted.

A heading and the line naming a project are left long: the first stops being a heading if it is broken, and what is indented under the second is the project's description rather than the rest of its name.

missioncontrolbuilder also separates what is written under a project with blank lines.  Markdown runs consecutive lines into one paragraph, so a project rendered as markdown was a single block of text.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64