### PR TITLE
feat: add u_mcproject for the fields a document does not show

### DIFF
--- a/news/mc-project-updater.rst
+++ b/news/mc-project-updater.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -97,6 +97,10 @@ LISTER_HELPER_SPECS = {
         "regolith.helpers.l_grantshelper:GrantsListerHelper",
         "regolith.helpers.l_grantshelper:subparser",
     ),
+    "u_mcproject": (
+        "regolith.helpers.u_mcprojecthelper:MCProjectUpdaterHelper",
+        "regolith.helpers.u_mcprojecthelper:subparser",
+    ),
     "l_mcgoals": (
         "regolith.helpers.l_mcgoalshelper:MCGoalsListerHelper",
         "regolith.helpers.l_mcgoalshelper:subparser",

--- a/src/regolith/helpers/u_mcprojecthelper.py
+++ b/src/regolith/helpers/u_mcprojecthelper.py
@@ -1,0 +1,160 @@
+"""Update a project in mission control from the command line.
+
+The document is where a project is described, and for anything wordy
+that is the easier place.  This is for the fields it does not show --
+who is the principal investigator, which grant pays for it, when it
+began -- and for the times when changing one field of one project, or
+the same field of many, is quicker said than typed.
+
+Nothing is guessed.  Only the fields given on the command line are
+written, so a project can be corrected without anything else about it
+being touched.
+"""
+
+from gooey import GooeyParser
+
+from regolith.helpers.basehelper import DbHelperBase
+from regolith.schemas import MC_STATI
+
+TARGET_COLL = "mc_projects"
+HELPER_TARGET = "u_mcproject"
+
+# what the command line can set, against the field each one sets.  A list is
+# replaced rather than added to, so that what is given is what is stored.
+FIELDS = [
+    ("name", "name"),
+    ("description", "project_description"),
+    ("deliverable", "project_deliverable"),
+    ("lead", "lead"),
+    ("collaborators", "collaborators"),
+    ("grants", "grants"),
+    ("pi_id", "pi_id"),
+    ("status", "status"),
+    ("begin_date", "begin_date"),
+    ("end_date", "end_date"),
+    ("urls", "urls"),
+    ("notes", "notes"),
+]
+
+
+def subparser(subpi):
+    date_kwargs = {}
+    if isinstance(subpi, GooeyParser):
+        date_kwargs["widget"] = "DateChooser"
+
+    subpi.add_argument("_id", help="The id of the project to update.")
+    subpi.add_argument("--name", help="What the project is called.")
+    subpi.add_argument("--description", help="What the project is, for the project report.")
+    subpi.add_argument("-d", "--deliverable", help="What the project produces, e.g. submit the paper.")
+    subpi.add_argument("-l", "--lead", help="The id of the person leading it.")
+    subpi.add_argument(
+        "-w",
+        "--with",
+        dest="collaborators",
+        nargs="+",
+        help="The ids of the people on it, replacing the ones stored.",
+    )
+    subpi.add_argument(
+        "-g",
+        "--grants",
+        nargs="+",
+        help="The ids of the grants that pay for it, replacing the ones stored.",
+    )
+    subpi.add_argument("--pi", dest="pi_id", help="The id of the principal investigator.")
+    subpi.add_argument("-s", "--status", help=f"The status of the project.  One of {MC_STATI}.")
+    subpi.add_argument("--begin-date", help="The date the project began.", **date_kwargs)
+    subpi.add_argument("--end-date", help="The date the project ended.", **date_kwargs)
+    subpi.add_argument(
+        "--url",
+        dest="urls",
+        nargs=2,
+        action="append",
+        metavar=("NAME", "URL"),
+        help="A link belonging to the project and what it is, e.g. --url paper "
+        "https://example.com/a. Give it more than once for more than one link. "
+        "They replace the links stored.",
+    )
+    subpi.add_argument("--notes", nargs="+", help="Notes about it, replacing the ones stored.")
+    return subpi
+
+
+def said(value):
+    """Return a value as one line, whatever shape it came in.
+
+    Parameters
+    ----------
+    value : str or list
+        What was written to the field.
+
+    Returns
+    -------
+    str
+        The value, a list written out as one line.
+    """
+    if not isinstance(value, list):
+        return str(value)
+    return ", ".join(f"{v['name']}: {v['url']}" if isinstance(v, dict) else str(v) for v in value)
+
+
+class MCProjectUpdaterHelper(DbHelperBase):
+    """Update a project in mission control."""
+
+    btype = HELPER_TARGET
+    needed_colls = [f"{TARGET_COLL}"]
+
+    def construct_global_ctx(self):
+        """Constructs the global context."""
+        super().construct_global_ctx()
+        self.rc.coll = f"{TARGET_COLL}"
+
+    def db_updater(self):
+        rc = self.rc
+        given = {field: getattr(rc, argument) for argument, field in FIELDS if getattr(rc, argument, None)}
+        if not given:
+            raise ValueError(
+                "Nothing was given to update. Please give at least one field to "
+                "change, such as --status or --grants."
+            )
+        if "status" in given and given["status"] not in MC_STATI:
+            raise ValueError(f"The status should be one of {MC_STATI}. Please pick one of those.")
+        if "urls" in given:
+            # the collection holds a link and what it is, rather than a bare link
+            given["urls"] = [{"name": name, "url": url} for name, url in given["urls"]]
+
+        dbname = self.where_it_is(rc._id)
+        if dbname is None:
+            raise ValueError(
+                f"There is no project called {rc._id}. Please check the id, which "
+                f"'regolith helper l_mcprojects' will list."
+            )
+        rc.client.update_one(dbname, rc.coll, {"_id": rc._id}, given)
+        print(f"{rc._id} updated:")
+        for field, value in given.items():
+            print(f"    {field}: {said(value)}")
+        return
+
+    def where_it_is(self, _id):
+        """Return the database holding a project.
+
+        A project is updated where it is stored rather than in the first
+        database that happens to be listed, since writing it anywhere
+        else would leave two of it and hide the one that is real.  That
+        is why ``rc.database`` is not used: the runcontrol fills it in
+        with the first database before any updater runs.
+
+        Parameters
+        ----------
+        _id : str
+            The id of the project.
+
+        Returns
+        -------
+        str or None
+            The name of the database holding it, or None when nothing
+            holds it.
+        """
+        rc = self.rc
+        for database in rc.client.collection_sources(rc.coll):
+            if rc.client.find_one(database["name"], rc.coll, {"_id": _id}):
+                return database["name"]
+        return None

--- a/tests/test_u_mcprojecthelper.py
+++ b/tests/test_u_mcprojecthelper.py
@@ -1,0 +1,97 @@
+"""Tests for updating a project in mission control from the command
+line."""
+
+import copy
+import os
+
+import pytest
+
+from regolith.database import connect
+from regolith.main import main
+from regolith.mc import slug
+from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
+
+ADD = ["helper", "a_mcproject", "a project to update", "-l", "sbillinge"]
+PROJECT_ID = "sb-a-project-to-update"
+
+
+def stored(_id):
+    """Return one project straight from the collection."""
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        return rc.client.get("mc_projects", _id)
+
+
+@pytest.mark.parametrize(
+    "args, field, expected",
+    [
+        # Test the fields the command line can set.  The document is where a
+        # project is described, so this is for what the document does not show
+        # and for changing one field without touching anything else.
+        # C1: the status, which the document cannot say on its own
+        (["-s", "backburner"], "status", "backburner"),
+        # C2: who pays for it
+        (["-g", "dmref15", "sym"], "grants", ["dmref15", "sym"]),
+        # C3: the principal investigator
+        (["--pi", "scopatz"], "pi_id", "scopatz"),
+        # C4: who leads it, which is how a project is reassigned
+        (["-l", "ascopatz"], "lead", "ascopatz"),
+        # C5: the fields the document owns, for changing many at once rather
+        # than opening each document
+        (["--name", "A better name"], "name", "A better name"),
+        (["--description", "what it is"], "project_description", "what it is"),
+        (["-d", "a paper"], "project_deliverable", "a paper"),
+        (["-w", "ascopatz", "afriend"], "collaborators", ["ascopatz", "afriend"]),
+        # C6: when it began and ended
+        (["--begin-date", "2026-01-01"], "begin_date", "2026-01-01"),
+        (["--end-date", "2026-12-31"], "end_date", "2026-12-31"),
+        # C7: where the work lives and what was said about it
+        (
+            ["--url", "the paper", "https://example.com/a"],
+            "urls",
+            [{"name": "the paper", "url": "https://example.com/a"}],
+        ),
+        (["--notes", "a note"], "notes", ["a note"]),
+    ],
+)
+def test_a_field_given_on_the_command_line_reaches_the_project(args, field, expected, make_db):
+    os.chdir(make_db)
+    # the adder puts an id given by hand through slug, so an underscore in a
+    # field name comes back as a hyphen
+    _id = slug(f"{PROJECT_ID}-{field}")
+    main(ADD + ["--id", _id])
+    main(["helper", "u_mcproject", _id] + args)
+    assert stored(_id)[field] == expected
+
+
+def test_only_what_was_given_is_written(make_db):
+    # Test that updating one field leaves the rest of the project alone, since
+    # an updater that blanked what it was not told would be worse than useless
+    os.chdir(make_db)
+    main(ADD + ["--id", "sb-untouched", "-d", "the original deliverable"])
+    main(["helper", "u_mcproject", "sb-untouched", "-s", "active"])
+    project = stored("sb-untouched")
+    assert project["status"] == "active"
+    assert project["project_deliverable"] == "the original deliverable"
+    assert project["lead"] == "sbillinge"
+
+
+@pytest.mark.parametrize(
+    "args, expected_message",
+    [
+        # Test that a mistake says what to do about it rather than writing
+        # something wrong.
+        # C1: an id nothing is stored under, expect it says how to find one
+        (["helper", "u_mcproject", "no-such-project", "-s", "active"], "no project called"),
+        # C2: a status outside the vocabulary, expect the allowed ones
+        (["helper", "u_mcproject", "sb-untouched", "-s", "nonsense"], "should be one of"),
+        # C3: nothing to change at all, expect it asks for something
+        (["helper", "u_mcproject", "sb-untouched"], "Nothing was given"),
+    ],
+)
+def test_a_mistake_says_what_to_do_about_it(args, expected_message, make_db):
+    os.chdir(make_db)
+    with pytest.raises(ValueError, match=expected_message):
+        main(args)


### PR DESCRIPTION
a_mcproject wrote a project down and nothing changed one afterwards, so a status, a grant or a principal investigator could only be set by editing the collection by hand.  u_mcproject sets any field of a project by id: the ones the database owns, and the name, description, deliverable and collaborators the document owns as well, since changing the same field of several projects is quicker said once than typed in each document.

Only what is given is written, so nothing else about the project is touched.  A link is given as its name and its url, which is the shape the collection holds.  The project is updated in the database that holds it rather than in rc.database, which the runcontrol fills in with the first database before any updater runs and which would leave a second copy of the project shadowing the real one.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64