### PR TITLE
fix: do not let --force apply a document that stopped being one

### DIFF
--- a/news/mc-sync-refuses-an-unreadable-document.rst
+++ b/news/mc-sync-refuses-an-unreadable-document.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -204,11 +204,25 @@ class MCSyncHelper(DbHelperBase):
         writes, drops = changes(parsed, None if person == UNASSIGNED else person, existing)
         held = sum(len(records) for records in existing.values())
         dropped = sum(len(ids) for ids in drops.values())
+        read = sum(len(parsed[kind]) for kind in ("projects", "goals", "tasks"))
+        if held and not read:
+            # nothing in it was recognised at all.  That is not somebody
+            # deleting their work, it is a file that has stopped being a
+            # mission control document, and --force does not apply to it:
+            # there is nothing in it to apply
+            print(f"{path.name} has nothing in it that a mission control document has.")
+            print("Its headings and its bullets have gone, which is what an editor does to a")
+            print("file when it saves it as plain text rather than as markdown.")
+            self.name_what_is_at_risk(existing, drops)
+            print("Nothing was written from it, with or without --force.")
+            print(f"Put the document back from your file history, or from {self.copies()}.")
+            return
         if held and dropped > held * DROP_SHARE and not rc.force:
             print(
                 f"{path.name} no longer holds {dropped} of the {held} things it had, which "
                 f"is more like damage than editing, so nothing was written from it."
             )
+            self.name_what_is_at_risk(existing, drops)
             print("Check the document, or run this again with --force to apply it anyway.")
             return
 
@@ -229,6 +243,30 @@ class MCSyncHelper(DbHelperBase):
             for _id in ids:
                 rc.client.update_field(rc.database, collection, _id, "status", "dropped")
         self.report(path, writes, drops, wrote=True)
+
+    def copies(self):
+        """Return where a render keeps the copy it took."""
+        return f"{self.rc.builddir}/mission-control-previous"
+
+    @staticmethod
+    def name_what_is_at_risk(existing, drops):
+        """Say which things a document no longer holds.
+
+        A count says how much is at stake and not what, and what is what
+        somebody needs in order to tell whether the document is right.
+
+        Parameters
+        ----------
+        existing : dict
+            The records stored, as ``{collection: {id: record}}``.
+        drops : dict
+            The ids no longer in the document, by collection.
+        """
+        for collection, ids in drops.items():
+            for _id in ids:
+                record = existing[collection].get(_id, {})
+                said = record.get("name") or record.get("text") or ""
+                print(f"    {_id}  {said}")
 
     @staticmethod
     def report(path, writes, drops, wrote):

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -164,12 +164,37 @@ def test_a_line_taken_out_is_dropped(mc_repo):
 
 def test_a_document_that_lost_most_of_itself_is_left_alone(mc_repo, capsys):
     # Test the guard against damage: a document missing most of what it held
-    # is more likely broken than edited, so nothing is written from it
+    # is more likely broken than edited, so nothing is written from it.  It
+    # still says what a mission control document says, so this is the guard
+    # that --force is for
     _, mcdir = mc_repo
-    (mcdir / "pei.md").write_text("# Mission control — Pei Liu\n")
+    path = mcdir / "pei.md"
+    kept = path.read_text().split("## Goals")[0]
+    path.write_text(kept)
     main(["helper", "mc_sync"])
-    assert "more like damage than editing" in capsys.readouterr().out
+    said = capsys.readouterr().out
+    assert "more like damage than editing" in said
+    # what is at stake is named, not just counted
+    assert "mct001  a task" in said
     assert stored(mc_repo, "mc_tasks", "mct001")["status"] == "active"
+
+
+def test_a_document_that_stopped_being_one_is_left_alone_even_forced(mc_repo, capsys):
+    # Test the file Simon lost his work to.  An editor saved his document as
+    # plain text, so its headings and bullets went, and every line in it
+    # became unreadable at once.  That is not somebody deleting their work,
+    # and --force must not treat it as though it were: there is nothing in the
+    # document to apply
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    stripped = path.read_text().replace("#", "").replace("- ", "").replace("[ ]", "").replace("**", "")
+    path.write_text(stripped)
+    main(["helper", "mc_sync", "--force"])
+    said = capsys.readouterr().out
+    assert "nothing in it that a mission control document has" in said
+    assert "with or without --force" in said
+    for collection, _id in [("mc_projects", "mc-a-project"), ("mc_goals", "mcg001"), ("mc_tasks", "mct001")]:
+        assert stored(mc_repo, collection, _id)["status"] != "dropped"
 
 
 def test_a_document_that_cannot_be_read_is_skipped_whole(mc_repo, capsys):


### PR DESCRIPTION
An editor saved Simon's document as plain text.  Its headings, bullets and boxes went, so mc.parse_document read nothing at all from it, every record he had became a line no longer in the document, and the damage guard fired: "4 of the 4 things it had".  That guard is meant for somebody deleting a lot of work on purpose, so --force is the way past it, and forcing it dropped all four records.

A document that reads as nothing is not somebody deleting their work, and --force no longer applies to it: there is nothing in it to apply. The message says what the file looks like and where the copy a render took can be found, since that is what somebody in this position needs.

Both guards now name the things at risk rather than counting them.  A count says how much is at stake and not what, and what is what somebody needs in order to tell whether the document is right.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64