### PR TITLE
feat: group l_mcprojects by lead and print only the keys asked for

### DIFF
--- a/news/mc-lister-group-and-keys.rst
+++ b/news/mc-lister-group-and-keys.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/l_mcprojectshelper.py
+++ b/src/regolith/helpers/l_mcprojectshelper.py
@@ -7,11 +7,13 @@ the group.  Nobody has to remember to reassign anything when somebody
 goes.
 """
 
+from collections import defaultdict
+
 from gooey import GooeyParser
 
 from regolith.helpers.basehelper import SoutHelperBase
 from regolith.mc import CLOSED, orphaned, unled
-from regolith.tools import all_docs_from_collection, key_value_pair_filter
+from regolith.tools import all_docs_from_collection, collection_str, key_value_pair_filter
 
 TARGET_COLL = "mc_projects"
 HELPER_TARGET = "l_mcprojects"
@@ -35,12 +37,28 @@ def subparser(subpi):
         action="store_true",
         help=f"Include the projects that are {' and '.join(CLOSED)}, which are left out by default.",
     )
+    subpi.add_argument(
+        "--grp-by-lead",
+        # the underscore spelling is what l_projecta took, and is kept so that
+        # nobody has to retype an alias they have used for years
+        "--grp_by_lead",
+        dest="grp_by_lead",
+        action="store_true",
+        help="Group the projects under whoever leads each one.",
+    )
     subpi.add_argument("-v", "--verbose", action="store_true", help="Say more about each one.")
     subpi.add_argument(
         "-f",
         "--filter",
         nargs="+",
         help="Search the collection by giving key value pairs.",
+    )
+    subpi.add_argument(
+        "-k",
+        "--keys",
+        nargs="+",
+        help="The keys to print the values of, e.g. -k status project_deliverable. "
+        "The id is printed whether it is asked for or not.",
     )
     return subpi
 
@@ -82,12 +100,44 @@ class MCProjectsListerHelper(SoutHelperBase):
         if rc.grant:
             projects = [p for p in projects if rc.grant in as_list(p.get("grants"))]
 
-        for project in sorted(projects, key=lambda p: (p.get("lead") or "", p["_id"])):
+        projects = sorted(projects, key=lambda p: (p.get("lead") or "", p["_id"]))
+        if rc.grp_by_lead:
+            for line in self.by_lead(projects):
+                print(line)
+            return
+        if rc.keys:
+            print(collection_str(projects, rc.keys), end="")
+            return
+        for project in projects:
             print(self.line(project))
             if rc.verbose:
                 for line in self.more(project):
                     print(line)
         return
+
+    @staticmethod
+    def by_lead(projects):
+        """Return the projects written out under whoever leads each one.
+
+        Parameters
+        ----------
+        projects : list of dict
+            The projects to write out.
+
+        Returns
+        -------
+        list of str
+            The lines, a lead and then what they lead.
+        """
+        grouped = defaultdict(list)
+        for project in projects:
+            grouped["nobody" if unled(project) else project["lead"]].append(project)
+        lines = []
+        for lead in sorted(grouped):
+            lines.append(f"{lead}:")
+            for project in grouped[lead]:
+                lines.append(f"    {project['_id']}  ({project.get('status', '?')})  {project.get('name', '')}")
+        return lines
 
     @staticmethod
     def line(project):

--- a/tests/test_mc_listers.py
+++ b/tests/test_mc_listers.py
@@ -1,9 +1,12 @@
 """Tests for listing the mission control projects and goals."""
 
+import os
+
 import pytest
 
 from regolith.helpers.l_mcgoalshelper import MCGoalsListerHelper
 from regolith.helpers.l_mcprojectshelper import MCProjectsListerHelper, as_list
+from regolith.main import main
 from regolith.mc import in_the_group, orphaned, unled
 
 PEOPLE = [
@@ -132,3 +135,48 @@ def test_goals_are_grouped_under_their_project():
     grouped = MCGoalsListerHelper.by_project(goals)
     assert [project for project, _ in grouped] == ["p1", "p2"]
     assert [g["_id"] for g in grouped[0][1]] == ["g1", "g2"]
+
+
+def test_projects_are_grouped_under_their_lead():
+    # Test the grouping that gets read out in a meeting: whose work is it, and
+    # what of it is there.  A project nobody leads is written under nobody
+    # rather than left out
+    lines = MCProjectsListerHelper.by_lead(
+        [
+            {"_id": "hs-solver", "name": "Solver", "lead": "here", "status": "active"},
+            {"_id": "hs-fits", "name": "Fits", "lead": "here", "status": "proposed"},
+            {"_id": "na-idea", "name": "An idea", "status": "proposed"},
+        ]
+    )
+    assert lines == [
+        "here:",
+        "    hs-solver  (active)  Solver",
+        "    hs-fits  (proposed)  Fits",
+        "nobody:",
+        "    na-idea  (proposed)  An idea",
+    ]
+
+
+@pytest.mark.parametrize(
+    "args, expected_in_output",
+    [
+        # Test the two ways of listing that read differently from one line per
+        # project, driven through the command line so that the arguments
+        # themselves are covered.  The database is shared with the tests that
+        # add projects to it, so each case looks for what it asked for rather
+        # than for the whole of what comes back.
+        # C1: grouped under the lead, expect the lead written as a heading and
+        # their project indented under it
+        (["helper", "l_mcprojects", "--grp-by-lead"], ["sbillinge:", "    sb-nanoparticle-pdf  (active)"]),
+        # C2: the spelling l_projecta took, expect it works the same, since
+        # people have been typing it for years
+        (["helper", "l_mcprojects", "--grp_by_lead"], ["sbillinge:", "    sb-nanoparticle-pdf  (active)"]),
+        # C3: named keys, expect the id and those keys and nothing else
+        (["helper", "l_mcprojects", "-k", "status"], ["sb-nanoparticle-pdf    status: active"]),
+    ],
+)
+def test_the_projects_are_listed_the_way_that_was_asked_for(args, expected_in_output, make_db, capsys):
+    os.chdir(make_db)
+    main(args)
+    written = capsys.readouterr().out
+    assert all(expected in written for expected in expected_in_output)


### PR DESCRIPTION
Two things l_projecta did that l_mcprojects did not.  --grp-by-lead writes each lead as a heading with their projects under it, which is how the list gets read out in a meeting, and a project nobody leads goes under nobody rather than being left out.  -k/--keys prints the id and the values of the keys named, for reading a field across the collection.

The old spelling --grp_by_lead is taken as well, so that an alias somebody has typed for years keeps working.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64