### PR TITLE
style: list the mission control helpers with hyphens, and take either…

### DIFF
--- a/news/mc-helpers-take-dashes.rst
+++ b/news/mc-helpers-take-dashes.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Helper targets can be typed with hyphens or with underscores, whichever way
+  they are listed, so ``regolith helper l-todo`` and ``regolith helper l_todo``
+  are the same command.  The mission control helpers are listed with hyphens.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helper.py
+++ b/src/regolith/helper.py
@@ -12,11 +12,11 @@ UPDATER_HELPER_SPECS = {
         "regolith.helpers.a_expensehelper:ExpenseAdderHelper",
         "regolith.helpers.a_expensehelper:subparser",
     ),
-    "mc_sync": (
+    "mc-sync": (
         "regolith.helpers.mcsynchelper:MCSyncHelper",
         "regolith.helpers.mcsynchelper:subparser",
     ),
-    "a_mcproject": (
+    "a-mcproject": (
         "regolith.helpers.a_mcprojecthelper:MCProjectAdderHelper",
         "regolith.helpers.a_mcprojecthelper:subparser",
     ),
@@ -97,15 +97,15 @@ LISTER_HELPER_SPECS = {
         "regolith.helpers.l_grantshelper:GrantsListerHelper",
         "regolith.helpers.l_grantshelper:subparser",
     ),
-    "u_mcproject": (
+    "u-mcproject": (
         "regolith.helpers.u_mcprojecthelper:MCProjectUpdaterHelper",
         "regolith.helpers.u_mcprojecthelper:subparser",
     ),
-    "l_mcgoals": (
+    "l-mcgoals": (
         "regolith.helpers.l_mcgoalshelper:MCGoalsListerHelper",
         "regolith.helpers.l_mcgoalshelper:subparser",
     ),
-    "l_mcprojects": (
+    "l-mcprojects": (
         "regolith.helpers.l_mcprojectshelper:MCProjectsListerHelper",
         "regolith.helpers.l_mcprojectshelper:subparser",
     ),

--- a/src/regolith/helpers/a_mcprojecthelper.py
+++ b/src/regolith/helpers/a_mcprojecthelper.py
@@ -37,7 +37,7 @@ SEEDED_COLLS = ("mc_goals", "mc_tasks")
 # a stub is written down so that it is not forgotten, and what is not known
 # yet says so rather than being left out
 TBD = "tbd"
-HELPER_TARGET = "a_mcproject"
+HELPER_TARGET = "a-mcproject"
 
 
 def subparser(subpi):

--- a/src/regolith/helpers/l_mcgoalshelper.py
+++ b/src/regolith/helpers/l_mcgoalshelper.py
@@ -12,7 +12,7 @@ from regolith.mc import CLOSED, HELD
 from regolith.tools import all_docs_from_collection, key_value_pair_filter
 
 TARGET_COLL = "mc_goals"
-HELPER_TARGET = "l_mcgoals"
+HELPER_TARGET = "l-mcgoals"
 
 
 def subparser(subpi):

--- a/src/regolith/helpers/l_mcprojectshelper.py
+++ b/src/regolith/helpers/l_mcprojectshelper.py
@@ -16,7 +16,7 @@ from regolith.mc import CLOSED, orphaned, unled
 from regolith.tools import all_docs_from_collection, collection_str, key_value_pair_filter
 
 TARGET_COLL = "mc_projects"
-HELPER_TARGET = "l_mcprojects"
+HELPER_TARGET = "l-mcprojects"
 
 
 def subparser(subpi):

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -33,7 +33,7 @@ from regolith.mc import (
 from regolith.schemas import SCHEMAS, validate
 from regolith.tools import all_docs_from_collection
 
-HELPER_TARGET = "mc_sync"
+HELPER_TARGET = "mc-sync"
 COLLECTIONS = ("mc_projects", "mc_goals", "mc_tasks")
 # a document that has lost more than this share of what it held is more
 # likely to be damaged than edited

--- a/src/regolith/helpers/u_mcprojecthelper.py
+++ b/src/regolith/helpers/u_mcprojecthelper.py
@@ -17,7 +17,7 @@ from regolith.helpers.basehelper import DbHelperBase
 from regolith.schemas import MC_STATI
 
 TARGET_COLL = "mc_projects"
-HELPER_TARGET = "u_mcproject"
+HELPER_TARGET = "u-mcproject"
 
 # what the command line can set, against the field each one sets.  A list is
 # replaced rather than added to, so that what is given is what is stored.

--- a/src/regolith/lazy.py
+++ b/src/regolith/lazy.py
@@ -34,7 +34,33 @@ class LazyRegistry(Mapping):
         module_name, _, attribute = spec.partition(":")
         return getattr(import_module(module_name), attribute)
 
+    def canonical(self, name):
+        """Return the name an entry is listed under.
+
+        Targets face the user with hyphens and python with underscores,
+        the way argparse has always done it, so a name typed either way
+        finds the entry.  A name that matches nothing is handed back as
+        it was, for whoever asked to report.
+
+        Parameters
+        ----------
+        name : str
+            The name as it was typed.
+
+        Returns
+        -------
+        str
+            The name it is listed under.
+        """
+        if name in self._specs:
+            return name
+        for spelling in (str(name).replace("_", "-"), str(name).replace("-", "_")):
+            if spelling in self._specs:
+                return spelling
+        return name
+
     def __getitem__(self, name):
+        name = self.canonical(name)
         if name not in self._resolved:
             self._resolved[name] = self._resolve(self._specs[name])
         return self._resolved[name]
@@ -42,7 +68,7 @@ class LazyRegistry(Mapping):
     def __contains__(self, name):
         # Answer from the names alone, so that testing for a target does
         # not import it
-        return name in self._specs
+        return self.canonical(name) in self._specs
 
     def __iter__(self):
         return iter(self._specs)

--- a/src/regolith/main.py
+++ b/src/regolith/main.py
@@ -314,6 +314,9 @@ def main(args=None):
         if len(rest) == 0:
             p.print_help()
         args2, rest2 = p.parse_known_args(rest, namespace=args0)
+        # a target typed with underscores is the same target as one typed with
+        # hyphens, and everything after this sees the name it is listed under
+        args2.helper_target = HELPERS.canonical(args2.helper_target)
         # it is not apparent from this but the following line calls the subparser in
         #   in the helper module to get the rest of the args.
         HELPERS[args2.helper_target][1](p)

--- a/tests/test_helper_gui.py
+++ b/tests/test_helper_gui.py
@@ -45,3 +45,28 @@ def test_no_argument_is_labelled_with_a_tuple(target):
             f"{target} labels {action.dest} with a tuple. Give it no metavar, or "
             f"one string, so that the helper GUI can label the field."
         )
+
+
+@pytest.mark.parametrize(
+    "typed, expected_target",
+    [
+        # Test that a target is found however it is spelled.  Targets face the
+        # user with hyphens now, the way argparse has always spelled an
+        # argument, and the underscored spelling keeps working so that nobody
+        # has to retype an alias.
+        # C1: the name as it is listed
+        ("mc-sync", "mc-sync"),
+        # C2: the same target with underscores
+        ("mc_sync", "mc-sync"),
+        # C3: a target still listed with underscores, typed as it is listed
+        ("l_todo", "l_todo"),
+        # C4: that one typed with hyphens
+        ("l-todo", "l_todo"),
+        # C5: a name that is no target at all, expect it handed back so that
+        # whoever asked can say so
+        ("no-such-helper", "no-such-helper"),
+    ],
+)
+def test_a_target_is_found_however_it_is_spelled(typed, expected_target):
+    assert HELPERS.canonical(typed) == expected_target
+    assert (typed in HELPERS) == (expected_target in HELPERS)


### PR DESCRIPTION
… spelling

argparse has spelled a user-facing name with hyphens and a python one with underscores since forever, and regolith followed it for arguments and not for targets: every helper target had underscores while half the builder targets had hyphens.

The mission control helpers are now mc-sync, a-mcproject, u-mcproject, l-mcprojects and l-mcgoals.  LazyRegistry takes a name spelled either way and hands back the one it is listed under, so no alias breaks, and main settles the name before anything else sees it, so nothing downstream has to know there are two spellings.

This is the first half of the second item in the regolith wishlist.  The targets that still have underscores can be renamed the same way whenever that is worth doing; typing them with hyphens already works.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64