### PR TITLE
fix: say more about a project when it is grouped under its lead

### DIFF
--- a/news/mc-lister-verbose-when-grouped.rst
+++ b/news/mc-lister-verbose-when-grouped.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/l_mcprojectshelper.py
+++ b/src/regolith/helpers/l_mcprojectshelper.py
@@ -102,7 +102,7 @@ class MCProjectsListerHelper(SoutHelperBase):
 
         projects = sorted(projects, key=lambda p: (p.get("lead") or "", p["_id"]))
         if rc.grp_by_lead:
-            for line in self.by_lead(projects):
+            for line in self.by_lead(projects, rc.verbose):
                 print(line)
             return
         if rc.keys:
@@ -115,14 +115,17 @@ class MCProjectsListerHelper(SoutHelperBase):
                     print(line)
         return
 
-    @staticmethod
-    def by_lead(projects):
+    @classmethod
+    def by_lead(cls, projects, verbose=False):
         """Return the projects written out under whoever leads each one.
 
         Parameters
         ----------
         projects : list of dict
             The projects to write out.
+        verbose : bool, optional
+            Whether to say more about each one, as the ungrouped listing
+            does.  The default is not to.
 
         Returns
         -------
@@ -137,6 +140,10 @@ class MCProjectsListerHelper(SoutHelperBase):
             lines.append(f"{lead}:")
             for project in grouped[lead]:
                 lines.append(f"    {project['_id']}  ({project.get('status', '?')})  {project.get('name', '')}")
+                if verbose:
+                    # what is said about a project sits under it, so it is
+                    # indented one further than the ungrouped listing puts it
+                    lines += [f"    {line}" for line in cls.more(project)]
         return lines
 
     @staticmethod

--- a/tests/test_mc_listers.py
+++ b/tests/test_mc_listers.py
@@ -180,3 +180,25 @@ def test_the_projects_are_listed_the_way_that_was_asked_for(args, expected_in_ou
     main(args)
     written = capsys.readouterr().out
     assert all(expected in written for expected in expected_in_output)
+
+
+def test_grouping_by_lead_still_says_more_when_asked():
+    # Test that --verbose and --grp-by-lead work together.  Grouping used to
+    # return before anything was said about a project, so asking for both got
+    # the grouping and nothing else
+    project = {
+        "_id": "hs-solver",
+        "name": "Solver",
+        "lead": "here",
+        "status": "active",
+        "project_deliverable": "Submit the paper",
+        "collaborators": ["ascopatz"],
+    }
+    lines = MCProjectsListerHelper.by_lead([project], verbose=True)
+    assert lines == [
+        "here:",
+        "    hs-solver  (active)  Solver",
+        "        deliverable: Submit the paper",
+        "        with: ascopatz",
+    ]
+    assert MCProjectsListerHelper.by_lead([project]) == ["here:", "    hs-solver  (active)  Solver"]


### PR DESCRIPTION
l_mcprojects returned as soon as it had written the grouping, so asking for --verbose and --grp-by-lead together got the grouping and nothing else.  What is said about a project now goes under it, indented one further than the ungrouped listing puts it.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64