### PR TITLE
fix: keep the order a document was typed in, not only the order of it…

### DIFF
--- a/news/mc-document-controls-the-order.rst
+++ b/news/mc-document-controls-the-order.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
-from regolith.mc import struck, wrap
+from regolith.mc import DocumentError, parse_document, struck, wrap
 from regolith.tools import all_docs_from_collection
 
 UNASSIGNED = "unassigned"
@@ -74,6 +74,43 @@ def ids_in_document(text):
     return seen
 
 
+def label(item):
+    """Return what a record is called, which is how a document names it
+    when it carries no id."""
+    return item.get("name") or item.get("text")
+
+
+def keys_in_document(text):
+    """Return what a document names, in the order it names them.
+
+    A line carries an id once a render has put one there, but a document
+    somebody typed carries none at all, and the order they typed is
+    still the order they chose.  So each thing is listed by its id and
+    by its text, and a render finds it either way.
+
+    Parameters
+    ----------
+    text : str
+        The document to read.
+
+    Returns
+    -------
+    list of str
+        The ids and the texts, in the order they appear, each once.
+    """
+    try:
+        read = parse_document(text)
+    except DocumentError:
+        # a document that cannot be read at all still has its ids
+        return ids_in_document(text)
+    keys = []
+    for record in read["projects"] + read["goals"] + read["tasks"]:
+        for key in (record["_id"], label(record)):
+            if key and key not in keys:
+                keys.append(key)
+    return keys
+
+
 def in_document_order(items, order, fallback_key):
     """Return items in the order a document put them in.
 
@@ -86,7 +123,8 @@ def in_document_order(items, order, fallback_key):
     items : list of dict
         The items to order.
     order : list of str
-        The ids the document carries, in order.
+        What the document names, in order: an id where a line carries
+        one and the text of the line where it does not.
     fallback_key : callable
         The sort key for items the document does not mention.
 
@@ -95,9 +133,16 @@ def in_document_order(items, order, fallback_key):
     list of dict
         The items, ordered.
     """
-    position = {_id: n for n, _id in enumerate(order)}
-    known = sorted((i for i in items if i["_id"] in position), key=lambda i: position[i["_id"]])
-    unknown = sorted((i for i in items if i["_id"] not in position), key=fallback_key)
+    position = {key: n for n, key in enumerate(order)}
+
+    def where(item):
+        """Return where the document put an item, or None for one it
+        does not name."""
+        found = position.get(item["_id"])
+        return position.get(label(item)) if found is None else found
+
+    known = sorted((i for i in items if where(i) is not None), key=where)
+    unknown = sorted((i for i in items if where(i) is None), key=fallback_key)
     return known + unknown
 
 
@@ -204,11 +249,11 @@ class MissionControlBuilder(BuilderBase):
             path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     def existing_orders(self):
-        """Return the id order of each document already in the build
-        dir."""
+        """Return what each document already in the build dir names, in
+        order."""
         by_name = {}
         for path in self.mcdir.glob("*.md"):
-            by_name[path.stem] = ids_in_document(path.read_text(encoding="utf-8"))
+            by_name[path.stem] = keys_in_document(path.read_text(encoding="utf-8"))
         people = {p.get("lead") or UNASSIGNED for p in self.gtx["mc_projects"]}
         return {person: by_name.get(self.document_name(person), []) for person in people}
 

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -9,6 +9,7 @@ from regolith.builders.missioncontrolbuilder import (
     as_date,
     ids_in_document,
     in_document_order,
+    keys_in_document,
     week_of,
 )
 from regolith.mc import WIDTH, parse_document
@@ -512,3 +513,65 @@ def test_a_wrapped_document_reads_back_the_same():
     assert read["goals"][0]["text"] == LONG
     assert [task["text"] for task in read["tasks"]] == [LONG, f"a sub task, {LONG}"]
     assert read["tasks"][1]["parent"] == read["tasks"][0]["_id"]
+
+
+TYPED_BY_HAND = """# Mission control — Pei Liu
+
+## Projects
+
+1. **GPU solver**
+
+2. **Nanoparticle structure from the PDF**
+
+## Goals — 2026Q3
+
+- 2.1  Draft the methods section
+- 2.2  Get the fits converging
+"""
+
+
+def test_a_document_with_no_ids_still_says_what_order_it_is_in():
+    # Test that a document somebody typed keeps the order they typed.  A line
+    # carries an id only once a render has put one there, so until then the
+    # text of the line is what says which thing it is, and without that a
+    # render sorts by id and hands back an order nobody chose
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(p, lead="pliu") for p in PROJECTS],
+        "mc_goals": GOALS,
+        "mc_tasks": TASKS,
+    }
+    document = "\n".join(builder.documents({"pliu": keys_in_document(TYPED_BY_HAND)})["pliu"])
+    assert "1. **GPU solver**  ^p-orphan" in document
+    assert "2. **Nanoparticle structure from the PDF**  ^p-pdf" in document
+    assert "- 2.1  Draft the methods section  ^g-methods" in document
+
+
+@pytest.mark.parametrize(
+    "document, expected_keys",
+    [
+        # Test what a document is read as naming, which is what a render puts
+        # back in order.
+        # C1: lines carrying ids, expect the ids and the texts both, so that
+        # either finds the thing again
+        (
+            "## Projects\n\n1. **A project**  ^p1\n",
+            ["p1", "A project"],
+        ),
+        # C2: a line carrying no id, expect its text, since that is all it
+        # says about which thing it is
+        (
+            "## Projects\n\n1. **A project**\n",
+            ["A project"],
+        ),
+        # C3: a document that cannot be read at all, expect the ids it carries
+        # rather than nothing, since a broken file still says something
+        (
+            "## Goals — 2026Q3\n\n- 9.9  a goal of no project  ^g9\n",
+            ["g9"],
+        ),
+    ],
+)
+def test_keys_in_document_reads_ids_and_texts(document, expected_keys):
+    keys = keys_in_document(document)
+    assert [key for key in keys if key in expected_keys] == expected_keys


### PR DESCRIPTION
…s ids

missioncontrolbuilder kept the order of a document by reading the ^ids out of it, and a line carries one only once a render has put it there. So a document somebody typed carried none, the render found no order at all, and fell back to sorting by id: a project typed second came back first because its id happened to sort earlier, and every goal and task was renumbered to follow.

That is backwards for a document people are meant to type into.  A line with no id still says which thing it is, in its text, so keys_in_document lists both and in_document_order finds a thing by either.  A document that cannot be read at all still gives up its ids, as before.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64