### PR TITLE
feat: put the lead's initials in front of a project id

### DIFF
--- a/news/mc-project-ids-carry-the-lead.rst
+++ b/news/mc-project-ids-carry-the-lead.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -18,7 +18,7 @@ from gooey import GooeyParser
 
 from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import short_id, slug
+from regolith.mc import UNLED_PREFIX, initials, project_id, slug
 from regolith.schemas import MC_STATI
 from regolith.tools import all_docs_from_collection
 
@@ -75,7 +75,7 @@ class MCProjectAdderHelper(DbHelperBase):
     """Add a project to mission control."""
 
     btype = HELPER_TARGET
-    needed_colls = [f"{TARGET_COLL}"]
+    needed_colls = [f"{TARGET_COLL}", "people"]
 
     def construct_global_ctx(self):
         """Constructs the global context."""
@@ -85,13 +85,25 @@ class MCProjectAdderHelper(DbHelperBase):
         if not rc.database:
             rc.database = rc.databases[0]["name"]
         self.gtx[rc.coll] = sorted(all_docs_from_collection(rc.client, rc.coll), key=_id_key)
+        self.gtx["people"] = list(all_docs_from_collection(rc.client, "people"))
+
+    def prefix(self):
+        """Return the initials a project of this lead's is named
+        with."""
+        rc = self.rc
+        if not rc.lead:
+            return UNLED_PREFIX
+        for entry in self.gtx["people"]:
+            if entry["_id"] == rc.lead:
+                return initials(entry.get("name") or rc.lead)
+        return slug(rc.lead)
 
     def db_updater(self):
         rc = self.rc
         taken = {project["_id"] for project in self.gtx[rc.coll]}
         # an id given by hand goes through the same slug, so an underscore
         # cannot get in that way either
