### PR TITLE
fix: name a project typed into a document by its name, not at random

### DIFF
--- a/news/mc-readable-project-ids.rst
+++ b/news/mc-readable-project-ids.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -18,32 +18,12 @@ from gooey import GooeyParser
 
 from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import short_id
+from regolith.mc import short_id, slug
 from regolith.schemas import MC_STATI
 from regolith.tools import all_docs_from_collection
 
 TARGET_COLL = "mc_projects"
 HELPER_TARGET = "a_mcproject"
-
-
-def slug(text):
-    """Return a name as an id someone would be willing to type.
-
-    Parameters
-    ----------
-    text : str
-        The name of the project.
-
-    Returns
-    -------
-    str
-        The name in lower case with anything but letters, numbers and
-        hyphens replaced by a hyphen.
-    """
-    # an underscore becomes a hyphen along with everything else that is not a
-    # letter or a number: underscores in ids are being retired
-    kept = [c if (c.isalnum() or c == "-") else "-" for c in text.lower()]
-    return "-".join(part for part in "".join(kept).split("-") if part)
 
 
 def subparser(subpi):

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -111,11 +111,24 @@ class MCSyncHelper(DbHelperBase):
         tasks = {task["_id"]: task for task in live(self.gtx["mc_tasks"]) if task.get("goal") in goals}
         return {"mc_projects": projects, "mc_goals": goals, "mc_tasks": tasks}
 
+    def taken(self):
+        """Return every id mission control holds.
+
+        A project is given an id made from its name, so unlike a drawn
+        id it can be one somebody else's document already has.
+
+        Returns
+        -------
+        set of str
+            The ids in use across the mission control collections.
+        """
+        return {record["_id"] for collection in COLLECTIONS for record in self.gtx[collection]}
+
     def read_one(self, path, person):
         """Read one document and write what it says."""
         rc = self.rc
         try:
-            parsed = parse_document(path.read_text(encoding="utf-8"))
+            parsed = parse_document(path.read_text(encoding="utf-8"), taken=self.taken())
         except DocumentError as error:
             print(f"{path.name} was not read and nothing was written from it: {error}")
             print("Fix the line it names and run this again.")

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -44,6 +44,59 @@ def short_id(taken=(), length=ID_LENGTH):
             return candidate
 
 
