### PR TITLE
feat: let a thing on deck or on the wishlist belong to no project yet

### DIFF
--- a/news/mc-held-items-need-no-project.rst
+++ b/news/mc-held-items-need-no-project.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -27,6 +27,7 @@ from regolith.mc import (
     period_key,
     period_of,
     struck,
+    unassigned,
     week_of,
     would_lose,
     wrap,
@@ -228,6 +229,12 @@ class MissionControlBuilder(BuilderBase):
         # goal belongs to and the order the archive reads in
         self.periods = getattr(rc, "mission_control_periods", None)
 
+    @staticmethod
+    def owner(person):
+        """Return the id a goal of no project carries, or None for the
+        unassigned document."""
+        return None if person == UNASSIGNED else person
+
     def display_name(self, person):
         """Return the name to head a person's document with."""
         for entry in self.gtx.get("people", []):
@@ -363,9 +370,15 @@ class MissionControlBuilder(BuilderBase):
         """
         projects = in_document_order(projects, order, lambda p: p["_id"])
         number_of = {project["_id"]: n for n, project in enumerate(projects, start=1)}
-        goals = in_document_order(
-            [g for g in live(self.gtx["mc_goals"]) if g["project"] in number_of], order, lambda g: g["_id"]
-        )
+        # a goal of a project belongs to whoever leads the project; a goal of
+        # no project says whose it is itself, and is held on deck or on the
+        # wishlist until somebody gives it a project
+        mine = [
+            g
+            for g in live(self.gtx["mc_goals"])
+            if g["project"] in number_of or (unassigned(g) and g.get("lead") == self.owner(person))
+        ]
+        goals = in_document_order(mine, order, lambda g: g["_id"])
         goal_number = self.number_goals(goals, number_of)
         tasks = [t for t in live(self.gtx["mc_tasks"]) if t["goal"] in goal_number]
 
@@ -396,7 +409,10 @@ class MissionControlBuilder(BuilderBase):
         """
         numbers = {}
         counts = defaultdict(int)
-        for goal in sorted(goals, key=lambda g: number_of[g["project"]]):
+        # a goal of no project has no number: the number says which project it
+        # is of, and that is the thing nobody has decided yet
+        of_a_project = [goal for goal in goals if goal["project"] in number_of]
+        for goal in sorted(of_a_project, key=lambda g: number_of[g["project"]]):
             counts[goal["project"]] += 1
             numbers[goal["_id"]] = f"{number_of[goal['project']]}.{counts[goal['project']]}"
         return numbers
@@ -429,6 +445,10 @@ class MissionControlBuilder(BuilderBase):
         lines = [f"## Goals — {current}", ""]
         for goal in self.in_order(goals, goal_number):
             if goal["period"] != current or goal["status"] in HELD_STATI:
+                continue
+            if goal["_id"] not in goal_number:
+                # of no project, so it belongs in a holding section rather
+                # than among the goals of the period
                 continue
             lines.append(
                 f"- {goal_number[goal['_id']]}  {struck(goal['text'], goal['status'])}  "
@@ -512,7 +532,8 @@ class MissionControlBuilder(BuilderBase):
         held = [g for g in self.in_order(goals, goal_number) if g["status"] == status]
         lines = [f"## {heading}", ""]
         for goal in held:
-            lines.append(f"- {goal_number[goal['_id']]}  {struck(goal['text'], goal['status'])}  ^{goal['_id']}")
+            number = f"{goal_number[goal['_id']]}  " if goal["_id"] in goal_number else ""
+            lines.append(f"- {number}{struck(goal['text'], goal['status'])}  ^{goal['_id']}")
         lines.append("")
         return lines
 
@@ -532,7 +553,8 @@ class MissionControlBuilder(BuilderBase):
             shown = [
                 g
                 for g in self.in_order(goals, goal_number)
-                if self.period_key(g["first_period"]) <= self.period_key(period) <= self.period_key(g["period"])
+                if g["_id"] in goal_number
+                and self.period_key(g["first_period"]) <= self.period_key(period) <= self.period_key(g["period"])
             ]
             if not shown:
                 continue
@@ -547,8 +569,15 @@ class MissionControlBuilder(BuilderBase):
 
     @staticmethod
     def in_order(goals, goal_number):
-        """Return the goals in the order their numbers read."""
-        return sorted(goals, key=lambda g: [int(n) for n in goal_number[g["_id"]].split(".")])
+        """Return the goals in the order their numbers read.
+
+        A goal with no number is of no project yet, and goes after the
+        ones that are, in the order the document already had them.
+        """
+        numbered = [g for g in goals if g["_id"] in goal_number]
+        unnumbered = [g for g in goals if g["_id"] not in goal_number]
+        in_number_order = sorted(numbered, key=lambda g: [int(n) for n in goal_number[g["_id"]].split(".")])
+        return in_number_order + unnumbered
 
     def period_key(self, period):
         """Return a key putting periods in the order they came round."""

--- a/src/regolith/helpers/l_mcgoalshelper.py
+++ b/src/regolith/helpers/l_mcgoalshelper.py
@@ -8,7 +8,7 @@ somebody agreed to get done this period and how far along it is.
 from gooey import GooeyParser
 
 from regolith.helpers.basehelper import SoutHelperBase
-from regolith.mc import CLOSED, HELD
+from regolith.mc import CLOSED, HELD, unassigned
 from regolith.tools import all_docs_from_collection, key_value_pair_filter
 
 TARGET_COLL = "mc_goals"
@@ -61,10 +61,17 @@ class MCGoalsListerHelper(SoutHelperBase):
         goals = key_value_pair_filter(self.gtx[rc.coll], rc.filter) if rc.filter else self.gtx[rc.coll]
         projects = {project["_id"]: project for project in self.gtx["mc_projects"]}
 
+        # a goal of a project belongs to whoever leads the project; one held
+        # on deck or on the wishlist may be of no project yet, and says whose
+        # it is itself
         if rc.lead:
-            goals = [g for g in goals if projects.get(g["project"], {}).get("lead") == rc.lead]
+            goals = [g for g in goals if self.whose(g, projects) == rc.lead]
         if rc.person:
-            goals = [g for g in goals if self.is_on(projects.get(g["project"], {}), rc.person)]
+            goals = [
+                g
+                for g in goals
+                if self.is_on(projects.get(g["project"], {}), rc.person) or self.whose(g, projects) == rc.person
+            ]
         if rc.held:
             goals = [g for g in goals if g.get("status") in HELD]
         elif not rc.all:
@@ -76,14 +83,37 @@ class MCGoalsListerHelper(SoutHelperBase):
             goals = [g for g in goals if g.get("period") == period]
 
         for project_id, its_goals in self.by_project(goals):
-            project = projects.get(project_id, {})
-            print(f"{project_id}  ({project.get('lead', 'nobody')})  {project.get('name', '')}")
+            if project_id not in projects:
+                print(f"{project_id}  (of no project yet)")
+            else:
+                project = projects[project_id]
+                print(f"{project_id}  ({project.get('lead', 'nobody')})  {project.get('name', '')}")
             for goal in its_goals:
                 print(f"    {self.line(goal)}")
                 if rc.verbose and goal.get("notes"):
                     for note in goal["notes"]:
                         print(f"        {note}")
         return
+
+    @staticmethod
+    def whose(goal, projects):
+        """Return whose goal it is, by its project or by itself.
+
+        Parameters
+        ----------
+        goal : dict
+            The goal.
+        projects : dict
+            The projects, keyed by id.
+
+        Returns
+        -------
+        str or None
+            The id of the person whose goal it is.
+        """
+        if unassigned(goal):
+            return goal.get("lead")
+        return projects.get(goal["project"], {}).get("lead")
 
     @staticmethod
     def is_on(project, person):

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -29,6 +29,7 @@ from regolith.mc import (
     led_by,
     parse_document,
     slug,
+    unassigned,
 )
 from regolith.schemas import SCHEMAS, validate
 from regolith.tools import all_docs_from_collection
@@ -150,7 +151,13 @@ class MCSyncHelper(DbHelperBase):
         projects = {
             project["_id"]: project for project in live(self.gtx["mc_projects"]) if led_by(project) == lead
         }
-        goals = {goal["_id"]: goal for goal in live(self.gtx["mc_goals"]) if goal.get("project") in projects}
+        goals = {
+            goal["_id"]: goal
+            for goal in live(self.gtx["mc_goals"])
+            # a goal of no project is not reached through a project, so it is
+            # found by whose it is, or it would read as deleted every sync
+            if goal.get("project") in projects or (unassigned(goal) and goal.get("lead") == lead)
+        }
         tasks = {task["_id"]: task for task in live(self.gtx["mc_tasks"]) if task.get("goal") in goals}
         return {"mc_projects": projects, "mc_goals": goals, "mc_tasks": tasks}
 

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -349,6 +349,8 @@ GOALS_HEADING = re.compile(r"^Goals\s+—\s+(?P<period>\S+)$")
 # heading used to say, and is still read so that a document written before the
 # rename keeps working.
 HELD_HEADINGS = {"on-deck": "on-deck", "backburner": "on-deck", "wishlist": "wishlist"}
+# what a goal says instead of a project when it is not of one yet
+UNASSIGNED_PROJECT = "tbd"
 WEEK_HEADING = re.compile(r"^Week of\s+(?P<monday>\d{4}-\d{2}-\d{2})$")
 
 
@@ -694,10 +696,17 @@ class _Reader:
             return False
         goal_number = found.group("number")
         if goal_number is None:
-            raise DocumentError(f"line {number}: a goal needs a number saying which project it is of")
-        project_number = goal_number.split(".")[0]
-        if project_number not in self.by_number:
-            raise DocumentError(f"line {number}: there is no project {project_number}")
+            if self.section not in HELD:
+                raise DocumentError(f"line {number}: a goal needs a number saying which project it is of")
+            # a thing held on deck or on the wishlist is an idea that has not
+            # been made anybody's work yet, so it does not have to say which
+            # project it is of.  It says so when somebody gives it a number
+            project = UNASSIGNED_PROJECT
+        else:
+            project_number = goal_number.split(".")[0]
+            if project_number not in self.by_number:
+                raise DocumentError(f"line {number}: there is no project {project_number}")
+            project = self.by_number[project_number]
         # the archive says what a period was; the current sections say what is
         _id = found.group("id") or self.mint()
         if self.section == "archive":
@@ -707,13 +716,14 @@ class _Reader:
             return True
         goal = {
             "_id": _id,
-            "project": self.by_number[project_number],
+            "project": project,
             "period": self.period,
             "text": text,
             "status": self.goal_status(struck_out),
         }
         self.goals.append(goal)
-        self.by_number[goal_number] = _id
+        if goal_number is not None:
+            self.by_number[goal_number] = _id
         return True
 
     def goal_status(self, struck_out):
@@ -912,6 +922,14 @@ def changes(parsed, person, existing, today=None):
         record["status"] = settled_status(read["status"], was.get("status"))
         # written once, so how long a goal has been carried is knowable
         record.setdefault("first_period", read["period"])
+        # a goal of no project has no project to say whose it is, so it says
+        # so itself: it belongs to whoever's document it was written in
+        if unassigned(record):
+            record["lead"] = person
+            if person is None:
+                record.pop("lead", None)
+        else:
+            record.pop("lead", None)
         _close(record, was, today)
         writes["mc_goals"].append(record)
         seen["mc_goals"].add(record["_id"])
@@ -950,6 +968,27 @@ def _close(record, was, today):
 NOBODY = ("", "na", "tbd", "none")
 # a project in one of these is done with, so it cannot be an orphan
 CLOSED = ("finished", "dropped")
+
+
+def unassigned(goal):
+    """Return True if a goal is not of any project yet.
+
+    Something held on deck or on the wishlist is an idea somebody wrote
+    down, not work anybody has taken on, so it need not say which
+    project it belongs to.  It says so when they give it a number.
+
+    Parameters
+    ----------
+    goal : dict
+        The goal.
+
+    Returns
+    -------
+    bool
+        Whether it belongs to a project.
+    """
+    project = goal.get("project")
+    return not project or str(project).strip().lower() in NOBODY
 
 
 def unled(project):

--- a/src/regolith/schemas.json
+++ b/src/regolith/schemas.json
@@ -1345,6 +1345,11 @@
             "schema": {
                 "type": "string"
             }
+        },
+        "lead": {
+            "description": "The id of the person whose goal it is, for a goal that is not of any project yet. A goal of a project belongs to whoever leads the project, and does not carry this.",
+            "required": false,
+            "type": "string"
         }
     },
     "mc_projects": {

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -350,3 +350,54 @@ def test_a_goal_is_held_by_whichever_heading_it_is_under(heading, expected_statu
     )
     goal = next(g for g in parse_document(document)["goals"] if g["_id"] == "g1")
     assert goal["status"] == expected_status
+
+
+HELD_DOCUMENT = """# Mission control — Adib Kabir
+
+## Projects
+
+1. **a project**  ^p1
+
+## Goals — 2026fall
+
+- 1.1  a goal of the project  ^g1
+
+## On-deck
+
+- an idea nobody has taken on
+- 1.2  one that is of the project  ^g2
+
+## Wishlist
+
+- something for one day
+"""
+
+
+@pytest.mark.parametrize(
+    "text, expected_project",
+    [
+        # Test that a thing held on deck or on the wishlist need not say which
+        # project it is of.  It is an idea somebody wrote down rather than
+        # work anybody has taken on, and making them number it is what stops
+        # them writing it down at all.
+        # C1: no number, expect it is of no project yet
+        ("an idea nobody has taken on", "tbd"),
+        # C2: a number, expect it is of that project, so that an idea can be
+        # taken on by giving it one
+        ("one that is of the project", "p1"),
+        # C3: the wishlist reads the same way as on-deck
+        ("something for one day", "tbd"),
+    ],
+)
+def test_a_held_thing_need_not_be_of_a_project(text, expected_project):
+    goal = next(g for g in parse_document(HELD_DOCUMENT)["goals"] if g["text"] == text)
+    assert goal["project"] == expected_project
+
+
+def test_a_goal_of_the_period_still_needs_its_number():
+    # Test that only the holding sections take a line with no number.  A goal
+    # of the period is work somebody is doing, and which project it is of is
+    # the thing that says who is doing it
+    without = HELD_DOCUMENT.replace("- 1.1  a goal of the project  ^g1", "- a goal with no number")
+    with pytest.raises(DocumentError, match="needs a number saying which project"):
+        parse_document(without)

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -314,3 +314,24 @@ def test_a_record_is_written_where_it_is_already_stored(mc_repo):
     main(["helper", "mc_sync"])
     stored_in_db = (tmp_path / "db" / "mc_goals.yaml").read_text()
     assert "a goal, reworded" in stored_in_db
+
+
+def test_a_held_thing_of_no_project_is_not_dropped_on_the_next_sync(mc_repo):
+    # Test that an idea of no project survives being read twice.  It is not
+    # reached through a project, so a sync that looked for it that way would
+    # find it missing and drop what somebody had just written down
+    _, mcdir = mc_repo
+    path = mcdir / "pei.md"
+    path.write_text(path.read_text() + "\n## On-deck\n\n- an idea nobody has taken on\n")
+    main(["helper", "mc_sync"])
+    rc = copy.copy(DEFAULT_RC)
+    rc._update(load_rcfile("regolithrc.json"))
+    filter_databases(rc)
+    with connect(rc) as rc.client:
+        idea = next(g for g in rc.client.all_documents("mc_goals") if g["text"] == "an idea nobody has taken on")
+    assert idea["project"] == "tbd"
+    assert idea["lead"] == "pliu"
+    assert idea["status"] == "on-deck"
+
+    main(["helper", "mc_sync"])
+    assert stored(mc_repo, "mc_goals", idea["_id"])["status"] == "on-deck"

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -719,3 +719,48 @@ def test_a_build_keeps_the_document_it_wrote_over(tmp_path):
     builder.gtx = dict(BUILDABLE, mc_goals=[dict(BUILDABLE["mc_goals"][0], text="a stored goal")])
     builder.render()
     assert (tmp_path / "build" / "mission-control-previous" / "pei.md").read_text() == first
+
+
+IDEA = {
+    "_id": "g-idea",
+    "project": "tbd",
+    "lead": "pliu",
+    "period": "2026fall",
+    "first_period": "2026fall",
+    "text": "write the OpEd about instrument access",
+    "status": "on-deck",
+}
+
+
+def test_a_held_thing_of_no_project_is_written_without_a_number():
+    # Test that an idea nobody has taken on is written back as it was typed.
+    # A number says which project a goal is of, and that is the thing nobody
+    # has decided, so printing one would be making it up
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], lead="pliu")],
+        "mc_goals": GOALS + [IDEA],
+        "mc_tasks": [],
+        "people": [],
+    }
+    document = "\n".join(builder.documents()["pliu"])
+    assert "- write the OpEd about instrument access  ^g-idea" in document
+    # and it is under the holding heading, not among the goals of the period
+    on_deck = document.split("## On-deck")[1]
+    assert "^g-idea" in on_deck.split("## Wishlist")[0]
+
+
+def test_a_held_thing_goes_to_the_document_of_whoever_wrote_it():
+    # Test that an idea of no project still knows whose it is.  It cannot be
+    # reached through a project, so without this it would belong to nobody and
+    # appear in no document at all
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], lead="pliu"), dict(PROJECTS[1], lead="ascopatz")],
+        "mc_goals": [IDEA],
+        "mc_tasks": [],
+        "people": [],
+    }
+    documents = builder.documents()
+    assert "^g-idea" in "\n".join(documents["pliu"])
+    assert "^g-idea" not in "\n".join(documents["ascopatz"])


### PR DESCRIPTION
A line in either holding section had to carry a number saying which project it was of, so writing down an idea meant deciding whose work it was first.  That is backwards: the holding sections are where a thing goes precisely because nobody has decided that.

A held line with no number is now stored with its project as tbd and rendered back as it was typed, no number invented for it.  Giving it a number in the document is how it joins a project, which is the same gesture as moving it into the goals of the period.

Since it is not reached through a project, it says whose it is itself: mc.changes writes the lead of a goal that has none, from whose document it was in.  Without that it would belong to nobody, appear in no document, and be dropped by the next sync for not being in one.

A goal of the period still needs its number.  That is work somebody is doing, and the project is what says who.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64