### PR TITLE
feat: let a project finished long ago leave the document

### DIFF
--- a/docs/source/rc.rst
+++ b/docs/source/rc.rst
@@ -179,6 +179,21 @@ The order the periods are given in does not matter, since they are put in the
 order they come round by the dates. That order is what mission control sorts an
 archive by, rather than the letters of the names, which do not agree with it.
 
+``mission_control_keep_finished_days``
+======================================
+How long a finished project stays in a mission control document, in days. If
+none is provided it defaults to 365.
+
+Seeing what has just been finished is worth the room it takes; a project
+finished years ago is not, and somebody who has been in the group a while has
+many. A project older than this leaves the document and stays in the
+collections, so ``regolith helper l-mcprojects --all`` still lists it and
+``regolith build mission-control --all`` still writes it out.
+
+The date counted from is the project's ``end_date``, or its ``begin_date`` when
+nothing recorded an end. A finished project with neither stays, since there is
+nothing to say it is old.
+
 ``static_source``
 =================
 File path to the static source for ``regolith build html``. If none provided it defaults to "templates"

--- a/news/mc-retire-old-finished-projects.rst
+++ b/news/mc-retire-old-finished-projects.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* No news: part of mission control, which cannot be used yet.  One item will
+  cover the feature once it works end to end.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -21,12 +21,14 @@ from pathlib import Path
 from regolith.builders.basebuilder import BuilderBase
 from regolith.dates import get_dates
 from regolith.mc import (
+    KEEP_FINISHED_DAYS,
     DocumentError,
     in_the_group,
     led_by,
     parse_document,
     period_key,
     period_of,
+    retired,
     struck,
     unassigned,
     week_of,
@@ -222,6 +224,8 @@ class MissionControlBuilder(BuilderBase):
     # it, and nobody wants to read through the documents of both.
     only_people = None
     build_all = False
+    # how long a project stays in the document after it is finished
+    keep_finished_days = KEEP_FINISHED_DAYS
 
     def __init__(self, rc):
         super().__init__(rc)
@@ -236,6 +240,7 @@ class MissionControlBuilder(BuilderBase):
         self.periods = getattr(rc, "mission_control_periods", None)
         self.only_people = getattr(rc, "people", None)
         self.build_all = bool(getattr(rc, "build_all", False))
+        self.keep_finished_days = getattr(rc, "mission_control_keep_finished_days", KEEP_FINISHED_DAYS)
 
     @staticmethod
     def owner(person):
@@ -296,6 +301,7 @@ class MissionControlBuilder(BuilderBase):
         read back yet, and writing over it would be the end of it.
         """
         self.mcdir.mkdir(parents=True, exist_ok=True)
+        self.left_out = {}
         wanted = self.whose_documents()
         left_out = 0
         for person, lines in sorted(self.documents(self.existing_orders()).items()):
@@ -306,7 +312,7 @@ class MissionControlBuilder(BuilderBase):
             written = "\n".join(lines) + "\n"
             if path.is_file():
                 existing = path.read_text(encoding="utf-8")
-                lost = would_lose(existing, written)
+                lost = would_lose(existing, written, self.left_out.get(person, ()))
                 if lost:
                     self.refuse(path, lost)
                     continue
@@ -398,6 +404,8 @@ class MissionControlBuilder(BuilderBase):
         people = {led_by(p) or UNASSIGNED for p in self.gtx["mc_projects"]}
         return {person: by_name.get(self.document_name(person), []) for person in people}
 
+    left_out = {}
+
     def documents(self, orders=None):
         """Return the lines of every document, keyed by the person it is
         for.
@@ -431,6 +439,13 @@ class MissionControlBuilder(BuilderBase):
             The lines of the document.
         """
         projects = in_document_order(projects, order, lambda p: p["_id"])
+        # a project finished long ago stays in the collections and leaves the
+        # document, along with everything under it
+        old = (
+            [] if self.build_all else [p for p in projects if retired(p, dt.date.today(), self.keep_finished_days)]
+        )
+        projects = [p for p in projects if p not in old]
+        self.left_out[person] = [p.get("name", "") for p in old]
         number_of = {project["_id"]: n for n, project in enumerate(projects, start=1)}
         # a goal of a project belongs to whoever leads the project; a goal of
         # no project says whose it is itself, and is held on deck or on the
@@ -443,6 +458,8 @@ class MissionControlBuilder(BuilderBase):
         goals = in_document_order(mine, order, lambda g: g["_id"])
         goal_number = self.number_goals(goals, number_of)
         tasks = [t for t in live(self.gtx["mc_tasks"]) if t["goal"] in goal_number]
+        gone = {p["_id"] for p in old}
+        self.left_out[person] += [g["text"] for g in live(self.gtx["mc_goals"]) if g.get("project") in gone]
 
         lines = [f"# Mission control — {self.display_name(person)}", ""]
         lines += self.render_projects(projects)

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -489,7 +489,7 @@ def said_in(line):
     return " ".join(MARKS.sub("", text).split())
 
 
-def would_lose(existing, written):
+def would_lose(existing, written, also_kept=()):
     """Return what a document says that a new one would not.
 
     A render writes the collections out over the document, so anything
@@ -508,6 +508,10 @@ def would_lose(existing, written):
         The document as it stands.
     written : str
         The document as the render would write it.
+    also_kept : iterable of str, optional
+        What the render left out on purpose, which the collections still
+        hold and so is not lost.  A project finished years ago is left
+        out this way.
 
     Returns
     -------
@@ -516,6 +520,7 @@ def would_lose(existing, written):
         says it.  Empty when nothing would be lost.
     """
     kept = {said_in(line) for _, line in logical_lines(written) if not HEADING_LINE.match(line)}
+    kept |= {said_in(text) for text in also_kept}
     lost = []
     for _, line in logical_lines(existing):
         if not line.strip() or HEADING_LINE.match(line):
@@ -968,6 +973,64 @@ def _close(record, was, today):
 NOBODY = ("", "na", "tbd", "none")
 # a project in one of these is done with, so it cannot be an orphan
 CLOSED = ("finished", "dropped")
+
+
+# how long a finished project stays in the document, when nothing says
+KEEP_FINISHED_DAYS = 365
+
+
+def retired(project, today, days=KEEP_FINISHED_DAYS):
+    """Return True if a project finished long enough ago to leave the
+    document.
+
+    Seeing what has just been finished is worth the room it takes; a
+    project finished years ago is not, and a person who has been in the
+    group a while has many.  It stays in the collections either way, and
+    a build asked for everything writes it out as before.
+
+    The date it finished is its end date, or the date it began when
+    nothing recorded an end.  A finished project with neither stays,
+    since there is nothing to say it is old.
+
+    Parameters
+    ----------
+    project : dict
+        The project.
+    today : datetime.date
+        The day to count back from.
+    days : int, optional
+        How long a finished project is kept.  The default is a year.
+
+    Returns
+    -------
+    bool
+        Whether it has been finished long enough to go.
+    """
+    if project.get("status") != "finished":
+        return False
+    when = as_a_date(project.get("end_date")) or as_a_date(project.get("begin_date"))
+    return bool(when) and (today - when).days > days
+
+
+def as_a_date(value):
+    """Return a date from a date or from what a collection wrote one as.
+
+    Parameters
+    ----------
+    value : datetime.date or str or None
+        The value to read.
+
+    Returns
+    -------
+    datetime.date or None
+        The date, or None when there was nothing to read.
+    """
+    if value is None or isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
 
 
 def unassigned(goal):

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -828,3 +828,87 @@ def test_a_held_thing_goes_to_the_document_of_whoever_wrote_it():
     documents = builder.documents()
     assert "^g-idea" in "\n".join(documents["pliu"])
     assert "^g-idea" not in "\n".join(documents["ascopatz"])
+
+
+LONG_AGO = "2020-06-30"
+RECENTLY = (dt.date.today() - dt.timedelta(days=30)).isoformat()
+
+
+def a_finished_build(tmp_path, **rc):
+    """Return a builder over one old finished project and one just
+    finished."""
+    projects = [
+        dict(
+            PROJECTS[0],
+            _id="p-old",
+            name="An old finished project",
+            lead="pliu",
+            status="finished",
+            end_date=LONG_AGO,
+        ),
+        dict(
+            PROJECTS[0],
+            _id="p-new",
+            name="A just finished project",
+            lead="pliu",
+            status="finished",
+            end_date=RECENTLY,
+        ),
+        dict(PROJECTS[0], _id="p-live", name="A live project", lead="pliu", status="active"),
+    ]
+    goals = [dict(GOALS[0], _id="g-old", project="p-old", text="a goal of the old project")]
+    builder = render_into(
+        tmp_path,
+        {
+            "mc_projects": projects,
+            "mc_goals": goals,
+            "mc_tasks": [],
+            # pliu is in the group, so that render writes their document
+            "people": [{"_id": "pliu", "name": "Pei Liu", "active": True}],
+        },
+    )
+    for key, value in rc.items():
+        setattr(builder, key, value)
+    return builder
+
+
+@pytest.mark.parametrize(
+    "asked_for, expected_in, expected_out",
+    [
+        # Test which finished projects a document keeps.  Seeing what has just
+        # been finished is worth the room it takes; a project finished years
+        # ago is not, and somebody who has been in the group a while has many.
+        # C1: nothing asked for, expect the recent one and not the old one
+        ({}, ["^p-new", "^p-live"], ["^p-old", "a goal of the old project"]),
+        # C2: everything asked for, expect the old one back
+        ({"build_all": True}, ["^p-new", "^p-live", "^p-old"], []),
+        # C3: a longer memory asked for in the runcontrol, expect it kept
+        ({"keep_finished_days": 10000}, ["^p-old"], []),
+        # C4: no memory at all, expect even the recent one goes
+        ({"keep_finished_days": 0}, ["^p-live"], ["^p-old", "^p-new"]),
+    ],
+)
+def test_a_project_finished_long_ago_leaves_the_document(asked_for, expected_in, expected_out, tmp_path):
+    builder = a_finished_build(tmp_path, **asked_for)
+    document = "\n".join(builder.documents()["pliu"])
+    for expected in expected_in:
+        assert expected in document
+    for gone in expected_out:
+        assert gone not in document
+
+
+def test_retiring_a_project_is_not_taken_for_losing_it(tmp_path):
+    # Test the two guards against each other.  A build refuses to write over a
+    # document holding anything the collections do not have, and a retired
+    # project is in the collections, so writing the document without it must
+    # not read as losing it
+    builder = a_finished_build(tmp_path, build_all=True)
+    builder.render()
+    path = builder.mcdir / "pei.md"
+    assert "^p-old" in path.read_text()
+
+    builder = a_finished_build(tmp_path)
+    builder.render()
+    written = path.read_text()
+    assert "^p-old" not in written
+    assert "^p-new" in written


### PR DESCRIPTION
Nothing aged out of a mission control document, so a person who had been in the group a while opened a file listing everything they ever finished.  Simon's own came to 67 kB and 32 projects after the projecta migration, of which 7 were of this year.

A project finished more than mission_control_keep_finished_days ago, a year by default, is not written into the document, and its goals go with it.  It stays in the collections: l-mcprojects --all lists it and build --all writes it out.  The date counted from is the end date, or the begin date when nothing recorded an end; a finished project with neither stays, since there is nothing to say it is old.

mc.would_lose takes what the render left out on purpose, so that the two guards do not fight: a build refuses to write over a document holding what the collections do not have, and a retired project is still in the collections.  Without that every build would have refused from here on.

On Simon's data this is 67.3 kB and 32 projects down to 3.1 kB and 7.

No news: part of mission control, which cannot be used yet.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64