+def slug(text):
+    """Return a name as an id someone would be willing to type.
+
+    Parameters
+    ----------
+    text : str
+        The name of the project.
+
+    Returns
+    -------
+    str
+        The name in lower case with anything but letters, numbers and
+        hyphens replaced by a hyphen.
+    """
+    # an underscore becomes a hyphen along with everything else that is not a
+    # letter or a number: underscores in ids are being retired
+    kept = [c if (c.isalnum() or c == "-") else "-" for c in text.lower()]
+    return "-".join(part for part in "".join(kept).split("-") if part)
+
+
+def project_id(name, taken=()):
+    """Return the id to give a project somebody has just named.
+
+    A project id is the one id here that a person reads and types: it
+    names the project in a lister, in a grant, and in whatever refers to
+    it later.  So it is made from the name rather than drawn at random,
+    the way the adder helper makes one, and a name that two projects
+    share is numbered rather than made unreadable.
+
+    Parameters
+    ----------
+    name : str
+        The name of the project.
+    taken : iterable of str, optional
+        The ids already in use.
+
+    Returns
+    -------
+    str
+        The id, or a short one when the name makes no id at all.
+    """
+    taken = set(taken)
+    stem = slug(name)
+    if not stem:
+        return short_id(taken)
+    if stem not in taken:
+        return stem
+    nth = 2
+    while f"{stem}-{nth}" in taken:
+        nth += 1
+    return f"{stem}-{nth}"
+
+
 def struck(text, status):
     """Return the text struck through when the thing is finished.
 
@@ -215,7 +268,9 @@ def parse_document(text, taken=()):
 
     A line with no ``^id`` is something somebody typed, and is given one.
     Ids are the only thing here that is not the person's to write, so
-    they are minted rather than demanded.
+    they are minted rather than demanded.  A project is given an id made
+    from its name, since that is the one id anybody reads or types; a
+    goal or a task is given a short one.
 
     Parameters
     ----------
@@ -263,6 +318,13 @@ class _Reader:
 
     def mint(self):
         _id = short_id(self.ids)
+        self.ids.add(_id)
+        return _id
+
+    def mint_project(self, name):
+        """Return an id made from a project's name, as the adder makes
+        one."""
+        _id = project_id(name, self.ids)
         self.ids.add(_id)
         return _id
 
@@ -331,7 +393,7 @@ class _Reader:
             return False
         text, struck_out = read_text(found.group("text"))
         project = {
-            "_id": found.group("id") or self.mint(),
+            "_id": found.group("id") or self.mint_project(text),
             "name": text,
             "status": "finished" if struck_out else "active",
         }

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -7,8 +7,8 @@ import os
 import pytest
 
 from regolith.database import connect
-from regolith.helpers.a_mcprojecthelper import slug
 from regolith.main import main
+from regolith.mc import slug
 from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
 
 

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -2,7 +2,16 @@
 
 import pytest
 
-from regolith.mc import ID_ALPHABET, ID_LENGTH, WIDTH, logical_lines, short_id, struck, wrap
+from regolith.mc import (
+    ID_ALPHABET,
+    ID_LENGTH,
+    WIDTH,
+    logical_lines,
+    project_id,
+    short_id,
+    struck,
+    wrap,
+)
 
 
 @pytest.mark.parametrize(
@@ -159,3 +168,34 @@ def test_wrap_writes_nothing_wider_than_the_width():
 )
 def test_logical_lines_joins_what_was_broken(document, expected):
     assert logical_lines(document) == expected
+
+
+@pytest.mark.parametrize(
+    "name, taken, expected_id",
+    [
+        # Test the id a project is given when somebody names one.  It is the
+        # one id here that a person reads and types, naming the project in a
+        # lister and in whatever refers to it later, so it is made from the
+        # name rather than drawn at random.
+        # C1: a plain name, expect it in lower case with hyphens
+        ("Shock compressed WC", (), "shock-compressed-wc"),
+        # C2: a name already used by another project, expect it numbered,
+        # since two projects can be called the same thing
+        ("Shock compressed WC", ("shock-compressed-wc",), "shock-compressed-wc-2"),
+        # C3: a name used twice already, expect the next number
+        (
+            "Shock compressed WC",
+            ("shock-compressed-wc", "shock-compressed-wc-2"),
+            "shock-compressed-wc-3",
+        ),
+        # C4: a name of punctuation, which makes no id at all, expect a short
+        # id rather than nothing
+        ("!!!", (), None),
+    ],
+)
+def test_project_id_is_made_from_the_name(name, taken, expected_id):
+    made = project_id(name, taken)
+    if expected_id is None:
+        assert len(made) == ID_LENGTH and set(made) <= set(ID_ALPHABET)
+    else:
+        assert made == expected_id

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -308,3 +308,20 @@ def test_going_deeper_and_back_out_again_follows_the_indent():
     assert tasks["t3"]["parent"] == "t2"
     assert tasks["t4"]["parent"] == "t1"
     assert "parent" not in tasks["t5"]
+
+
+def test_a_project_typed_into_a_document_is_named_by_its_name():
+    # Test that typing a project in gives it the same readable id the adder
+    # helper would give it.  A project id is the one id somebody reads and
+    # types, so a drawn one would make the collections hard to work with
+    text = DOCUMENT.replace("1. **nanodiamond-pdf**  ^ak-nano", "1. **Nanodiamond PDF**")
+    project = parse_document(text)["projects"][0]
+    assert project["_id"] == "nanodiamond-pdf"
+
+
+def test_a_project_does_not_take_an_id_another_one_has():
+    # Test that a name somebody else has used already is numbered rather than
+    # written over, since two people can name a project the same thing
+    text = DOCUMENT.replace("1. **nanodiamond-pdf**  ^ak-nano", "1. **Nanodiamond PDF**")
+    project = parse_document(text, taken={"nanodiamond-pdf"})["projects"][0]
+    assert project["_id"] == "nanodiamond-pdf-2"

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -214,3 +214,19 @@ def test_what_was_dropped_is_not_dropped_again(mc_repo, capsys):
     main(["helper", "mc_sync"])
     assert "dropped 0" in capsys.readouterr().out
     assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "dropped"
+
+
+def test_a_project_typed_in_is_stored_under_a_readable_id(mc_repo):
+    # Test that a project somebody types into their document gets the same
+    # readable id the adder helper gives one, since a project id is what names
+    # it in a lister and in whatever refers to it later
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(
+        path.read_text().replace(
+            "1. **a project**  ^mc-a-project",
+            "1. **a project**  ^mc-a-project\n\n2. **A Second Project**",
+        )
+    )
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, "mc_projects", "a-second-project")["name"] == "A Second Project"


### PR DESCRIPTION
The adder helper made a project id from the name, but mc.parse_document drew a short id for anything typed without one, so the same project got "p9x2mt" from a document and "shock-compressed-wc" from the CLI.  A project id is the one id here that a person reads and types, naming the project in a lister and in whatever refers to it later, so a drawn one made the collections hard to work with.

mc.project_id makes it, and slug moves to mc.py beside it now that both paths use it.  A name another project already has is numbered rather than written over, and mcsynchelper tells the parser every id mission control holds, since unlike a drawn id a name can be one another document has used.  Goals and tasks keep their short ids: nobody reads those.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64