### PR TITLE
docs: gather the mission control work into one release note

### DIFF
--- a/news/consolidate-mission-control-news.rst
+++ b/news/consolidate-mission-control-news.rst
@@ -1,0 +1,56 @@
+**Added:**
+
+* **Mission control**, a way of running a group from a document rather than a
+  form.  Each person has a markdown file they type into — their projects, the
+  goals of the period, the tasks of the week — and regolith reads it back into
+  the collections and writes it out again.  Nobody has to learn the command
+  line to use it, and nothing anybody types is lost to a build.
+
+  * ``regolith build mission-control`` writes a document per person, and one
+    for the projects nobody leads.  It writes for the people currently in the
+    group; ``--all`` writes for everybody, and ``--people`` names whoever
+    should be written whatever their standing.
+  * ``regolith helper mc-sync`` reads the documents back.  A line typed with
+    no id is given one, a line taken out marks its record dropped rather than
+    deleting it, and a document that has lost most of what it held, or that
+    has stopped looking like a mission control document at all, is left alone
+    and says why.
+  * ``regolith helper a-mcproject`` writes a project down in the moment it is
+    mentioned: a name is all that is required, and what nobody has said yet
+    says ``tbd``.  It seeds a goal and a task so the document has the headings
+    and numbering to type over.
+  * ``regolith helper u-mcproject`` sets any field of a project by id, for what
+    the document does not show — the grant, the principal investigator, the
+    status — and for changing the same field of several projects at once.
+  * ``regolith helper l-mcprojects`` and ``l-mcgoals`` replace ``l_projecta``
+    and ``l_milestones``.  ``--orphans`` lists the work nobody is doing:
+    projects with no lead, and projects led by somebody who has left.
+  * Three collections hold it: ``mc_projects``, ``mc_goals`` and ``mc_tasks``.
+    A goal belongs to a project, a task to a goal, and anything hanging off
+    neither is a todo, which is a separate thing and stays separate.
+
+* Three runcontrol settings, all optional: ``mission_control_dir``, where the
+  documents are written; ``mission_control_periods``, what the periods of the
+  year are called and when each starts, semesters by default; and
+  ``mission_control_keep_finished_days``, how long a finished project stays in
+  the document, a year by default.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/mc-adder-seeds-a-goal-and-a-task.rst
+++ b/news/mc-adder-seeds-a-goal-and-a-task.rst
@@ -1,12 +1,12 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mc-adder-stubs-say-tbd.rst
+++ b/news/mc-adder-stubs-say-tbd.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mc-adopted-ids-fix-references.rst
+++ b/news/mc-adopted-ids-fix-references.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-build-never-overwrites-work.rst
+++ b/news/mc-build-never-overwrites-work.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-configurable-periods.rst
+++ b/news/mc-configurable-periods.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-document-controls-the-order.rst
+++ b/news/mc-document-controls-the-order.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-dropped-stays-dropped.rst
+++ b/news/mc-dropped-stays-dropped.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-held-items-need-no-project.rst
+++ b/news/mc-held-items-need-no-project.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mc-hyphenated-ids.rst
+++ b/news/mc-hyphenated-ids.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-lister-group-and-keys.rst
+++ b/news/mc-lister-group-and-keys.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-lister-verbose-when-grouped.rst
+++ b/news/mc-lister-verbose-when-grouped.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-listers.rst
+++ b/news/mc-listers.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-project-description.rst
+++ b/news/mc-project-description.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-project-ids-carry-the-lead.rst
+++ b/news/mc-project-ids-carry-the-lead.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mc-project-status-from-document.rst
+++ b/news/mc-project-status-from-document.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-project-updater.rst
+++ b/news/mc-project-updater.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mc-readable-project-ids.rst
+++ b/news/mc-readable-project-ids.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-retire-old-finished-projects.rst
+++ b/news/mc-retire-old-finished-projects.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mc-sync-reads-what-is-on-disk.rst
+++ b/news/mc-sync-reads-what-is-on-disk.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-sync-refuses-an-unreadable-document.rst
+++ b/news/mc-sync-refuses-an-unreadable-document.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-sync-says-where-it-wrote.rst
+++ b/news/mc-sync-says-where-it-wrote.rst
@@ -16,8 +16,8 @@
 
 **Fixed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Security:**
 

--- a/news/mc-wrap-lines.rst
+++ b/news/mc-wrap-lines.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Deprecated:**
 

--- a/news/mission-control-parser.rst
+++ b/news/mission-control-parser.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mission-control-schemas-and-render.rst
+++ b/news/mission-control-schemas-and-render.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: the first piece of mission control, which cannot be used yet.  One
-  item will cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mission-control-strikethrough-and-subtasks.rst
+++ b/news/mission-control-strikethrough-and-subtasks.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 

--- a/news/mission-control-sync.rst
+++ b/news/mission-control-sync.rst
@@ -1,7 +1,7 @@
 **Added:**
 
-* No news: part of mission control, which cannot be used yet.  One item will
-  cover the feature once it works end to end.
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
 
 **Changed:**
 


### PR DESCRIPTION
Twenty-six PRs built mission control, and each said no news because the feature could not be used until the last of them.  It can be used now, so this is the item they were waiting for: what it is, the five helpers, the three collections and the three runcontrol settings.  Every one of those PRs now points here rather than promising a note that did not exist yet.

The two general things that came out of the work keep their own items, since neither is about mission control: --all on a build, and helper targets taking hyphens or underscores.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64