### PR TITLE
fix: order the week by what the numbers say, not by how they sort as …

### DIFF
--- a/news/mc-number-order-not-text-order.rst
+++ b/news/mc-number-order-not-text-order.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* No news: part of mission control, summarised in
+  consolidate-mission-control-news.
+
+**Security:**
+
+* <news item>

--- a/src/regolith/builders/missioncontrolbuilder.py
+++ b/src/regolith/builders/missioncontrolbuilder.py
@@ -115,6 +115,25 @@ def one_blank_between(lines):
     return tidied
 
 
+def number_key(number):
+    """Return a key putting numbers in the order they are read aloud.
+
+    ``1.10`` comes after ``1.9`` and before ``1.11``, which sorting the
+    text of it does not do.
+
+    Parameters
+    ----------
+    number : str
+        The number, e.g. ``1.2`` or ``1.2.3``.
+
+    Returns
+    -------
+    list of int
+        The parts of it, as numbers.
+    """
+    return [int(part) for part in number.split(".")]
+
+
 def label(item):
     """Return what a record is called, which is how a document names it
     when it carries no id."""
@@ -562,7 +581,7 @@ class MissionControlBuilder(BuilderBase):
             lines += [f"## Week of {monday.isoformat()}", ""]
             counts = defaultdict(int)
             roots = in_document_order(by_week[monday], order, lambda t: t["_id"])
-            for task in sorted(roots, key=lambda t: goal_number[t["goal"]]):
+            for task in sorted(roots, key=lambda t: number_key(goal_number[t["goal"]])):
                 counts[task["goal"]] += 1
                 number = f"{goal_number[task['goal']]}.{counts[task['goal']]}"
                 lines += self.render_task(task, number, children, order, depth=0)
@@ -655,7 +674,7 @@ class MissionControlBuilder(BuilderBase):
         """
         numbered = [g for g in goals if g["_id"] in goal_number]
         unnumbered = [g for g in goals if g["_id"] not in goal_number]
-        in_number_order = sorted(numbered, key=lambda g: [int(n) for n in goal_number[g["_id"]].split(".")])
+        in_number_order = sorted(numbered, key=lambda g: number_key(goal_number[g["_id"]]))
         return in_number_order + unnumbered
 
     def period_key(self, period):

--- a/tests/test_missioncontrolbuilder.py
+++ b/tests/test_missioncontrolbuilder.py
@@ -10,6 +10,7 @@ from regolith.builders.missioncontrolbuilder import (
     ids_in_document,
     in_document_order,
     keys_in_document,
+    number_key,
 )
 from regolith.mc import WIDTH, parse_document, week_of
 
@@ -255,6 +256,45 @@ def test_ids_in_document_reads_the_order(text, expected_ids):
 def test_in_document_order_puts_the_document_first(order, expected_ids):
     ordered = in_document_order(PROJECTS, order, lambda p: p["_id"])
     assert [p["_id"] for p in ordered] == expected_ids
+
+
+def test_moving_a_project_renumbers_everything_under_it():
+    # Test the meeting workflow: somebody cuts a project and pastes it above
+    # another, and everything follows.  The numbers are positional, so the
+    # projects, their goals and the tasks of the week all renumber, and none
+    # of it touches the collections
+    builder = MissionControlBuilder.__new__(MissionControlBuilder)
+    builder.gtx = {
+        "mc_projects": [dict(p, lead="pliu") for p in PROJECTS],
+        "mc_goals": GOALS,
+        "mc_tasks": TASKS,
+        "people": [],
+    }
+    first = "\n".join(builder.documents({"pliu": ["p-pdf", "p-orphan"]})["pliu"])
+    assert "1. **Nanoparticle structure from the PDF**" in first
+    assert "- 1.1  Get the fits converging" in first
+
+    moved = "\n".join(builder.documents({"pliu": ["p-orphan", "p-pdf"]})["pliu"])
+    assert "1. **GPU solver**" in moved
+    assert "2. **Nanoparticle structure from the PDF**" in moved
+    assert "- 2.1  Get the fits converging" in moved
+    assert "- [ ] 2.1.1  Re-run the fits" in moved
+
+
+@pytest.mark.parametrize(
+    "numbers, expected_order",
+    [
+        # Test that numbers order the way they are read aloud rather than the
+        # way their text sorts.  A person with ten goals of one project had
+        # the week of 1.10 written above the week of 1.2.
+        # C1: past the first nine, where text and number part company
+        (["1.2", "1.10", "1.9"], ["1.2", "1.9", "1.10"]),
+        # C2: three deep, as a task of a goal of a project is
+        (["1.2.10", "1.2.2", "1.10.1"], ["1.2.2", "1.2.10", "1.10.1"]),
+    ],
+)
+def test_numbers_order_as_numbers(numbers, expected_order):
+    assert sorted(numbers, key=number_key) == expected_order
 
 
 def test_a_render_keeps_the_order_the_document_chose():


### PR DESCRIPTION
…text

The tasks of a week were sorted on the text of the goal number they carry, so once somebody had ten goals of one project the week of 1.10 was written above the week of 1.2, and the meeting read out of order. The goals themselves were already ordered by number; this gives the week the same key.

Moving a project in the document already renumbered everything under it, which is what makes rearranging one in a meeting work.  There is now a test of that, since it is a promise worth keeping rather than a thing that happens to hold.

No news: part of mission control, summarised in
consolidate-mission-control-news.


Claude-Session: https://claude.ai/code/session_013L8AVi8sbSn9YouARB7n64