### PR TITLE
fix: never write a mission control document over work it still holds

### DIFF
--- a/news/mc-build-never-overwrites-work.rst
+++ b/news/mc-build-never-overwrites-work.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -28,11 +28,15 @@ from regolith.mc import (
     period_of,
     struck,
     week_of,
+    would_lose,
     wrap,
 )
 from regolith.tools import all_docs_from_collection
 
 UNASSIGNED = "unassigned"
+# how many of the things a document would lose to name before saying how many
+# more there are
+SHOWN_WHEN_REFUSING = 10
 UNASSIGNED_NAME = "unassigned"
 HELD_STATI = ("on-deck", "wishlist")
 ID_IN_DOCUMENT = re.compile(r"\^([\w.-]+)")
@@ -269,11 +273,50 @@ class MissionControlBuilder(BuilderBase):
         gtx["all_docs_from_collection"] = all_docs_from_collection
 
     def render(self):
-        """Write a document for each person, and one for the orphans."""
+        """Write a document for each person, and one for the orphans.
+
+        A render writes the collections out over the document, so a
+        document is only written when everything in it is in the
+        collections already.  Anything else is work that has not been
+        read back yet, and writing over it would be the end of it.
+        """
         self.mcdir.mkdir(parents=True, exist_ok=True)
         for person, lines in sorted(self.documents(self.existing_orders()).items()):
             path = self.mcdir / f"{self.document_name(person)}.md"
-            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            written = "\n".join(lines) + "\n"
+            if path.is_file():
+                existing = path.read_text(encoding="utf-8")
+                lost = would_lose(existing, written)
+                if lost:
+                    self.refuse(path, lost)
+                    continue
+                self.keep_a_copy(path, existing)
+            path.write_text(written, encoding="utf-8")
+
+    @staticmethod
+    def refuse(path, lost):
+        """Say why a document was left as it is."""
+        print(f"{path.name} was left alone: it says things the collections do not have.")
+        for said in lost[:SHOWN_WHEN_REFUSING]:
+            print(f"    {said}")
+        if len(lost) > SHOWN_WHEN_REFUSING:
+            print(f"    ... and {len(lost) - SHOWN_WHEN_REFUSING} more")
+        print("Run 'regolith helper mc_sync' to read them in, then build again.")
+        print(
+            "A line still named after a sync is one the collections cannot hold as "
+            "it is: put it under a goal or a project, or take it out."
+        )
+
+    def keep_a_copy(self, path, existing):
+        """Keep the document as it was before writing over it.
+
+        The copy goes under the build directory rather than beside the
+        document, so that it is out of the way of whatever syncs the
+        documents themselves.
+        """
+        previous = Path(self.bldir) / "mission-control-previous"
+        previous.mkdir(parents=True, exist_ok=True)
+        (previous / path.name).write_text(existing, encoding="utf-8")
 
     def existing_orders(self):
         """Return what each document already in the build dir names, in

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -458,6 +458,72 @@ def logical_lines(text):
     return joined
 
 
+HEADING_LINE = re.compile(r"^\s*#+\s")
+# what a render may add to or take off a line without the line having changed
+LEADING = re.compile(r"^\s*(?:[-*]\s+(?:\[[ xX]\]\s+)?)?(?:\d+(?:\.\d+)*\.?\s+)?")
+NOTE = re.compile(r"\((?:carried since|finished|dropped|→ rolled to)[^)]*\)")
+MARKS = re.compile(r"\^[\w.-]+|~~|\*\*")
+
+
+def said_in(line):
+    """Return what a line says, without the marks a render may change.
+
+    The number in front of a goal is positional, the id after it is
+    written by the render, and the note at the end says what became of
+    it.  None of them is what somebody typed, so none of them counts
+    when asking whether a line is still there.
+
+    Parameters
+    ----------
+    line : str
+        The line, as the document has it.
+
+    Returns
+    -------
+    str
+        What it says.
+    """
+    text = NOTE.sub("", LEADING.sub("", line.strip(), count=1))
+    return " ".join(MARKS.sub("", text).split())
+
+
+def would_lose(existing, written):
+    """Return what a document says that a new one would not.
+
+    A render writes the collections out over the document, so anything
+    in the document that never reached the collections is gone.  That is
+    every line typed since the last sync, and every line a sync could
+    not store: a goal under no project, a task under no goal, a note
+    somebody left in the margin.
+
+    Headings are not compared.  They are the shape of the document
+    rather than anything somebody typed, and a week with nothing left in
+    it is meant to go.
+
+    Parameters
+    ----------
+    existing : str
+        The document as it stands.
+    written : str
+        The document as the render would write it.
+
+    Returns
+    -------
+    list of str
+        What the document says and the render does not, in the order it
+        says it.  Empty when nothing would be lost.
+    """
+    kept = {said_in(line) for _, line in logical_lines(written) if not HEADING_LINE.match(line)}
+    lost = []
+    for _, line in logical_lines(existing):
+        if not line.strip() or HEADING_LINE.match(line):
+            continue
+        said = said_in(line)
+        if said and said not in kept and said not in lost:
+            lost.append(said)
+    return lost
+
+
 def parse_document(text, taken=(), prefix=None):
     """Return the projects, goals and tasks a mission control document
     describes.

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -17,6 +17,7 @@ from regolith.mc import (
     project_id,
     short_id,
     struck,
+    would_lose,
     wrap,
 )
 
@@ -321,3 +322,62 @@ def test_a_period_written_some_other_way_still_sorts():
 def test_a_period_that_does_not_start_on_a_date_says_so(periods):
     with pytest.raises(DocumentError, match="not a date of the year"):
         period_of(dt.date(2026, 9, 7), periods)
