### PR TITLE
feat: read a wishlist written as a list with a list under it

### DIFF
--- a/news/mc-held-items-take-a-breakdown.rst
+++ b/news/mc-held-items-take-a-breakdown.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -489,8 +489,9 @@ class MissionControlBuilder(BuilderBase):
         numbers = {}
         counts = defaultdict(int)
         # a goal of no project has no number: the number says which project it
-        # is of, and that is the thing nobody has decided yet
-        of_a_project = [goal for goal in goals if goal["project"] in number_of]
+        # is of, and that is the thing nobody has decided yet.  Nor does a
+        # piece of another goal, which is of whatever its goal is
+        of_a_project = [goal for goal in goals if goal["project"] in number_of and not goal.get("parent")]
         for goal in sorted(of_a_project, key=lambda g: number_of[g["project"]]):
             counts[goal["project"]] += 1
             numbers[goal["_id"]] = f"{number_of[goal['project']]}.{counts[goal['project']]}"
@@ -608,12 +609,61 @@ class MissionControlBuilder(BuilderBase):
         The heading is written whether or not there is anything under
         it, so that a document has somewhere to move a goal to.
         """
-        held = [g for g in self.in_order(goals, goal_number) if g["status"] == status]
+        ordered = self.in_order(goals, goal_number)
+        held = [g for g in ordered if g["status"] == status]
+        # a piece of a held goal is written under it whatever it says itself:
+        # ticking one off does not take it out of the list it is a piece of
+        theirs = {g["_id"] for g in held}
+        for goal in ordered:
+            parent = goal.get("parent")
+            while parent and parent not in theirs and parent in {g["_id"] for g in ordered}:
+                parent = next((g.get("parent") for g in ordered if g["_id"] == parent), None)
+            if parent in theirs and goal["_id"] not in theirs:
+                held.append(goal)
+                theirs.add(goal["_id"])
+        held = [g for g in ordered if g["_id"] in theirs]
+        under = defaultdict(list)
+        for goal in held:
+            under[goal.get("parent")].append(goal)
+        shown = {goal["_id"] for goal in held}
         lines = [f"## {heading}", ""]
         for goal in held:
-            number = f"{goal_number[goal['_id']]}  " if goal["_id"] in goal_number else ""
-            lines.append(f"- {number}{struck(goal['text'], goal['status'])}  ^{goal['_id']}")
+            # a piece of a goal is written under it rather than in its own
+            # right, and one whose goal has gone is written in its own right
+            # rather than not at all
+            if goal.get("parent") in shown:
+                continue
+            lines += self.render_held(goal, goal_number, under, depth=0)
         lines.append("")
+        return lines
+
+    def render_held(self, goal, goal_number, under, depth):
+        """Return the lines of a held goal and the breakdown under it.
+
+        Parameters
+        ----------
+        goal : dict
+            The goal to write.
+        goal_number : dict
+            The number of each goal that has one, keyed by id.
+        under : dict
+            The goals under each goal, keyed by parent id.
+        depth : int
+            How far under a goal of its own it sits.
+
+        Returns
+        -------
+        list of str
+            The lines, indented by depth.
+        """
+        # only a goal of its own is numbered: the number says which project it
+        # is of, and a piece of a goal is of whatever its goal is
+        number = f"{goal_number[goal['_id']]}  " if not depth and goal["_id"] in goal_number else ""
+        indent = "  " * depth
+        box = "[x] " if goal["status"] == "finished" and depth else "[ ] " if depth else ""
+        lines = [f"{indent}- {box}{number}{struck(goal['text'], goal['status'])}  ^{goal['_id']}"]
+        for piece in under.get(goal["_id"], []):
+            lines += self.render_held(piece, goal_number, under, depth + 1)
         return lines
 
     def render_archive(self, goals, goal_number):

--- a/src/regolith/mc.py
+++ b/src/regolith/mc.py
@@ -332,8 +332,14 @@ WITH_LINE = re.compile(r"^\s+with:\s*(?P<people>.*?)\s*$")
 DESCRIPTION_LINE = re.compile(r"^\s+description:\s*(?P<text>.*?)\s*$")
 # anything else written under a project is what the project is about
 PROSE_LINE = re.compile(r"^\s+(?P<text>\S.*?)\s*$")
+# A goal may be indented, to put it under the goal above, and may carry a box,
+# since somebody writing a list of things to do writes boxes beside them.  The
+# note at the end is only read as one when it says what a render writes there;
+# any other parenthesis is what somebody typed and stays in the text.
 GOAL_LINE = re.compile(
-    r"^-\s+(?P<number>[\d.]+)?\s*(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?\s*(?:\((?P<note>.*)\))?\s*$"
+    r"^(?P<indent>\s*)-\s+(?:\[(?P<box>[ xX])\]\s+)?(?P<number>\d+(?:\.\d+)*\.?)?\s*"
+    r"(?P<text>.*?)\s*(?:\^(?P<id>[\w.-]+))?"
+    r"\s*(?:\((?P<note>(?:carried since|finished|dropped|→ rolled to)[^)]*)\))?\s*$"
 )
 TASK_LINE = re.compile(
     r"^(?P<indent>\s*)-\s+\[(?P<box>[ xX])\]\s+(?P<number>[\d.]+)?\s*"
@@ -593,6 +599,7 @@ class _Reader:
         self.monday = None
         self.by_number = {}
         self.stack = []
+        self.goal_stack = []
         self.mentioned = []
 
     def mint(self):
@@ -628,6 +635,7 @@ class _Reader:
             self.person = title.split("—")[-1].strip()
             return
         self.stack = []
+        self.goal_stack = []
         goals = GOALS_HEADING.match(title)
         week = WEEK_HEADING.match(title)
         if title == "Projects":
@@ -699,8 +707,21 @@ class _Reader:
         text, struck_out = read_text(found.group("text"))
         if not text:
             return False
+        # a goal indented under another is a piece of it, the way a sub task is
+        # a piece of a task.  Only the holding sections take one: a goal of the
+        # period is somebody's work and says which project it is of
+        indent = len(found.group("indent").expandtabs(4))
+        under = None
+        if self.section in HELD:
+            while self.goal_stack and self.goal_stack[-1][0] >= indent:
+                self.goal_stack.pop()
+            if self.goal_stack:
+                under = self.goal_stack[-1][1]
         goal_number = found.group("number")
-        if goal_number is None:
+        if under is not None:
+            # a piece of the goal above, so it is of whatever that is of
+            project = under["project"]
+        elif goal_number is None:
             if self.section not in HELD:
                 raise DocumentError(f"line {number}: a goal needs a number saying which project it is of")
             # a thing held on deck or on the wishlist is an idea that has not
@@ -719,14 +740,20 @@ class _Reader:
             # is a line nobody deleted, so it must not read as one
             self.mentioned.append(_id)
             return True
+        ticked = (found.group("box") or " ").lower() == "x"
         goal = {
             "_id": _id,
             "project": project,
             "period": self.period,
             "text": text,
-            "status": self.goal_status(struck_out),
+            # a strike is believed over a box, since the box is what gets forgotten
+            "status": "finished" if (struck_out or ticked) else self.goal_status(struck_out),
         }
+        if under is not None:
+            goal["parent"] = under["_id"]
         self.goals.append(goal)
+        if self.section in HELD:
+            self.goal_stack.append((indent, goal))
         if goal_number is not None:
             self.by_number[goal_number] = _id
         return True

--- a/src/regolith/schemas.json
+++ b/src/regolith/schemas.json
@@ -1350,6 +1350,11 @@
             "description": "The id of the person whose goal it is, for a goal that is not of any project yet. A goal of a project belongs to whoever leads the project, and does not carry this.",
             "required": false,
             "type": "string"
+        },
+        "parent": {
+            "description": "The id of the goal this one is a piece of, for a breakdown written under a goal held on deck or on the wishlist. A goal of its own does not carry this.",
+            "required": false,
+            "type": "string"
         }
     },
     "mc_projects": {

--- a/tests/test_mc_parser.py
+++ b/tests/test_mc_parser.py
@@ -394,6 +394,55 @@ def test_a_held_thing_need_not_be_of_a_project(text, expected_project):
     assert goal["project"] == expected_project
 
 
+BREAKDOWN = """# Mission control — Caden Myers
+
+## Projects
+
+1. **diffpy.cmi relaunch**  ^p1
+
+## Wishlist
+
+- [ ] 1. Relaunch with these from the wishlist:
+  - [ ] XANESCalculator
+  - [x] LJCalculator
+- 1. Merge the ase adapter (please update the below, copied from the old MC)
+"""
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # Test a wishlist somebody wrote as a list with a list under it, which
+        # is how anybody writes one down.  Every indented line used to be
+        # passed over in silence, so a build would not write the document and
+        # a sync would not store what was in it.
+        # C1: the line the others hang under, which is of the project it names
+        ("Relaunch with these from the wishlist:", {"project": "p1", "parent": None, "status": "wishlist"}),
+        # C2: a piece of it, which is of whatever its goal is and says which
+        # goal by hanging off it rather than by carrying a number
+        ("XANESCalculator", {"project": "p1", "parent": "the one above", "status": "wishlist"}),
+        # C3: a piece somebody has ticked, which is done whatever section it
+        # is in, the way a ticked task is
+        ("LJCalculator", {"project": "p1", "parent": "the one above", "status": "finished"}),
+        # C4: a line ending in a parenthesis of its own, which is what
+        # somebody typed and not the note a render writes there
+        (
+            "Merge the ase adapter (please update the below, copied from the old MC)",
+            {"project": "p1", "parent": None, "status": "wishlist"},
+        ),
+    ],
+)
+def test_a_held_thing_can_have_a_breakdown_under_it(text, expected):
+    goals = {g["text"]: g for g in parse_document(BREAKDOWN)["goals"]}
+    goal = goals[text]
+    assert goal["project"] == expected["project"]
+    assert goal["status"] == expected["status"]
+    if expected["parent"] is None:
+        assert "parent" not in goal
+    else:
+        assert goal["parent"] == goals["Relaunch with these from the wishlist:"]["_id"]
+
+
 def test_a_goal_of_the_period_still_needs_its_number():
     # Test that only the holding sections take a line with no number.  A goal
     # of the period is work somebody is doing, and which project it is of is

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -171,6 +171,30 @@ def test_a_goal_is_rendered_under_its_status(heading, expected_goal, documents):
     assert expected_goal in section
 
 
+def test_a_held_goal_carries_its_breakdown():
+    # Test that a wishlist entry written as a list with a list under it comes
+    # back that way.  A piece of a goal is written under it, unnumbered and
+    # with a box, since the number says which project a goal is of and a piece
+    # is of whatever its goal is
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    held = dict(GOALS[0], _id="g-wish", text="Relaunch with these", status="wishlist", first_period="2026Q3")
+    builder.gtx = {
+        "mc_projects": [dict(PROJECTS[0], lead="pliu")],
+        "mc_goals": [
+            held,
+            dict(held, _id="g-one", text="XANESCalculator", parent="g-wish"),
+            dict(held, _id="g-two", text="LJCalculator", parent="g-wish", status="finished"),
+        ],
+        "mc_tasks": [],
+        "people": [],
+    }
+    document = "\n".join(builder.documents()["pliu"])
+    wishlist = document.split("## Wishlist")[1]
+    assert "- 1.1  Relaunch with these  ^g-wish" in wishlist
+    assert "  - [ ] XANESCalculator  ^g-one" in wishlist
+    assert "  - [x] ~~LJCalculator~~  ^g-two" in wishlist
+
+
 @pytest.mark.parametrize(
     "expected_line",
     [


### PR DESCRIPTION
Caden's wishlist has 26 indented lines under the entries they belong to, which is how anybody writes a wishlist down.  Every one of them was passed over in silence: the goal pattern would not match an indented line, so nothing was stored and the build refused to write the document for holding things the collections did not have.

A goal indented under another is now a piece of it, the way a sub task is a piece of a task, and carries a parent.  Only the holding sections take one: a goal of the period is somebody's work and says which project it is of.  A piece is written back under its goal, unnumbered and with a box, and stays there when it is ticked off rather than leaving the list it is a piece of.

Two other things the goal pattern lost, both found in the same document:

- a box on a goal line ended up in its text as the letters "[ ]".  It is now read, and a ticked one is finished, as it is for a task.
- a line ending in a parenthesis lost it.  The pattern took any parenthesis for the note a render writes there, so "Merge pr on ase adapter (please update the below)" stored only the words before it. Only what a render writes is read as a note now.

No news: part of mission control, summarised in
consolidate-mission-control-news.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64