### PR TITLE
fix: build a document that still names something dropped or retired

### DIFF
--- a/news/mc-archive-does-not-drop-what-it-shows.rst
+++ b/news/mc-archive-does-not-drop-what-it-shows.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -458,8 +458,7 @@ class MissionControlBuilder(BuilderBase):
         goals = in_document_order(mine, order, lambda g: g["_id"])
         goal_number = self.number_goals(goals, number_of)
         tasks = [t for t in live(self.gtx["mc_tasks"]) if t["goal"] in goal_number]
-        gone = {p["_id"] for p in old}
-        self.left_out[person] += [g["text"] for g in live(self.gtx["mc_goals"]) if g.get("project") in gone]
+        self.left_out[person] = self.not_written(person, {p["_id"] for p in projects}, goal_number, tasks)
 
         lines = [f"# Mission control — {self.display_name(person)}", ""]
         lines += self.render_projects(projects)
@@ -657,6 +656,50 @@ class MissionControlBuilder(BuilderBase):
         unnumbered = [g for g in goals if g["_id"] not in goal_number]
         in_number_order = sorted(numbered, key=lambda g: [int(n) for n in goal_number[g["_id"]].split(".")])
         return in_number_order + unnumbered
+
+    def not_written(self, person, shown, goal_number, tasks):
+        """Return what the collections hold for somebody and the
+        document does not say.
+
+        A document is not written with everything: a project finished
+        long ago is left out, and so is anything dropped.  None of it is
+        lost, because the collections still hold it, so a document that
+        still names it is not a document holding the only copy.
+
+        Parameters
+        ----------
+        person : str
+            The id of the person, or ``unassigned``.
+        shown : set of str
+            The ids of the projects the document is written with.
+        goal_number : dict
+            The goals the document is written with, keyed by id.
+        tasks : list of dict
+            The tasks the document is written with.
+
+        Returns
+        -------
+        list of str
+            What each of them says, for a render to account for.
+        """
+        owner = self.owner(person)
+        mine = [p for p in self.gtx["mc_projects"] if (led_by(p) or UNASSIGNED) == (owner or UNASSIGNED)]
+        theirs = {p["_id"] for p in mine}
+        goals = [
+            g
+            for g in self.gtx["mc_goals"]
+            if g.get("project") in theirs or (unassigned(g) and g.get("lead") == owner)
+        ]
+        written = {t["_id"] for t in tasks}
+        return (
+            [p.get("name", "") for p in mine if p["_id"] not in shown]
+            + [g.get("text", "") for g in goals if g["_id"] not in goal_number]
+            + [
+                t.get("text", "")
+                for t in self.gtx["mc_tasks"]
+                if t.get("goal") in {g["_id"] for g in goals} and t["_id"] not in written
+            ]
+        )
 
     def period_key(self, period):
         """Return a key putting periods in the order they came round."""

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -562,8 +562,9 @@ def parse_document(text, taken=(), prefix=None):
     -------
     dict
         ``person``, and ``projects``, ``goals`` and ``tasks`` as lists of
-        records in the order the document put them, plus ``mentioned``,
-        the ids the document showed without saying anything to store.
+        records in the order the document put them, plus ``mentioned``
+        and ``mentioned_text``, the ids and the words of what the
+        document showed without saying anything to store.
 
     Raises
     ------
@@ -594,6 +595,7 @@ class _Reader:
         self.by_number = {}
         self.stack = []
         self.mentioned = []
+        self.mentioned_text = []
 
     def mint(self):
         _id = short_id(self.ids)
@@ -716,8 +718,12 @@ class _Reader:
         _id = found.group("id") or self.mint()
         if self.section == "archive":
             # nothing in the archive is written back, but a line that is there
-            # is a line nobody deleted, so it must not read as one
+            # is a line nobody deleted, so it must not read as one.  The text
+            # goes with the id because a line that has lost its id would
+            # otherwise protect an id nobody has, and the record it was
+            # written for would be dropped
             self.mentioned.append(_id)