+
+
+BUILT = """# Mission control — Simon Billinge
+
+## Projects
+
+1. **a project**  ^p1
+
+## Goals — 2026summer
+
+- 1.1  a stored goal  ^g1
+
+## Week of 2026-09-07
+
+- [ ] 1.1.1  a stored task  ^t1
+
+## On-deck
+
+## Wishlist
+
+## Archive
+"""
+
+
+@pytest.mark.parametrize(
+    "typed, expected_lost",
+    [
+        # Test what a render would write over.  A render puts the collections
+        # out over the document, so anything in the document that never
+        # reached the collections is gone, and that is what this has to catch.
+        # C1: nothing added, expect nothing lost
+        (BUILT, []),
+        # C2: a goal typed with no number, which a sync cannot store and so
+        # never reaches the collections
+        (
+            BUILT.replace("- 1.1  a stored goal  ^g1", "- 1.1  a stored goal  ^g1\n- one I typed"),
+            ["one I typed"],
+        ),
+        # C3: a task typed since the last sync
+        (
+            BUILT.replace("- [ ] 1.1.1  a stored task  ^t1", "- [ ] 1.1.1  a stored task  ^t1\n- [ ] and another"),
+            ["and another"],
+        ),
+        # C4: a note left in the margin, which no section holds and so no
+        # sync can store.  This is the one that cost Simon a morning's work
+        (
+            BUILT.replace("## On-deck", "remember to ask about the beamtime\n\n## On-deck"),
+            ["remember to ask about the beamtime"],
+        ),
+        # C5: a line whose number and id changed but whose text did not, which
+        # is an ordinary render and loses nothing
+        (BUILT.replace("- 1.1  a stored goal  ^g1", "- 2.3  a stored goal  ^g1  (carried since 2026spring)"), []),
+        # C6: a line struck through since the last sync, which says the same
+        # thing and so is not lost, only unsaved
+        (BUILT.replace("a stored goal", "~~a stored goal~~"), []),
+    ],
+)
+def test_would_lose_finds_what_a_render_would_write_over(typed, expected_lost):
+    assert would_lose(typed, BUILT) == expected_lost

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -652,3 +652,70 @@ def test_the_archive_reads_in_the_order_the_periods_came_round():
     # the latest period is the current one, so it heads the document rather
     # than the archive
     assert "## Goals — 2027winter" in document
+
+
+def render_into(tmp_path, gtx):
+    """Return a builder writing into a directory."""
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = gtx
+    builder.mcdir = tmp_path / "mission-control"
+    builder.bldir = str(tmp_path / "build")
+    return builder
+
+
+BUILDABLE = {
+    "mc_projects": [{"_id": "p1", "name": "a project", "status": "active", "lead": "pliu"}],
+    "mc_goals": [
+        {
+            "_id": "g1",
+            "project": "p1",
+            "period": "2026fall",
+            "first_period": "2026fall",
+            "text": "a stored goal",
+            "status": "active",
+        }
+    ],
+    "mc_tasks": [],
+    "people": [{"_id": "pliu", "name": "Pei Liu"}],
+}
+
+
+def test_a_build_writes_a_document_that_holds_nothing_new(tmp_path):
+    # Test the ordinary build: the document says what the collections say, so
+    # writing it over loses nothing and it is written
+    builder = render_into(tmp_path, BUILDABLE)
+    builder.render()
+    written = (builder.mcdir / "pei.md").read_text()
+    assert "^g1" in written
+    builder.render()
+    assert (builder.mcdir / "pei.md").read_text() == written
+
+
+def test_a_build_leaves_a_document_that_holds_work_of_its_own(tmp_path, capsys):
+    # Test the promise the whole design rests on: a build writes the
+    # collections out over the document, so a document holding anything the
+    # collections do not have is left alone rather than written over.  Simon
+    # lost a morning's work to this, typed into the file and never synced
+    builder = render_into(tmp_path, BUILDABLE)
+    builder.render()
+    path = builder.mcdir / "pei.md"
+    typed = path.read_text().replace("## On-deck", "ask about the beamtime\n\n## On-deck")
+    path.write_text(typed)
+
+    builder.render()
+    assert path.read_text() == typed
+    said = capsys.readouterr().out
+    assert "was left alone" in said
+    assert "ask about the beamtime" in said
+    assert "mc_sync" in said
+
+
+def test_a_build_keeps_the_document_it_wrote_over(tmp_path):
+    # Test that a document written over is still recoverable, since a render
+    # that loses nothing by its own reckoning may still surprise somebody
+    builder = render_into(tmp_path, BUILDABLE)
+    builder.render()
+    first = (builder.mcdir / "pei.md").read_text()
+    builder.gtx = dict(BUILDABLE, mc_goals=[dict(BUILDABLE["mc_goals"][0], text="a stored goal")])
+    builder.render()
+    assert (tmp_path / "build" / "mission-control-previous" / "pei.md").read_text() == first


### PR DESCRIPTION
build mission-control wrote the collections out over every document without reading one first.  It opened each only to learn the order of the ids in it.  So everything typed since the last sync was gone, and so was everything a sync could not store: a goal under no project, a task under no goal, a note left in the margin.  Nothing warned, and nothing kept a copy.

mc.would_lose says what a document says that a new one would not, comparing what each line says rather than how it is written, so renumbering, wrapping, an id being added and a note like "carried since" all count as the same line.  Headings are not compared: they are the shape of the document rather than anything anybody typed.

A document that would lose something is left alone, and the build says which lines are at risk and what to do about them.  A document that would lose nothing is copied to <builddir>/mission-control-previous before it is written, so that even an ordinary render can be undone.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64