-        _id = slug(rc._id) if rc._id else (slug(rc.name) or short_id(taken))
+        _id = slug(rc._id) if rc._id else project_id(rc.name, prefix=self.prefix())
         if _id in taken:
             raise ValueError(
                 f"There is already a project called {_id}. Give it another name, or "

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -21,7 +21,7 @@ from regolith.builders.missioncontrolbuilder import (
     live,
 )
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import DocumentError, changes, parse_document
+from regolith.mc import UNLED_PREFIX, DocumentError, changes, initials, parse_document, slug
 from regolith.schemas import SCHEMAS, validate
 from regolith.tools import all_docs_from_collection
 
@@ -158,11 +158,34 @@ class MCSyncHelper(DbHelperBase):
         """
         return {record["_id"] for collection in COLLECTIONS for record in self.gtx[collection]}
 
+    def prefix(self, person):
+        """Return what a project typed into one document is named with.
+
+        Parameters
+        ----------
+        person : str
+            The id of the person whose document it is, or
+            ``unassigned``.
+
+        Returns
+        -------
+        str
+            Their initials, or ``na`` for the document of nobody.
+        """
+        if person == UNASSIGNED:
+            return UNLED_PREFIX
+        for entry in self.gtx["people"]:
+            if entry["_id"] == person:
+                return initials(entry.get("name") or person)
+        return slug(person)
+
     def read_one(self, path, person):
         """Read one document and write what it says."""
         rc = self.rc
         try:
-            parsed = parse_document(path.read_text(encoding="utf-8"), taken=self.taken())
+            parsed = parse_document(
+                path.read_text(encoding="utf-8"), taken=self.taken(), prefix=self.prefix(person)
+            )
         except DocumentError as error:
             print(f"{path.name} was not read and nothing was written from it: {error}")
             print("Fix the line it names and run this again.")

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -64,7 +64,34 @@ def slug(text):
     return "-".join(part for part in "".join(kept).split("-") if part)
 
 
-def project_id(name, taken=()):
+UNLED_PREFIX = "na"
+
+
+def initials(name):
+    """Return the initials a project of somebody's is named with.
+
+    Parameters
+    ----------
+    name : str
+        The name of the person, as the people collection has it.
+
+    Returns
+    -------
+    str
+        The first letter of their first name and of their last, in lower
+        case, which is how the group has always shortened a name.  A
+        middle name is passed over, so that Simon J. L. Billinge is sb
+        rather than sjlb.
+    """
+    parts = name.split()
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0][0].lower()
+    return f"{parts[0][0]}{parts[-1][0]}".lower()
+
+
+def project_id(name, taken=(), prefix=None):
     """Return the id to give a project somebody has just named.
 
     A project id is the one id here that a person reads and types: it
@@ -73,12 +100,21 @@ def project_id(name, taken=()):
     the way the adder helper makes one, and a name that two projects
     share is numbered rather than made unreadable.
 
+    Whose project it is comes first, as the initials of the person
+    leading it.  Group members name their projects alike -- there is a
+    software maintenance in most of them -- so without that the second
+    one to be written down would be the first one numbered, and neither
+    id would say whose it was.
+
     Parameters
     ----------
     name : str
         The name of the project.
     taken : iterable of str, optional
         The ids already in use.
+    prefix : str, optional
+        What to put in front, which is the initials of whoever leads it,
+        or ``na`` for a project nobody leads.
 
     Returns
     -------
@@ -87,6 +123,8 @@ def project_id(name, taken=()):
     """
     taken = set(taken)
     stem = slug(name)
+    if stem and prefix:
+        stem = f"{slug(prefix)}-{stem}"
     if not stem:
         return short_id(taken)
     if stem not in taken:
@@ -256,7 +294,7 @@ def logical_lines(text):
     return joined
 
 
-def parse_document(text, taken=()):
+def parse_document(text, taken=(), prefix=None):
     """Return the projects, goals and tasks a mission control document
     describes.
 
@@ -279,6 +317,9 @@ def parse_document(text, taken=()):
     taken : iterable of str, optional
         Ids in use elsewhere, so a newly minted one does not collide with
         another person's document.
+    prefix : str, optional
+        What to put in front of the id of a project typed in here, which
+        is the initials of whoever the document belongs to.
 
     Returns
     -------
@@ -293,7 +334,7 @@ def parse_document(text, taken=()):
         When a recognised line cannot be placed, naming the line.
     """
     ids = set(taken) | set(re.findall(r"\^([\w.-]+)", text))
-    state = _Reader(ids)
+    state = _Reader(ids, prefix)
     for number, line in logical_lines(text):
         state.read(line, number)
     return state.result()
@@ -303,8 +344,9 @@ class _Reader:
     """Reads a document a line at a time, holding where it has got
     to."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, prefix=None):
         self.ids = set(ids)
+        self.prefix = prefix
         self.person = None
         self.projects = []
         self.goals = []
@@ -324,7 +366,7 @@ class _Reader:
     def mint_project(self, name):
         """Return an id made from a project's name, as the adder makes
         one."""
-        _id = project_id(name, self.ids)
+        _id = project_id(name, self.ids, self.prefix)
         self.ids.add(_id)
         return _id
 

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -76,7 +76,9 @@ def test_a_project_is_stored_with_what_was_given(make_db):
     rc._update(load_rcfile("regolithrc.json"))
     filter_databases(rc)
     with connect(rc) as rc.client:
-        project = rc.client.get("mc_projects", "grain-boundaries")
+        # the id carries whose project it is, so that two people naming a
+        # project the same thing do not clash
+        project = rc.client.get("mc_projects", "sb-grain-boundaries")
     assert project["lead"] == "sbillinge"
     assert project["collaborators"] == ["ascopatz", "afriend"]
     assert project["grants"] == ["dmref15"]

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -6,6 +6,7 @@ from regolith.mc import (
     ID_ALPHABET,
     ID_LENGTH,
     WIDTH,
+    initials,
     logical_lines,
     project_id,
     short_id,
@@ -199,3 +200,52 @@ def test_project_id_is_made_from_the_name(name, taken, expected_id):
         assert len(made) == ID_LENGTH and set(made) <= set(ID_ALPHABET)
     else:
         assert made == expected_id
+
+
+@pytest.mark.parametrize(
+    "name, expected_initials",
+    [
+        # Test how a name is shortened for the front of a project id, which is
+        # how the group has always shortened one
+        # C1: a first name and a last, expect the first letter of each
+        ("Adib Kabir", "ak"),
+        # C2: middle names as well, expect them passed over rather than piled
+        # up, so that Simon J. L. Billinge is sb
+        ("Simon J. L. Billinge", "sb"),
+        # C3: one name only, expect the one letter
+        ("Prince", "p"),
+        # C4: no name at all, expect nothing rather than an error
+        ("", ""),
+    ],
+)
+def test_initials_shorten_a_name_the_way_the_group_does(name, expected_initials):
+    assert initials(name) == expected_initials
+
+
+@pytest.mark.parametrize(
+    "name, taken, prefix, expected_id",
+    [
+        # Test that a project id says whose project it is.  Group members name
+        # their projects alike, so without that the second software
+        # maintenance to be written down would be the first one numbered, and
+        # neither id would say whose it was.
+        # C1: a lead, expect their initials in front
+        ("Software maintenance", (), "ak", "ak-software-maintenance"),
+        # C2: nobody leading it, expect na in front, since it is nobody's
+        # until somebody picks it up
+        ("Software maintenance", (), "na", "na-software-maintenance"),
+        # C3: the same name led by somebody else, expect no clash at all
+        ("Software maintenance", ("ak-software-maintenance",), "sb", "sb-software-maintenance"),
+        # C4: the same name led by the same person, expect it numbered
+        (
+            "Software maintenance",
+            ("ak-software-maintenance",),
+            "ak",
+            "ak-software-maintenance-2",
+        ),
+        # C5: no prefix given, expect the name alone
+        ("Software maintenance", (), None, "software-maintenance"),
+    ],
+)
+def test_a_project_id_says_whose_project_it_is(name, taken, prefix, expected_id):
+    assert project_id(name, taken, prefix) == expected_id

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -229,7 +229,7 @@ def test_a_project_typed_in_is_stored_under_a_readable_id(mc_repo):
         )
     )
     main(["helper", "mc_sync"])