+            self.mentioned_text.append(text)
             return True
         goal = {
             "_id": _id,
@@ -783,6 +789,7 @@ class _Reader:
             "goals": self.goals,
             "tasks": self.tasks,
             "mentioned": self.mentioned,
+            "mentioned_text": self.mentioned_text,
         }
 
 
@@ -958,6 +965,13 @@ def changes(parsed, person, existing, today=None):
     # the archive shows a goal without saying anything to store about it, so
     # what it shows is neither written nor taken for deleted
     seen["mc_goals"].update(parsed.get("mentioned", ()))
+    # a line that has lost its id is still a line nobody deleted, so what the
+    # archive showed is matched by what it said as well as by the id it
+    # carried.  Two goals of one person can say the same thing, and then one
+    # line shields both: erring towards keeping a record nobody asked to keep
+    # is the way round to err, since the other way loses work
+    shown = set(parsed.get("mentioned_text", ()))
+    seen["mc_goals"].update(_id for _id, goal in existing["mc_goals"].items() if goal.get("text") in shown)
     drops = {collection: sorted(set(records) - seen[collection]) for collection, records in existing.items()}
     return writes, drops
 

--- a/tests/test_mc_changes.py
+++ b/tests/test_mc_changes.py
@@ -278,3 +278,27 @@ def test_a_sub_task_follows_the_task_it_hangs_off():
         today=TODAY,
     )
     assert written(writes, "mc_tasks")["t-sub"]["parent"] == "t-old"
+
+
+def test_an_archive_line_that_lost_its_id_still_shields_its_goal():
+    # Test the line that cost Steven a goal.  An archive line carries an id,
+    # and when that id goes the reader mints a new one, so the line protected
+    # an id nobody had and the goal it was written for was dropped.  What the
+    # line says protects it too
+    document = parsed(projects=[read_project()], goals=[])
+    document["mentioned"] = ["a-minted-id-nothing-has"]
+    document["mentioned_text"] = ["a goal shown only in the archive"]
+    stored_goals = [stored(_id="g-archived", text="a goal shown only in the archive")]
+    _, drops = changes(document, "pliu", existing(projects=[STORED_PROJECT], goals=stored_goals), today=TODAY)
+    assert drops["mc_goals"] == []
+
+
+def test_a_goal_the_archive_does_not_show_is_still_dropped():
+    # Test that the shielding is not a blanket: a goal in neither the sections
+    # nor the archive is a goal somebody took out, and still goes
+    document = parsed(projects=[read_project()], goals=[])
+    document["mentioned"] = []
+    document["mentioned_text"] = ["something else entirely"]
+    stored_goals = [stored(_id="g-deleted", text="a goal somebody took out")]
+    _, drops = changes(document, "pliu", existing(projects=[STORED_PROJECT], goals=stored_goals), today=TODAY)
+    assert drops["mc_goals"] == ["g-deleted"]


### PR DESCRIPTION
A document is not written with everything the collections hold: a project finished long ago is left out, and so is anything dropped.  The build then read those lines as work the collections did not have and refused to write the file, which is a standoff nothing could end: the sync will not restore an archive line, so the record stayed dropped and the document stayed unwritable.  Steven's document could not be built because it named two goals that had been dropped.

missioncontrolbuilder now accounts for everything it holds for a person and does not write, so a line naming it is not a line holding the only copy.  The record is not written back either: the collections say dropped, and the document is written without it, which is what dropping means.

mc.changes also shields an archive line by what it says as well as by the id it carries.  An archive line whose id has gone gets a minted one from the reader, so it protected an id nobody had while the record it was written for was dropped.  Two goals of one person can say the same thing and then one line shields both, which errs towards keeping a record nobody asked to keep; that is the way round to err.

No news: part of mission control, summarised in
consolidate-mission-control-news.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64