### PR TITLE
fix: do not read what a document leaves out on purpose as a line deleted

### DIFF
--- a/news/mc-sync-knows-what-the-doc-omits.rst
+++ b/news/mc-sync-knows-what-the-doc-omits.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/helpers/mcsynchelper.py
+++ b/src/regolith/helpers/mcsynchelper.py
@@ -10,6 +10,7 @@ render cannot put back, and a document that cannot be read at all is
 skipped whole rather than half applied.
 """
 
+import datetime as dt
 from pathlib import Path
 
 from gooey import GooeyParser
@@ -22,12 +23,14 @@ from regolith.builders.missioncontrolbuilder import (
 )
 from regolith.helpers.basehelper import DbHelperBase
 from regolith.mc import (
+    KEEP_FINISHED_DAYS,
     UNLED_PREFIX,
     DocumentError,
     changes,
     initials,
     led_by,
     parse_document,
+    retired,
     slug,
     unassigned,
 )
@@ -174,6 +177,30 @@ class MCSyncHelper(DbHelperBase):
         """
         return {record["_id"] for collection in COLLECTIONS for record in self.gtx[collection]}
 
+    def left_out_of_documents(self, existing):
+        """Return the ids a document is not written with.
+
+        A project finished longer ago than the runcontrol keeps them is
+        left out of the document by the builder, and so are its goals
+        and their tasks.
+
+        Parameters
+        ----------
+        existing : dict
+            The records stored, as ``{collection: {id: record}}``.
+
+        Returns
+        -------
+        list of str
+            The ids the document is not expected to hold.
+        """
+        days = getattr(self.rc, "mission_control_keep_finished_days", KEEP_FINISHED_DAYS)
+        today = dt.date.today()
+        projects = [_id for _id, p in existing["mc_projects"].items() if retired(p, today, days)]
+        goals = [_id for _id, g in existing["mc_goals"].items() if g.get("project") in projects]
+        tasks = [_id for _id, t in existing["mc_tasks"].items() if t.get("goal") in goals]
+        return projects + goals + tasks
+
     def prefix(self, person):
         """Return what a project typed into one document is named with.
 
@@ -208,6 +235,11 @@ class MCSyncHelper(DbHelperBase):
             return
 
         existing = self.mine(person)
+        # a document is not written with everything the collections hold, so
+        # what it leaves out on purpose must not read as a line somebody
+        # deleted.  The record is neither written nor dropped: the document
+        # says nothing about it either way
+        parsed["mentioned"] = list(parsed.get("mentioned", ())) + self.left_out_of_documents(existing)
         writes, drops = changes(parsed, None if person == UNASSIGNED else person, existing)
         held = sum(len(records) for records in existing.values())
         dropped = sum(len(ids) for ids in drops.values())

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -955,9 +955,12 @@ def changes(parsed, person, existing, today=None):
         writes["mc_tasks"].append(record)
         seen["mc_tasks"].add(record["_id"])
 
-    # the archive shows a goal without saying anything to store about it, so
-    # what it shows is neither written nor taken for deleted
-    seen["mc_goals"].update(parsed.get("mentioned", ()))
+    # some things a document does not say anything about: the archive shows a
+    # goal without saying what to store, and a project finished long ago is
+    # left out of the document altogether.  Neither is written, and neither is
+    # taken for deleted
+    for collection in seen:
+        seen[collection].update(parsed.get("mentioned", ()))
     drops = {collection: sorted(set(records) - seen[collection]) for collection, records in existing.items()}
     return writes, drops
 

--- a/tests/test_mcsynchelper.py
+++ b/tests/test_mcsynchelper.py
@@ -335,3 +335,53 @@ def test_a_held_thing_of_no_project_is_not_dropped_on_the_next_sync(mc_repo):
 
     main(["helper", "mc_sync"])
     assert stored(mc_repo, "mc_goals", idea["_id"])["status"] == "on-deck"
+
+
+def test_a_project_the_document_leaves_out_is_not_read_as_deleted(mc_repo, capsys):
+    # Test the two halves of the round trip against each other.  A build
+    # leaves a project finished long ago out of the document; a sync reading
+    # that document must not take the missing lines for lines somebody
+    # deleted.  Estefania's document held 5 of her 34 things for this reason,
+    # and the sync called it damage and refused
+    tmp_path, mcdir = mc_repo
+    dump_yaml(
+        tmp_path / "db" / "mc_projects.yaml",
+        {
+            "mc-a-project": {"_id": "mc-a-project", "name": "a project", "lead": "pliu", "status": "active"},
+            "mc-an-old-one": {
+                "_id": "mc-an-old-one",
+                "name": "a project finished long ago",
+                "lead": "pliu",
+                "status": "finished",
+                "end_date": "2020-06-30",
+            },
+        },
+    )
+    dump_yaml(
+        tmp_path / "db" / "mc_goals.yaml",
+        {
+            "mcg001": {
+                "_id": "mcg001",
+                "project": "mc-a-project",
+                "period": "2026Q3",
+                "first_period": "2026Q3",
+                "text": "a goal",
+                "status": "active",
+            },
+            "mcg002": {
+                "_id": "mcg002",
+                "project": "mc-an-old-one",
+                "period": "2020summer",
+                "first_period": "2020summer",
+                "text": "a goal of the old project",
+                "status": "finished",
+            },
+        },
+    )
+    main(["helper", "mc_sync"])
+    said = capsys.readouterr().out
+    assert "more like damage than editing" not in said
+    # the old project and its goal are neither written nor dropped: the
+    # document says nothing about them either way
+    assert stored(mc_repo, "mc_projects", "mc-an-old-one")["status"] == "finished"
+    assert stored(mc_repo, "mc_goals", "mcg002")["status"] == "finished"


### PR DESCRIPTION
#1355 stopped writing a project finished long ago into the document, and its goals and tasks with it.  mcsynchelper knew nothing of that: it still counted every record the collections hold for a person, found most of them missing from the document, and refused to write anything. Estefania's document held 5 of her 34 things, so the sync called it damage.  Forcing it would have dropped all 29.

The ids a document is not written with now go through the same channel the archive already used: they are neither written nor taken for deleted, so the document says nothing about them either way.  changes applies that to all three collections rather than to goals alone.

This does not depend on how the document was built.  Marking an id as one the document may omit only stops it being dropped, so a document built with --all, which does hold the old projects, still writes them back from its own lines.

No news: part of mission control, summarised in
consolidate-mission-control-news.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64