-    assert stored(mc_repo, "mc_projects", "a-second-project")["name"] == "A Second Project"
+    assert stored(mc_repo, "mc_projects", "pl-a-second-project")["name"] == "A Second Project"
 
 
 def test_a_document_is_read_even_when_the_collections_hold_nothing_of_its_own(mc_repo):
@@ -252,3 +252,15 @@ def test_a_document_named_for_nobody_says_so(mc_repo, capsys):
     (mcdir / "whoever.md").write_text("# Mission control — Whoever\n")
     main(["helper", "mc_sync"])
     assert "whoever.md is not named for anybody" in capsys.readouterr().out
+
+
+def test_a_project_nobody_leads_is_named_na(mc_repo):
+    # Test that a project typed into the unassigned document is named na, so
+    # that it reads as nobody's until somebody picks it up, and does not clash
+    # with a project of the same name that somebody leads
+    _, mcdir = mc_repo
+    (mcdir / "unassigned.md").write_text(
+        "# Mission control — unassigned\n\n## Projects\n\n1. **Software maintenance**\n"
+    )
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, "mc_projects", "na-software-maintenance")["status"] == "proposed"


### PR DESCRIPTION
Group members name their projects alike; there is a software maintenance in most of them.  So a project id made from the name alone would have the second one written down be the first one numbered, and neither id would say whose it was.

mc.project_id takes a prefix and mc.initials makes one from a name, first letter and last as the group has always shortened one, so that Simon J. L. Billinge is sb rather than sjlb.  Both paths that name a project pass one: mcsynchelper from whose document it is, and a_mcproject from the lead given on the command line.  A project nobody leads is na, in either path, so it reads as nobody's until somebody picks it up.

An id given to a_mcproject by hand is untouched, as before.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64