### PR TITLE
fix: read the mission control documents that are there, not the ones …

### DIFF
--- a/news/mc-sync-reads-what-is-on-disk.rst
+++ b/news/mc-sync-reads-what-is-on-disk.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 from gooey import GooeyParser
 
-from regolith.builders.missioncontrolbuilder import UNASSIGNED, MissionControlBuilder, live
+from regolith.builders.missioncontrolbuilder import (
+    UNASSIGNED,
+    UNASSIGNED_NAME,
+    MissionControlBuilder,
+    live,
+)
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.mc import DocumentError, changes, parse_document
 from regolith.schemas import SCHEMAS, validate
@@ -72,17 +77,46 @@ class MCSyncHelper(DbHelperBase):
             print("Run 'regolith build mission-control' to write them first.")
             return
 
-        for person in self.people(renderer):
-            path = mcdir / f"{renderer.document_name(person)}.md"
-            if path.is_file():
-                self.read_one(path, person)
+        for path, person in self.documents(mcdir, renderer):
+            self.read_one(path, person)
         return
 
-    def people(self, renderer):
-        """Return everyone a document could belong to, and the
-        orphans."""
-        leads = {project.get("lead") or UNASSIGNED for project in live(self.gtx["mc_projects"])}
-        return sorted(leads | {UNASSIGNED})
+    def documents(self, mcdir, renderer):
+        """Return each document in the directory, with whose it is.
+
+        The documents are what there is to read, so they are what is
+        read.  Working the list out from the projects in the collections
+        instead would pass over the document of somebody who has no
+        project in them, and that is exactly the person whose document
+        is asking for one to be made.
+
+        Parameters
+        ----------
+        mcdir : pathlib.Path
+            The directory the documents are in.
+        renderer : MissionControlBuilder
+            The builder, which knows what each person's document is
+            called.
+
+        Returns
+        -------
+        list of tuple of (pathlib.Path, str)
+            Each document and the id of the person whose it is.
+        """
+        whose = {UNASSIGNED_NAME: UNASSIGNED}
+        for person in self.gtx["people"]:
+            whose.setdefault(renderer.document_name(person["_id"]), person["_id"])
+        for project in self.gtx["mc_projects"]:
+            if project.get("lead"):
+                whose.setdefault(renderer.document_name(project["lead"]), project["lead"])
+        found = []
+        for path in sorted(mcdir.glob("*.md")):
+            if path.stem in whose:
+                found.append((path, whose[path.stem]))
+            else:
+                print(f"{path.name} is not named for anybody, so nothing was read from it.")
+                print("Name it for the person whose it is, or add them to the people collection.")
+        return found
 
     def mine(self, person):
         """Return the records already stored for one person.

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -230,3 +230,25 @@ def test_a_project_typed_in_is_stored_under_a_readable_id(mc_repo):
     )
     main(["helper", "mc_sync"])
     assert stored(mc_repo, "mc_projects", "a-second-project")["name"] == "A Second Project"
+
+
+def test_a_document_is_read_even_when_the_collections_hold_nothing_of_its_own(mc_repo):
+    # Test that a document is read on its own account.  Somebody whose project
+    # has gone from the collections still has the document that describes it,
+    # and that document is how they put it back, so working out which
+    # documents to read from the collections would pass over the one that
+    # matters most
+    tmp_path, mcdir = mc_repo
+    dump_yaml(tmp_path / "db" / "mc_projects.yaml", {})
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, "mc_projects", "mc-a-project")["name"] == "a project"
+
+
+def test_a_document_named_for_nobody_says_so(mc_repo, capsys):
+    # Test that a file nobody is named by is reported rather than passed over
+    # in silence, since a document that is never read looks exactly like one
+    # that had nothing to say
+    _, mcdir = mc_repo
+    (mcdir / "whoever.md").write_text("# Mission control — Whoever\n")
+    main(["helper", "mc_sync"])
+    assert "whoever.md is not named for anybody" in capsys.readouterr().out


### PR DESCRIPTION
…the collections imply

mcsynchelper worked out which documents to read from the projects in the collections: a person was read only if a project in the database named them as its lead.  So a person whose projects had gone from the database had their document passed over entirely, which is the one case where the document is the only copy of what it says and reading it back is the whole point.

Deleting a project from the yaml therefore made its owner's document unreadable rather than restorable, and after the dropped record fix it went further: a person whose every project was dropped fell out of the list too, so deleting a project from a document made that document unreadable ever after.

The documents in the directory are what there is to read, so they are what is read, and whose each one is comes from the people collection.  A file named for nobody says so rather than being passed over in silence.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64