### PR TITLE
fix: do not label a helper argument with a tuple, which stops the GUI…

### DIFF
--- a/news/fix-gooey-tuple-metavar.rst
+++ b/news/fix-gooey-tuple-metavar.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The helper GUI opens again.  An argument taking a name and a value labelled
+  its field with a tuple, which brought the window down before it appeared.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/u_mcprojecthelper.py
+++ b/src/regolith/helpers/u_mcprojecthelper.py
@@ -69,10 +69,11 @@ def subparser(subpi):
         dest="urls",
         nargs=2,
         action="append",
-        metavar=("NAME", "URL"),
-        help="A link belonging to the project and what it is, e.g. --url paper "
-        "https://example.com/a. Give it more than once for more than one link. "
-        "They replace the links stored.",
+        # no metavar: gooey labels the field with it, and a tuple of them is
+        # not something a label can be made of
+        help="What a link is and the link, e.g. --url paper https://example.com/a. "
+        "Give it more than once for more than one link. They replace the links "
+        "stored.",
     )
     subpi.add_argument("--notes", nargs="+", help="Notes about it, replacing the ones stored.")
     return subpi

--- a/tests/test_helper_gui.py
+++ b/tests/test_helper_gui.py
@@ -1,0 +1,47 @@
+"""Tests for what the helpers promise the graphical front end.
+
+helper_gui builds a page of fields from each helper's arguments, and it
+cannot be run here: it needs a display, and wxPython is not installed on
+every machine the suite runs on.  So what it needs of an argument is
+checked directly, which is what these do.
+"""
+
+import argparse
+
+import pytest
+
+from regolith.helper import HELPERS
+
+
+def parser_for(target):
+    """Return a plain parser carrying one helper's arguments.
+
+    Parameters
+    ----------
+    target : str
+        The name of the helper, as the command line takes it.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        A parser the helper has added its arguments to.
+    """
+    parser = argparse.ArgumentParser(prog=target)
+    # the registry resolves the import when it is asked for the helper
+    HELPERS[target][1](parser)
+    return parser
+
+
+@pytest.mark.parametrize("target", sorted(HELPERS))
+def test_no_argument_is_labelled_with_a_tuple(target):
+    # Test that no argument gives gooey a metavar it cannot make a label out
+    # of.  Gooey labels each field with "action.metavar or action.dest", and
+    # hands that to wx.StaticText, which takes a string: a tuple metavar, which
+    # argparse allows for an argument taking several values, brings the whole
+    # window down before it opens with a TypeError naming neither the helper
+    # nor the argument
+    for action in parser_for(target)._actions:
+        assert not isinstance(action.metavar, tuple), (
+            f"{target} labels {action.dest} with a tuple. Give it no metavar, or "
+            f"one string, so that the helper GUI can label the field."
+        )

--- a/tests/test_u_mcprojecthelper.py
+++ b/tests/test_u_mcprojecthelper.py
@@ -31,7 +31,7 @@ def stored(_id):
         # project is described, so this is for what the document does not show
         # and for changing one field without touching anything else.
         # C1: the status, which the document cannot say on its own
-        (["-s", "backburner"], "status", "backburner"),
+        (["-s", "on-deck"], "status", "on-deck"),
         # C2: who pays for it
         (["-g", "dmref15", "sym"], "grants", ["dmref15", "sym"]),
         # C3: the principal investigator


### PR DESCRIPTION
… opening

u_mcproject's --url takes a name and a link, and gave argparse the tuple metavar ("NAME", "URL") that argparse allows for exactly that.  Gooey labels each field with "action.metavar or action.dest" and hands it to wx.StaticText, which takes a string, so helper_gui came down with a TypeError before its window appeared -- naming neither the helper nor the argument, and taking every other helper with it.

The metavar goes, and the two values are named in the help instead.

tests/test_helper_gui.py checks every helper for the same thing.  The GUI cannot be run in the suite, since it wants a display and wxPython is not installed everywhere, so what it needs of an argument is checked here instead.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64