### PR TITLE
fix: follow a line's id when the line turns out to be one already stored

### DIFF
--- a/news/mc-adopted-ids-fix-references.rst
+++ b/news/mc-adopted-ids-fix-references.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -644,9 +644,17 @@ def changes(parsed, person, existing, today=None):
     today = today or dt.date.today()
     writes = {"mc_projects": [], "mc_goals": [], "mc_tasks": []}
     seen = {"mc_projects": set(), "mc_goals": set(), "mc_tasks": set()}
+    # what a line was given while reading, against what it turned out to be.
+    # A goal says which project it is of by the id the reader gave that
+    # project, so when the project turns out to be one already stored, every
+    # reference to it has to follow it
+    adopted = {}
 
     for read in parsed["projects"]:
+        given = read["_id"]
         was = adopt(read, existing["mc_projects"], seen["mc_projects"])
+        if read["_id"] != given:
+            adopted[given] = read["_id"]
         record = dict(was)
         record.update({k: v for k, v in read.items() if k != "status"})
         # a project written into somebody's document is one that somebody is
@@ -664,7 +672,11 @@ def changes(parsed, person, existing, today=None):
         seen["mc_projects"].add(record["_id"])
 
     for read in parsed["goals"]:
+        given = read["_id"]
+        read["project"] = adopted.get(read["project"], read["project"])
         was = adopt(read, existing["mc_goals"], seen["mc_goals"])
+        if read["_id"] != given:
+            adopted[given] = read["_id"]
         record = dict(was)
         record.update({k: v for k, v in read.items() if k != "status"})
         record["status"] = settled_status(read["status"], was.get("status"))
@@ -675,7 +687,13 @@ def changes(parsed, person, existing, today=None):
         seen["mc_goals"].add(record["_id"])
 
     for read in parsed["tasks"]:
+        given = read["_id"]
+        read["goal"] = adopted.get(read["goal"], read["goal"])
+        if read.get("parent"):
+            read["parent"] = adopted.get(read["parent"], read["parent"])
         was = adopt(read, existing["mc_tasks"], seen["mc_tasks"])
+        if read["_id"] != given:
+            adopted[given] = read["_id"]
         record = dict(was)
         record.update({k: v for k, v in read.items() if k != "status"})
         record["status"] = settled_status(read["status"], was.get("status"))

--- a/tests/test_mc_changes.py
+++ b/tests/test_mc_changes.py
@@ -201,3 +201,80 @@ def test_a_project_takes_its_status_from_whose_document_it_is_in(person, was, ex
     stored_projects = [dict(typed, status=was)] if was else []
     writes, _ = changes(parsed(projects=[typed]), person, existing(projects=stored_projects), today=TODAY)
     assert writes["mc_projects"][0]["status"] == expected_status
+
+
+def read_project(**kw):
+    """Return a project line as the parser hands it over."""
+    base = {"_id": "minted-p", "name": "shock", "status": "active"}
+    base.update(kw)
+    return base
+
+
+def read_task(**kw):
+    """Return a task line as the parser hands it over."""
+    base = {
+        "_id": "minted-t",
+        "goal": "minted-g",
+        "text": "a task",
+        "status": "active",
+        "due_date": dt.date(2026, 9, 14),
+    }
+    base.update(kw)
+    return base
+
+
+STORED_PROJECT = {"_id": "pl-shock", "name": "shock", "status": "active", "lead": "pliu"}
+STORED_TASK = {"_id": "t-old", "goal": "g-old", "text": "a task", "status": "active"}
+
+
+def written(writes, collection):
+    """Return what was written to one collection, keyed by id."""
+    return {record["_id"]: record for record in writes[collection]}
+
+
+def test_a_reference_follows_the_line_it_points_at():
+    # Test a document typed by hand, where no line carries an id.  The reader
+    # gives every line a new one and adopt then matches each to what is
+    # already stored, so a goal saying which project it is of, and a task
+    # saying which goal, are pointing at ids that turned out to be somebody
+    # else's.  Left alone the goal and the task hang off nothing and vanish
+    # from the next render.
+    document = parsed(
+        projects=[read_project()],
+        goals=[read(_id="minted-g", project="minted-p")],
+        tasks=[read_task()],
+    )
+    writes, drops = changes(
+        document,
+        "pliu",
+        existing(
+            projects=[STORED_PROJECT],
+            goals=[stored(_id="g-old", project="pl-shock")],
+            tasks=[STORED_TASK],
+        ),
+        today=TODAY,
+    )
+    assert written(writes, "mc_goals")["g-old"]["project"] == "pl-shock"
+    assert written(writes, "mc_tasks")["t-old"]["goal"] == "g-old"
+    assert drops == {"mc_projects": [], "mc_goals": [], "mc_tasks": []}
+
+
+def test_a_sub_task_follows_the_task_it_hangs_off():
+    # Test the same for a sub task, which says which task it is under rather
+    # than which goal
+    document = parsed(
+        projects=[read_project()],
+        goals=[read(_id="minted-g", project="minted-p")],
+        tasks=[read_task(), read_task(_id="minted-sub", parent="minted-t", text="a sub task")],
+    )
+    writes, _ = changes(
+        document,
+        "pliu",
+        existing(
+            projects=[STORED_PROJECT],
+            goals=[stored(_id="g-old", project="pl-shock")],
+            tasks=[STORED_TASK, dict(STORED_TASK, _id="t-sub", parent="t-old", text="a sub task")],
+        ),
+        today=TODAY,
+    )
+    assert written(writes, "mc_tasks")["t-sub"]["parent"] == "t-old"


### PR DESCRIPTION
A document typed by hand carries no ids, so mc.parse_document gives every line a new one and a goal says which project it is of by the id it gave that project.  changes then adopts each line into the record already stored with the same name, which moves the project's id but left every reference to it pointing at the id the reader made up.

So a goal ended up hanging off a project that does not exist, and a task off a goal that does not exist.  Neither is reachable from the collections any more, and the next render drops both from the document: the project comes back, its goals and tasks do not.

changes now keeps what each line was given against what it turned out to be, and a goal's project, a task's goal and a sub task's parent all follow.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64