### PR TITLE
feat: write tbd into a stub rather than leaving the field out

### DIFF
--- a/news/mc-adder-stubs-say-tbd.rst
+++ b/news/mc-adder-stubs-say-tbd.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
-from regolith.mc import DocumentError, parse_document, struck, wrap
+from regolith.mc import DocumentError, led_by, parse_document, struck, wrap
 from regolith.tools import all_docs_from_collection
 
 UNASSIGNED = "unassigned"
@@ -254,7 +254,7 @@ class MissionControlBuilder(BuilderBase):
         by_name = {}
         for path in self.mcdir.glob("*.md"):
             by_name[path.stem] = keys_in_document(path.read_text(encoding="utf-8"))
-        people = {p.get("lead") or UNASSIGNED for p in self.gtx["mc_projects"]}
+        people = {led_by(p) or UNASSIGNED for p in self.gtx["mc_projects"]}
         return {person: by_name.get(self.document_name(person), []) for person in people}
 
     def documents(self, orders=None):
@@ -270,7 +270,7 @@ class MissionControlBuilder(BuilderBase):
         orders = orders or {}
         by_person = defaultdict(list)
         for project in live(self.gtx["mc_projects"]):
-            by_person[project.get("lead") or UNASSIGNED].append(project)
+            by_person[led_by(project) or UNASSIGNED].append(project)
         return {
             person: self.render_person(person, projects, orders.get(person, []))
             for person, projects in by_person.items()

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -18,11 +18,14 @@ from gooey import GooeyParser
 
 from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import UNLED_PREFIX, initials, project_id, slug
+from regolith.mc import UNLED_PREFIX, initials, project_id, slug, unled
 from regolith.schemas import MC_STATI
 from regolith.tools import all_docs_from_collection
 
 TARGET_COLL = "mc_projects"
+# a stub is written down so that it is not forgotten, and what is not known
+# yet says so rather than being left out
+TBD = "tbd"
 HELPER_TARGET = "a_mcproject"
 
 
@@ -35,9 +38,10 @@ def subparser(subpi):
     subpi.add_argument(
         "-l",
         "--lead",
-        help="The id of the person leading it.  Without one the project is "
-        "unassigned, and is written to the unassigned document until somebody "
-        "moves it into theirs.",
+        default=TBD,
+        help=f"The id of the person leading it.  Default is {TBD}, which leaves "
+        f"the project unassigned and writes it to the unassigned document until "
+        f"somebody moves it into theirs.",
     )
     subpi.add_argument(
         "-w",
@@ -46,10 +50,25 @@ def subparser(subpi):
         nargs="+",
         help="The ids of the people on it, group members and others alike.",
     )
-    subpi.add_argument("-g", "--grants", nargs="+", help="The ids of the grants that pay for it.")
+    subpi.add_argument(
+        "-g",
+        "--grants",
+        nargs="+",
+        default=[TBD],
+        help=f"The ids of the grants that pay for it.  Default is {TBD}.",
+    )
     subpi.add_argument("--pi", dest="pi_id", help="The id of the principal investigator.")
-    subpi.add_argument("-d", "--deliverable", help="What the project produces, e.g. submit the paper.")
-    subpi.add_argument("--description", help="What the project is, for the project report.")
+    subpi.add_argument(
+        "-d",
+        "--deliverable",
+        default=TBD,
+        help=f"What the project produces, e.g. submit the paper.  Default is {TBD}.",
+    )
+    subpi.add_argument(
+        "--description",
+        default=TBD,
+        help=f"What the project is, for the project report.  Default is {TBD}.",
+    )
     subpi.add_argument(
         "-s",
         "--status",
@@ -91,7 +110,9 @@ class MCProjectAdderHelper(DbHelperBase):
         """Return the initials a project of this lead's is named
         with."""
         rc = self.rc
-        if not rc.lead:
+        # tbd is a placeholder rather than a person, so it names the project
+        # the way no lead at all does
+        if unled({"lead": rc.lead}):
             return UNLED_PREFIX
         for entry in self.gtx["people"]:
             if entry["_id"] == rc.lead:
@@ -130,6 +151,6 @@ class MCProjectAdderHelper(DbHelperBase):
                 project[key] = value
         rc.client.insert_one(rc.database, rc.coll, project)
 
-        whose = f"to {rc.lead}" if rc.lead else "unassigned"
+        whose = "unassigned" if unled(project) else f"to {rc.lead}"
         print(f'The project "{rc.name}" has been added {whose} as {_id}.')
         return

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -21,7 +21,15 @@ from regolith.builders.missioncontrolbuilder import (
     live,
 )
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import UNLED_PREFIX, DocumentError, changes, initials, parse_document, slug
+from regolith.mc import (
+    UNLED_PREFIX,
+    DocumentError,
+    changes,
+    initials,
+    led_by,
+    parse_document,
+    slug,
+)
 from regolith.schemas import SCHEMAS, validate
 from regolith.tools import all_docs_from_collection
 
@@ -107,8 +115,9 @@ class MCSyncHelper(DbHelperBase):
         for person in self.gtx["people"]:
             whose.setdefault(renderer.document_name(person["_id"]), person["_id"])
         for project in self.gtx["mc_projects"]:
-            if project.get("lead"):
-                whose.setdefault(renderer.document_name(project["lead"]), project["lead"])
+            lead = led_by(project)
+            if lead:
+                whose.setdefault(renderer.document_name(lead), lead)
         found = []
         for path in sorted(mcdir.glob("*.md")):
             if path.stem in whose:
@@ -139,7 +148,7 @@ class MCSyncHelper(DbHelperBase):
         """
         lead = None if person == UNASSIGNED else person
         projects = {
-            project["_id"]: project for project in live(self.gtx["mc_projects"]) if project.get("lead") == lead
+            project["_id"]: project for project in live(self.gtx["mc_projects"]) if led_by(project) == lead
         }
         goals = {goal["_id"]: goal for goal in live(self.gtx["mc_goals"]) if goal.get("project") in projects}
         tasks = {task["_id"]: task for task in live(self.gtx["mc_tasks"]) if task.get("goal") in goals}

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -739,6 +739,26 @@ def unled(project):
     return not lead or str(lead).strip().lower() in NOBODY
 
 
+def led_by(project):
+    """Return who leads a project, or None when nobody does.
+
+    A lead written as ``tbd`` or ``na`` is a placeholder rather than a
+    person, so it reads the same as no lead at all: the project belongs
+    in the unassigned document until somebody picks it up.
+
+    Parameters
+    ----------
+    project : dict
+        The project.
+
+    Returns
+    -------
+    str or None
+        The id of whoever leads it, or None.
+    """
+    return None if unled(project) else project["lead"]
+
+
 def in_the_group(person_id, people):
     """Return True if somebody is in the group at the moment.
 

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -8,7 +8,7 @@ import pytest
 
 from regolith.database import connect
 from regolith.main import main
-from regolith.mc import slug
+from regolith.mc import led_by, slug
 from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
 
 
@@ -49,8 +49,7 @@ def test_adding_a_project_says_whose_it_is(args, expected_in_output, make_db, ca
 
 
 def test_a_project_is_stored_with_what_was_given(make_db):
-    # Test that what the command line carries reaches the collection, and that
-    # what it does not carry is left out rather than stored empty
+    # Test that what the command line carries reaches the collection
     os.chdir(make_db)
     main(
         [
@@ -84,7 +83,8 @@ def test_a_project_is_stored_with_what_was_given(make_db):
     assert project["grants"] == ["dmref15"]
     assert project["project_deliverable"] == "a short paper"
     assert project["status"] == "proposed"
-    assert "project_description" not in project
+    # nothing was said about it, so it says so rather than being left out
+    assert project["project_description"] == "tbd"
 
 
 def test_adding_a_project_that_is_already_there_says_how_to_pick_another(make_db):
@@ -124,3 +124,45 @@ def test_an_id_given_by_hand_is_put_in_the_form_ids_take(given_id, expected_id, 
     filter_databases(rc)
     with connect(rc) as rc.client:
         assert rc.client.get("mc_projects", expected_id) is not None
+
+
+@pytest.mark.parametrize(
+    "field, expected",
+    [
+        # Test that a stub says what is not known yet rather than leaving it
+        # out.  The point of the adder is to write a project down in the
+        # moment it is mentioned, and a tbd in the document is what reminds
+        # somebody to fill it in.
+        # C1: no lead given, expect tbd, which reads as unassigned everywhere
+        ("lead", "tbd"),
+        # C2: nothing said about what it produces
+        ("project_deliverable", "tbd"),
+        # C3: nothing said about what it is
+        ("project_description", "tbd"),
+        # C4: no grant paying for it yet
+        ("grants", ["tbd"]),
+    ],
+)
+def test_a_stub_says_what_is_not_known_yet(field, expected, make_db):
+    os.chdir(make_db)
+    main(["helper", "a_mcproject", f"stub for {field}"])
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        assert rc.client.get("mc_projects", f"na-stub-for-{slug(field)}")[field] == expected
+
+
+def test_a_stub_with_no_lead_is_named_and_read_as_nobody_s(make_db):
+    # Test that tbd is a placeholder and not a person: the id says na, the
+    # message says unassigned, and a render puts the project in the unassigned
+    # document rather than making one called tbd
+    os.chdir(make_db)
+    main(["helper", "a_mcproject", "a stub nobody leads"])
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        project = rc.client.get("mc_projects", "na-a-stub-nobody-leads")
+    assert project["lead"] == "tbd"
+    assert led_by(project) is None

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -575,3 +575,29 @@ def test_a_document_with_no_ids_still_says_what_order_it_is_in():
 def test_keys_in_document_reads_ids_and_texts(document, expected_keys):
     keys = keys_in_document(document)
     assert [key for key in keys if key in expected_keys] == expected_keys
+
+
+@pytest.mark.parametrize(
+    "lead",
+    [
+        # Test that a placeholder lead is not taken for a person.  The adder
+        # writes tbd into a stub, and projecta wrote na, and neither is
+        # somebody whose document should be written.
+        # C1: the adder's placeholder
+        "tbd",
+        # C2: the one projecta used
+        "na",
+        # C3: what a form leaves behind
+        "",
+    ],
+)
+def test_a_project_nobody_leads_goes_to_the_unassigned_document(lead):
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], lead=lead)],
+        "mc_goals": [],
+        "mc_tasks": [],
+        "people": [],
+    }
+    documents = builder.documents()
+    assert list(documents) == ["unassigned"]


### PR DESCRIPTION
a_mcproject is for the moment in a conversation when a project is mentioned and writing it down should cost nothing, so what nobody has said yet now says tbd: the lead, the deliverable, the description and the grants.  A tbd in the rendered document is what reminds somebody to fill it in, where a field left out says nothing at all.

tbd is a placeholder rather than a person, so mc.led_by reads it, and na and an empty string, as nobody.  Without that a stub would have been written to a document called tbd.md, and mcsynchelper would have looked for a person of that name.  The status and the begin date keep their own defaults, since neither would validate as tbd.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64