### PR TITLE
fix: sync a record into the database that holds it, and say what was new

### DIFF
--- a/news/mc-sync-says-where-it-wrote.rst
+++ b/news/mc-sync-says-where-it-wrote.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -219,22 +219,70 @@ class MCSyncHelper(DbHelperBase):
                     print(f"{path.name}: {record['_id']} does not fit {collection} and was not written.")
                     print(f"  {why}")
                     return
+        new = sum(
+            1 for collection, records in writes.items() for r in records if r["_id"] not in existing[collection]
+        )
         if rc.dry_run:
-            self.report(path, writes, drops, wrote=False)
+            self.report(path, writes, drops, wrote=False, new=new)
             return
         for collection, records in writes.items():
             for record in records:
-                rc.client.update_one(rc.database, collection, {"_id": record["_id"]}, record, upsert=True)
+                where = self.where_it_goes(collection, record["_id"])
+                rc.client.update_one(where, collection, {"_id": record["_id"]}, record, upsert=True)
         for collection, ids in drops.items():
             for _id in ids:
-                rc.client.update_field(rc.database, collection, _id, "status", "dropped")
-        self.report(path, writes, drops, wrote=True)
+                rc.client.update_field(self.where_it_goes(collection, _id), collection, _id, "status", "dropped")
+        self.report(path, writes, drops, wrote=True, new=new)
+
+    def where_it_goes(self, collection, _id):
+        """Return the database a record belongs in.
+
+        A record already stored is written where it is stored, rather
+        than in the first database that happens to be listed, since
+        writing it anywhere else would leave two of it and hide the one
+        that is real.  A record nothing holds yet goes where the
+        collection is, or to rc.database when nothing holds it at all.
+
+        Parameters
+        ----------
+        collection : str
+            The name of the collection.
+        _id : str
+            The id of the record.
+
+        Returns
+        -------
+        str
+            The name of the database to write to.
+        """
+        rc = self.rc
+        sources = rc.client.collection_sources(collection)
+        for database in sources:
+            if rc.client.find_one(database["name"], collection, {"_id": _id}):
+                return database["name"]
+        return sources[0]["name"] if sources else rc.database
 
     @staticmethod
-    def report(path, writes, drops, wrote):
+    def report(path, writes, drops, wrote, new=0):
         """Say what was written, so a surprise is seen rather than
-        found."""
+        found.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            The document that was read.
+        writes : dict
+            The records written, by collection.
+        drops : dict
+            The ids dropped, by collection.
+        wrote : bool
+            Whether anything was actually written.
+        new : int, optional
+            How many of the records nothing held before, which is what
+            somebody typing into the document wants to see.
+        """
         written = sum(len(records) for records in writes.values())
         dropped = sum(len(ids) for ids in drops.values())
         did = "wrote" if wrote else "would write"
-        print(f"{path.name}: {did} {written}, dropped {dropped}")
+        of_which = f", {new} of them new" if new else ""
+        print(f"{path.name}: {did} {written}{of_which}, dropped {dropped}")

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -264,3 +264,28 @@ def test_a_project_nobody_leads_is_named_na(mc_repo):
     )
     main(["helper", "mc_sync"])
     assert stored(mc_repo, "mc_projects", "na-software-maintenance")["status"] == "proposed"
+
+
+def test_the_sync_says_how_many_lines_were_new(mc_repo, capsys):
+    # Test that a sync says what it did in terms somebody typing can check.
+    # "wrote 3" says nothing about whether the lines just typed were among
+    # them, which is the one thing worth knowing after typing into a document
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(
+        path.read_text().replace("- 1.1  a goal  ^mcg001", "- 1.1  a goal  ^mcg001\n- 1.2  a new goal")
+    )
+    main(["helper", "mc_sync"])
+    assert "1 of them new" in capsys.readouterr().out
+
+
+def test_a_record_is_written_where_it_is_already_stored(mc_repo):
+    # Test that a sync writes a record back to the database holding it rather
+    # than to whichever database is listed first, which would leave a second
+    # copy shadowing the real one
+    tmp_path, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text().replace("a goal", "a goal, reworded"))
+    main(["helper", "mc_sync"])
+    stored_in_db = (tmp_path / "db" / "mc_goals.yaml").read_text()
+    assert "a goal, reworded" in stored_in_db


### PR DESCRIPTION
mcsynchelper wrote every record to rc.databases[0], which the runcontrol fills in before any updater runs.  With one database that is right by accident.  With more than one, a record stored in the second was written to the first instead, leaving two of it, with whichever the chain resolves last winning: a line read back from a document could look as though it had never been stored.

Each record now goes to the database that already holds it, the way u_mcproject does it, and a record nothing holds yet goes where its collection lives.

The report also says how many of the records nothing held before.  "wrote 9" says nothing about whether the lines somebody has just typed were among them, which is the one thing worth knowing after typing into a document.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64