### PR TITLE
feat: let a group say what its periods of the year are called

### DIFF
--- a/docs/source/rc.rst
+++ b/docs/source/rc.rst
@@ -154,6 +154,31 @@ would allow the names of people to also be
 
 See the collections for a complete list of the schemas.
 
+``mission_control_periods``
+===========================
+What the periods of the year are called and the day each one starts, as
+``{name: "MM-DD"}``. Mission control writes a period as the year and the name
+together, so ``{"fall": "09-01"}`` gives ``2026fall``.
+
+If none is provided it defaults to semesters:
+
+.. code-block:: json
+
+    {"spring": "01-01", "summer": "06-01", "fall": "09-01"}
+
+A group on a quarter system says so. For example, at UCSB:
+
+.. code-block:: json
+
+    {"winter": "01-01", "spring": "04-01", "summer": "07-01", "fall": "10-01"}
+
+The names need not be terms at all: a group that works in halves could say
+``{"first": "01-01", "second": "07-01"}``.
+
+The order the periods are given in does not matter, since they are put in the
+order they come round by the dates. That order is what mission control sorts an
+archive by, rather than the letters of the names, which do not agree with it.
+
 ``static_source``
 =================
 File path to the static source for ``regolith build html``. If none provided it defaults to "templates"

--- a/news/mc-configurable-periods.rst
+++ b/news/mc-configurable-periods.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -24,7 +24,8 @@ from regolith.mc import (
     DocumentError,
     led_by,
     parse_document,
-    quarter_of,
+    period_key,
+    period_of,
     struck,
     week_of,
     wrap,
@@ -204,6 +205,12 @@ class MissionControlBuilder(BuilderBase):
 
     btype = "mission-control"
     needed_colls = ["mc_projects", "mc_goals", "mc_tasks", "people"]
+    # what the periods of the year are called and when they start, which a
+    # group says in regolithrc.json.  It decides the period a new goal belongs
+    # to and the order the archive reads in.  None is the semesters that
+    # mc.DEFAULT_PERIODS gives, and stands for a builder made without a
+    # runcontrol, as the sync helper makes one to name documents with.
+    periods = None
 
     def __init__(self, rc):
         super().__init__(rc)
@@ -212,6 +219,10 @@ class MissionControlBuilder(BuilderBase):
         # the build directory.  rc.mission_control_dir says where; without it
         # they go under the build directory like any other built thing.
         self.mcdir = Path(getattr(rc, "mission_control_dir", None) or self.bldir)
+        # what the periods of the year are called and when they start, which a
+        # group says in regolithrc.json and which decides both the period a new
+        # goal belongs to and the order the archive reads in
+        self.periods = getattr(rc, "mission_control_periods", None)
 
     def display_name(self, person):
         """Return the name to head a person's document with."""
@@ -470,11 +481,16 @@ class MissionControlBuilder(BuilderBase):
         stays truthful without a second document.
         """
         current = self.current_period(goals)
-        periods = sorted({g["first_period"] for g in goals} | {g["period"] for g in goals}, reverse=True)
-        past = [p for p in periods if p < current]
+        seen = {g["first_period"] for g in goals} | {g["period"] for g in goals}
+        periods = sorted(seen, key=self.period_key, reverse=True)
+        past = [p for p in periods if self.period_key(p) < self.period_key(current)]
         lines = ["## Archive", ""]
         for period in past:
-            shown = [g for g in self.in_order(goals, goal_number) if g["first_period"] <= period <= g["period"]]
+            shown = [
+                g
+                for g in self.in_order(goals, goal_number)
+                if self.period_key(g["first_period"]) <= self.period_key(period) <= self.period_key(g["period"])
+            ]
             if not shown:
                 continue
             lines += [f"### Goals — {period}", ""]
@@ -491,15 +507,21 @@ class MissionControlBuilder(BuilderBase):
         """Return the goals in the order their numbers read."""
         return sorted(goals, key=lambda g: [int(n) for n in goal_number[g["_id"]].split(".")])
 
-    @staticmethod
-    def current_period(goals):
+    def period_key(self, period):
+        """Return a key putting periods in the order they came round."""
+        return period_key(period, self.periods)
+
+    def current_period(self, goals):
         """Return the latest period any goal is in.
 
-        A person with no goals yet is in the quarter everybody else is,
-        so that their document has a goals section to type into.
+        A person with no goals yet is in the period everybody else is,
+        so that their document has a goals section to type into.  The
+        names of the periods do not sort into the order they happen, so
+        the latest is found by when it came round rather than by its
+        text.
         """
         periods = [g["period"] for g in goals]
-        return max(periods) if periods else quarter_of(dt.date.today())
+        return max(periods, key=self.period_key) if periods else period_of(dt.date.today(), self.periods)
 
     @staticmethod
     def carried(goal):

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -18,7 +18,17 @@ from gooey import GooeyParser
 
 from regolith.fsclient import _id_key
 from regolith.helpers.basehelper import DbHelperBase
-from regolith.mc import UNLED_PREFIX, initials, project_id, quarter_of, short_id, slug, unled, week_of
+from regolith.mc import (
+    UNLED_PREFIX,
+    initials,
+    next_period,
+    period_of,
+    project_id,
+    short_id,
+    slug,
+    unled,
+    week_of,
+)
 from regolith.schemas import MC_STATI
 from regolith.tools import all_docs_from_collection
 
@@ -89,7 +99,17 @@ def subparser(subpi):
     )
     subpi.add_argument(
         "--period",
-        help="The period the seeded goal belongs to, e.g. 2026Q3.  Default is " "the quarter we are in.",
+        help="The period the seeded goal belongs to, e.g. 2026fall.  Default is "
+        "the period we are in, which mission_control_periods in regolithrc.json "
+        "gives the names and dates of.",
+    )
+    subpi.add_argument(
+        "-n",
+        "--next",
+        dest="next_one",
+        action="store_true",
+        help="Put the seeded goal in the period after this one, for preparing "
+        "work that starts next term while this one is still running.",
     )
     subpi.add_argument("--database", help="The database to write to.")
     return subpi
@@ -188,7 +208,10 @@ class MCProjectAdderHelper(DbHelperBase):
         """
         rc = self.rc
         taken = {record["_id"] for collection in SEEDED_COLLS for record in self.gtx[collection]}
-        period = rc.period or quarter_of(dt.date.today())
+        periods = getattr(rc, "mission_control_periods", None)
+        today = dt.date.today()
+        which = next_period if rc.next_one else period_of
+        period = rc.period or which(today, periods)
         goal = {
             "_id": short_id(taken),
             "project": project_id,
@@ -198,7 +221,7 @@ class MCProjectAdderHelper(DbHelperBase):
             "status": rc.status,
         }
         taken.add(goal["_id"])
-        monday = week_of(dt.date.today())
+        monday = week_of(today)
         task = {
             "_id": short_id(taken),
             "goal": goal["_id"],

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -60,20 +60,148 @@ def week_of(date):
     return date - dt.timedelta(days=date.weekday())
 
 
-def quarter_of(date):
+# When the periods of the year begin, for a group that has not said.  Most
+# universities are on semesters, so those are the default; a group on quarters,
+# or on nothing much, says so in regolithrc.json under mission_control_periods,
+# as {name: MM-DD} saying what each period is called and the day it starts.
+DEFAULT_PERIODS = {"spring": "01-01", "summer": "06-01", "fall": "09-01"}
+
+
+def period_starts(periods=None):
+    """Return when each period of the year starts, earliest first.
+
+    Parameters
+    ----------
+    periods : dict, optional
+        The periods as ``{name: "MM-DD"}``.  The default is semesters.
+
+    Returns
+    -------
+    list of tuple of (int, int, str)
+        The month, the day and the name of each, in the order they come
+        round.
+
+    Raises
+    ------
+    DocumentError
+        When a start is not written as MM-DD, naming the one that is not.
+    """
+    starts = []
+    for name, start in (periods or DEFAULT_PERIODS).items():
+        try:
+            month, day = (int(part) for part in str(start).split("-"))
+            dt.date(2000, month, day)
+        except (TypeError, ValueError):
+            raise DocumentError(
+                f"The period {name} starts on {start!r}, which is not a date of the "
+                f"year. Please write it as MM-DD, such as 09-01, in "
+                f"mission_control_periods in regolithrc.json."
+            )
+        starts.append((month, day, str(name)))
+    return sorted(starts)
+
+
+def period_of(date, periods=None):
     """Return the period a date falls in, as the documents write one.
+
+    The year goes in front of the name, so a period reads as the whole
+    of when it was: ``2026fall``.
 
     Parameters
     ----------
     date : datetime.date
         The date to place.
+    periods : dict, optional
+        The periods as ``{name: "MM-DD"}``.  The default is semesters.
 
     Returns
     -------
     str
-        The quarter, e.g. ``2026Q3``.
+        The period, e.g. ``2026fall``.
     """
-    return f"{date.year}Q{(date.month - 1) // 3 + 1}"
+    starts = period_starts(periods)
+    begun = [(month, day, name) for month, day, name in starts if (month, day) <= (date.month, date.day)]
+    if begun:
+        return f"{date.year}{begun[-1][2]}"
+    # the year has not reached its first period yet, so we are still in the
+    # last one of the year before
+    return f"{date.year - 1}{starts[-1][2]}"
+
+
+def next_period(date, periods=None):
+    """Return the period after the one a date falls in.
+
+    Preparing for the period to come is ordinary work, and it happens
+    while the one before it is still running.
+
+    Parameters
+    ----------
+    date : datetime.date
+        The date to start from.
+    periods : dict, optional
+        The periods as ``{name: "MM-DD"}``.  The default is semesters.
+
+    Returns
+    -------
+    str
+        The period after this one.
+    """
+    starts = period_starts(periods)
+    year, name = split_period(period_of(date, periods), periods)
+    nth = [start[2] for start in starts].index(name) + 1
+    if nth == len(starts):
+        return f"{int(year) + 1}{starts[0][2]}"
+    return f"{year}{starts[nth][2]}"
+
+
+def split_period(period, periods=None):
+    """Return a period as its year and its name.
+
+    Parameters
+    ----------
+    period : str
+        The period, e.g. ``2026fall``.
+    periods : dict, optional
+        The periods as ``{name: "MM-DD"}``.  The default is semesters.
+
+    Returns
+    -------
+    tuple of (str, str) or None
+        The year and the name, or None for a period written some other
+        way.
+    """
+    for _, _, name in period_starts(periods):
+        if period.endswith(name) and period[: -len(name)]:
+            return period[: -len(name)], name
+    return None
+
+
+def period_key(period, periods=None):
+    """Return a key that puts periods in the order they came round.
+
+    The names of the periods do not sort into the order they happen --
+    fall comes before spring in the alphabet and after it in the year --
+    so anything ordering periods sorts on this rather than on the text.
+
+    Parameters
+    ----------
+    period : str
+        The period, e.g. ``2026fall``.
+    periods : dict, optional
+        The periods as ``{name: "MM-DD"}``.  The default is semesters.
+
+    Returns
+    -------
+    tuple of (str, int)
+        The year, and where in the year the period comes.  A period
+        written some other way sorts after the ones of its own text.
+    """
+    starts = period_starts(periods)
+    split = split_period(period, periods)
+    if split is None:
+        return (period, len(starts))
+    year, name = split
+    return (year, [start[2] for start in starts].index(name))
 
 
 def slug(text):

--- a/tests/test_a_mcprojecthelper.py
+++ b/tests/test_a_mcprojecthelper.py
@@ -9,7 +9,7 @@ import pytest
 
 from regolith.database import connect
 from regolith.main import main
-from regolith.mc import led_by, quarter_of, slug, week_of
+from regolith.mc import led_by, next_period, period_of, slug, week_of
 from regolith.runcontrol import DEFAULT_RC, filter_databases, load_rcfile
 
 
@@ -175,7 +175,7 @@ def test_a_new_project_comes_with_a_goal_and_a_task_under_it(make_db):
     # something to put in them, so a project with nothing under it gives a
     # file with no goals section and no week to type into
     os.chdir(make_db)
-    main(["helper", "a_mcproject", "a seeded project", "--period", "2026Q3"])
+    main(["helper", "a_mcproject", "a seeded project", "--period", "2026fall"])
     rc = copy.copy(DEFAULT_RC)
     rc._update(load_rcfile("regolithrc.json"))
     filter_databases(rc)
@@ -185,16 +185,16 @@ def test_a_new_project_comes_with_a_goal_and_a_task_under_it(make_db):
         goal = goals[0]
         tasks = [t for t in rc.client.all_documents("mc_tasks") if t["goal"] == goal["_id"]]
     assert goal["text"] == "tbd"
-    assert goal["period"] == "2026Q3"
-    assert goal["first_period"] == "2026Q3"
+    assert goal["period"] == "2026fall"
+    assert goal["first_period"] == "2026fall"
     assert len(tasks) == 1
     assert tasks[0]["text"] == "tbd"
     assert tasks[0]["due_date"] == tasks[0]["first_due_date"] == week_of(dt.date.today())
 
 
-def test_the_seeded_goal_is_of_the_quarter_we_are_in(make_db):
-    # Test the default period, since nobody wants to type the quarter to write
-    # a project down in the moment it is mentioned
+def test_the_seeded_goal_is_of_the_period_we_are_in(make_db):
+    # Test the default period, since nobody wants to type the term to write a
+    # project down in the moment it is mentioned
     os.chdir(make_db)
     main(["helper", "a_mcproject", "a project of this quarter"])
     rc = copy.copy(DEFAULT_RC)
@@ -204,4 +204,19 @@ def test_the_seeded_goal_is_of_the_quarter_we_are_in(make_db):
         goal = next(
             g for g in rc.client.all_documents("mc_goals") if g["project"] == "na-a-project-of-this-quarter"
         )
-    assert goal["period"] == quarter_of(dt.date.today())
+    assert goal["period"] == period_of(dt.date.today())
+
+
+def test_a_project_can_be_prepared_for_the_period_to_come(make_db):
+    # Test --next.  Preparing for next term happens while this one is still
+    # running, and without this the goal would land in the period being
+    # finished rather than the one being planned
+    os.chdir(make_db)
+    main(["helper", "a_mcproject", "a project for next term", "--next"])
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        goal = next(g for g in rc.client.all_documents("mc_goals") if g["project"] == "na-a-project-for-next-term")
+    assert goal["period"] == next_period(dt.date.today())
+    assert goal["period"] != period_of(dt.date.today())

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -1,13 +1,19 @@
 """Tests for the pieces the mission control tools share."""
 
+import datetime as dt
+
 import pytest
 
 from regolith.mc import (
     ID_ALPHABET,
     ID_LENGTH,
     WIDTH,
+    DocumentError,
     initials,
     logical_lines,
+    next_period,
+    period_key,
+    period_of,
     project_id,
     short_id,
     struck,
@@ -249,3 +255,69 @@ def test_initials_shorten_a_name_the_way_the_group_does(name, expected_initials)
 )
 def test_a_project_id_says_whose_project_it_is(name, taken, prefix, expected_id):
     assert project_id(name, taken, prefix) == expected_id
+
+
+UCSB = {"fall": "10-01", "winter": "01-01", "spring": "04-01", "summer": "07-01"}
+
+
+@pytest.mark.parametrize(
+    "date, periods, expected_period, expected_next",
+    [
+        # Test which period a date falls in and which comes after it.  A group
+        # says what its periods are called and when they start; the default is
+        # semesters, since most universities are on them.
+        # C1: the default semesters, in the autumn one
+        (dt.date(2026, 9, 7), None, "2026fall", "2027spring"),
+        # C2: the same date on a quarter system, where the autumn term has not
+        # started yet
+        (dt.date(2026, 9, 7), UCSB, "2026summer", "2026fall"),
+        # C3: the last period of the year, where the next one is next year's
+        (dt.date(2026, 11, 15), UCSB, "2026fall", "2027winter"),
+        # C4: the first day of a period, which belongs to the period it starts
+        (dt.date(2027, 1, 1), UCSB, "2027winter", "2027spring"),
+        # C5: before the first period of the year begins, on a calendar whose
+        # periods all start later, expect the last period of the year before
+        (dt.date(2027, 2, 1), {"midyear": "06-01"}, "2026midyear", "2027midyear"),
+    ],
+)
+def test_a_date_falls_in_the_period_a_group_says_it_does(date, periods, expected_period, expected_next):
+    assert period_of(date, periods) == expected_period
+    assert next_period(date, periods) == expected_next
+
+
+def test_periods_sort_into_the_order_they_come_round():
+    # Test that periods order by when they happen rather than by their names,
+    # which do not agree: fall comes before spring in the alphabet and after
+    # it in the year.  The archive and the current period both depend on this
+    written = ["2026fall", "2026spring", "2026summer", "2026winter", "2027winter"]
+    assert sorted(written, key=lambda p: period_key(p, UCSB)) == [
+        "2026winter",
+        "2026spring",
+        "2026summer",
+        "2026fall",
+        "2027winter",
+    ]
+
+
+def test_a_period_written_some_other_way_still_sorts():
+    # Test that a period from before a group settled its calendar does not
+    # bring the ordering down, since documents already carry them
+    assert period_key("2026Q3", UCSB) > period_key("2026fall", UCSB)
+
+
+@pytest.mark.parametrize(
+    "periods",
+    [
+        # Test that a calendar nobody can read says so, naming the period that
+        # is wrong, rather than failing somewhere later.
+        # C1: a date written the wrong way round
+        {"fall": "01-40"},
+        # C2: not a date at all
+        {"fall": "the first of October"},
+        # C3: nothing there
+        {"fall": None},
+    ],
+)
+def test_a_period_that_does_not_start_on_a_date_says_so(periods):
+    with pytest.raises(DocumentError, match="not a date of the year"):
+        period_of(dt.date(2026, 9, 7), periods)

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -627,3 +627,28 @@ def test_every_section_is_written_even_with_nothing_in_it():
     ]:
         assert heading in document
     assert "\n\n\n" not in document
+
+
+def test_the_archive_reads_in_the_order_the_periods_came_round():
+    # Test that the archive is ordered by when a period happened rather than
+    # by the letters of its name.  Named periods do not sort into the order
+    # they come round, so an archive sorted on the text would put the autumn
+    # term of a year before its spring
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.periods = {"fall": "10-01", "winter": "01-01", "spring": "04-01"}
+    named = [
+        dict(GOALS[0], _id=f"g-{period}", period=period, first_period=period, status="finished")
+        for period in ("2026winter", "2026spring", "2026fall", "2027winter")
+    ]
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], lead="pliu")],
+        "mc_goals": named,
+        "mc_tasks": [],
+        "people": [],
+    }
+    document = "\n".join(builder.documents()["pliu"])
+    archived = [line for line in document.splitlines() if line.startswith("### Goals — ")]
+    assert archived == ["### Goals — 2026fall", "### Goals — 2026spring", "### Goals — 2026winter"]
+    # the latest period is the current one, so it heads the document rather
+    # than the archive
+    assert "## Goals — 2027winter" in document


### PR DESCRIPTION
The period was the calendar quarter the date fell in, written 2026Q3. Nobody runs a group by calendar quarters: UCSB is on terms starting in January, April, July and October, Columbia is on semesters, and a group outside a university may be on something else again.

mission_control_periods in regolithrc.json now says what the periods are called and the day each starts, as {name: "MM-DD"}, and a period is written as the year and the name: 2026fall.  The default is semesters, starting on 1 January, 1 June and 1 September, since most universities are on them.  A start that is not a date of the year says so, naming the period that is wrong.

This brought an ordering bug with it, which mc.period_key fixes.  Named periods do not sort into the order they come round -- fall comes before spring in the alphabet and after it in the year -- so an archive sorted on the text put a year's autumn term before its spring, and the current period, being the latest, came out as whichever sorted last.  Everything that orders periods now orders them by when they came round.  A period written some other way, as the ones already in the collections are, still sorts rather than bringing the render down.

a_mcproject --next seeds the goal into the period after this one, for preparing work that starts next term while this one is still running.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64